### PR TITLE
[fix] server: drop chi RealIP middleware (spoofing-prone, unused)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/adithyan-ak/agenthound
 go 1.25.11
 
 require (
-	github.com/go-chi/chi/v5 v5.2.5
+	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/cors v1.2.2
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
-github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
+github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
 github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/server/internal/api/server.go
+++ b/server/internal/api/server.go
@@ -54,7 +54,10 @@ func NewServer(deps ServerDeps) *Server {
 	r := chi.NewRouter()
 
 	r.Use(chimw.RequestID)
-	r.Use(chimw.RealIP)
+	// RealIP intentionally omitted: it rewrites RemoteAddr from spoofable
+	// X-Forwarded-For / X-Real-IP headers (GHSA-3fxj-6jh8-hvhx). The server
+	// is localhost-only and nothing reads RemoteAddr, so it adds spoofing
+	// surface for zero benefit.
 	r.Use(apimw.Logger)
 	r.Use(chimw.Recoverer)
 	r.Use(apimw.CORS(deps.CORSOrigins))


### PR DESCRIPTION
## Why

After the Go 1.25.11 bump cleared govulncheck, the **next** thing blocking CI is the `lint` job on any PR that crosses **chi 5.3.0** — including the grouped Dependabot go bump (#30). chi 5.3.0 deprecates `middleware.RealIP`, and staticcheck flags it:

```
server/internal/api/server.go:57:8: SA1019: chimw.RealIP is deprecated:
RealIP is vulnerable to IP spoofing — it mutates r.RemoteAddr to the
leftmost X-Forwarded-For value... (GHSA-3fxj-6jh8-hvhx)
```

`main` is green today only because it pins chi 5.2.5, which predates the deprecation.

## Fix

**Remove the middleware** rather than `//nolint` it:
- The server **binds localhost only** and is single-user (per the repo's security posture).
- **Nothing in the codebase reads `RemoteAddr`** (grep-verified across `server/`, `collector/`, `sdk/`).
- `RealIP`'s entire job is to rewrite `RemoteAddr` from spoofable `X-Forwarded-For` / `X-Real-IP` headers — so here it's pure attack surface for zero benefit. Suppressing the lint would keep the spoofing risk *and* the warning debt.

Also **bump chi to 5.3.0 in this same PR** so CI actually exercises the deprecation gate and proves it passes — instead of leaving the fix unverified behind the 5.2.5 pin.

## Interaction with the open Dependabot PRs
- This makes the chi portion of grouped go-bump **#30** mergeable. After this lands, rebase #30 (or let the monthly run regenerate it) and its `lint` job goes green.

## Verification (local, go1.25.11, chi 5.3.0)
- `go build ./...` — OK
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `staticcheck ./server/internal/api/...` — **no SA1019 / RealIP finding**
- `go test ./... -short -race` — exit 0
- `govulncheck ./...` — 0 affected vulnerabilities