### PR TITLE
[docs] rules: record chi RealIP ban + ClientIP successor

### DIFF
--- a/.claude/rules/server.md
+++ b/.claude/rules/server.md
@@ -7,6 +7,7 @@ paths:
 - API routes at /api/v1/*. Read endpoints open; mutating endpoints require localhost bearer token.
 - Token auto-generated at first startup, persisted to ~/.agenthound/server.token (0o600).
 - CORS: AllowCredentials=false. CORSOrigins configurable via AGENTHOUND_CORS_ORIGINS.
+- No chi `middleware.RealIP`: it rewrites RemoteAddr from spoofable X-Forwarded-For / X-Real-IP (GHSA-3fxj-6jh8-hvhx) and staticcheck flags it as deprecated (SA1019) at chi >=5.3.0. Server is localhost-only and nothing reads RemoteAddr. If ever placed behind a trusted reverse proxy, use chi 5.3.0's `middleware.ClientIP` (one of its 4 mutually-exclusive variants — no safe default) instead of re-adding RealIP.
 - Neo4j version compat: detect via CALL dbms.components(), branch on 4.4 vs 5.x constraint syntax.
 - APOC fallback: all APOC-dependent code needs non-APOC fallbacks. APOC only required for Dijkstra.
 - Batch writes: group by (primaryLabel, sortedUmbrellaLabels) tuple. 1000 ops/txn with UNWIND.


### PR DESCRIPTION
Persists the architectural decision behind removing `chi middleware.RealIP` (PR #33) into `.claude/rules/server.md` so future server code doesn't re-introduce the spoofing-prone middleware. Notes chi 5.3.0's `middleware.ClientIP` as the supported replacement if the server is ever placed behind a trusted reverse proxy. Docs/rules only — no code change.