### PR TITLE
[chore] ci: stop artifact storage leak + tame Dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,44 @@
 version: 2
+# Low-noise version updates: monthly, capped, grouped, majors ignored.
+# Security fixes are handled separately by Dependabot security updates
+# (repo setting), which open a PR only when a real CVE affects a dependency
+# regardless of the schedule/cap below.
 updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
+    open-pull-requests-limit: 5
     groups:
-      go-chi:
-        patterns: ["github.com/go-chi/*"]
-      jackc:
-        patterns: ["github.com/jackc/*"]
-      golang-x:
-        patterns: ["golang.org/x/*"]
+      go-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # Majors carry breaking changes; bump them deliberately, not via bot.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      actions-all:
+        applies-to: version-updates
+        patterns: ["*"]
+
   - package-ecosystem: npm
     directory: "/server/ui"
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on the same ref so a force-push or rapid PR pushes
+# don't pile up redundant matrix runs.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -69,10 +75,6 @@ jobs:
         run: bash scripts/deps-check.sh
       - name: Size-check
         run: bash scripts/size-check.sh
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: binaries
-          path: bin/
 
   test-integration:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Root cause (the *real* "quota" failure)

On GitHub **Free**, a public repo gets **unlimited Actions minutes** but only **500 MB** of artifact/package storage. This repo had accumulated **~772 MB across 136 artifacts**, so `actions/upload-artifact` failed with *"Artifact storage quota has been hit"* — which is what turned the `build` job red on nearly every recent PR (it was **not** govulncheck, and **not** any individual dependency).

The kicker: **nothing in CI ever downloads that `binaries` artifact.** Releases are built separately by GoReleaser. It was pure dead weight, re-uploaded every run.

## Changes

**`ci.yml`**
- **Remove the unused `upload-artifact` step.** The `build` job still compiles both binaries and runs `deps-check` / `size-check` (those read the local `bin/` dir, not the artifact), so coverage is unchanged. This permanently stops the storage leak.
- **Add a `concurrency` group** (`cancel-in-progress: true`) so a force-push or rapid PR pushes cancel superseded runs instead of stacking redundant matrix runs.

**`dependabot.yml`** — converts the chaotic ~15-PR flood into a calm, scheduled trickle:
- `daily`/`weekly` → **`monthly`**
- **`open-pull-requests-limit: 5`** per ecosystem
- **Group all minor+patch** into one PR per ecosystem (gomod / github-actions / npm)
- **Ignore major bumps** (breaking — e.g. react 19, vite 8; bump those deliberately, not via bot)

## Done out-of-band (API / repo settings)
- Purged the 136-artifact backlog → storage now **0 bytes** (verified), upload quota cleared.
- Enabled **Dependabot vulnerability alerts** + **automated security fixes** — real CVEs now open a PR promptly, independent of the monthly version-update schedule/cap above. (This is what keeps a *security* tool's deps honest without the noise.)

## Notes
- `github.ref` / `github.workflow` in the concurrency key are trusted GitHub context, not user input — no injection surface.
- Go-version bump to 1.25.11 (the actual govulncheck fix) is a **separate** PR (#22); this branch is off `main` and doesn't touch it.

## Verification
- All three YAML files parse cleanly.
- Dependabot grouping syntax (`applies-to`, grouped `update-types`, `ignore` major, `open-pull-requests-limit` + groups) validated against the current GitHub Dependabot options reference.