### PR TITLE
[fix] ci: bump Go to 1.25.11 to clear govulncheck failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - name: Run unit tests
@@ -60,7 +60,7 @@ jobs:
       - run: mkdir -p server/internal/api/ui && cp -r server/ui/dist server/internal/api/ui/dist
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Build collector
         run: go build -o bin/agenthound ./collector/cmd/agenthound
       - name: Build server
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - name: Run full test suite with DB
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - run: |
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - name: Build collector

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5.6.0
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.11"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adithyan-ak/agenthound
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## Why

`govulncheck` (the PR-only CI gate) started failing on **every** PR — including the merged #21 UI-logo change, which touched no Go code. The cause isn't any PR: two new Go **standard-library** advisories were published, both fixed in **go1.25.11**, while the repo is pinned to 1.25.10:

| ID | Package | Reached via |
|----|---------|-------------|
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` (inefficient hostname parsing) | `api.Server.ListenAndServe` → `Certificate.Verify` / `VerifyHostname`; `HandleWeightedPath` → `x509.HostnameError.Error` |
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` (unescaped input in errors) | `http.Server.ListenAndServe` → `textproto.Reader.ReadMIMEHeader` |

## What

Bump the pinned exact toolchain version everywhere it's nailed down:
- `go.mod`: `1.25.10` → `1.25.11`
- `.github/workflows/ci.yml`: 6 jobs, `1.25.10` → `1.25.11`
- `.github/workflows/release.yml`: `1.25.9` → `1.25.11`

Docker images use the floating `golang:1.25-alpine` tag and already resolve to the latest patch — no change needed.

## Verification (local, go1.25.11)

- `go build ./...` — OK
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `go test ./... -short -race` — all pass
- `govulncheck ./...` — **0 affected vulnerabilities** (exit 0)