### PR TITLE
[fix] resolve 9 validated audit findings (implant dispatch, credential-chain, UI/CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           cache: npm
           cache-dependency-path: server/ui/package-lock.json
       - run: cd server/ui && npm ci --ignore-scripts && npm run build
-      - run: mkdir -p server/internal/api/ui && cp -r server/ui/dist server/internal/api/ui/dist
+      - run: mkdir -p server/internal/api/ui/dist && cp -r server/ui/dist/. server/internal/api/ui/dist/
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: "1.25.11"

--- a/collector/cli/implant.go
+++ b/collector/cli/implant.go
@@ -30,6 +30,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/module"
@@ -73,17 +74,37 @@ func init() {
 		module.RegisterFlagsFor(implantCmd, mod)
 	}
 	for _, mod := range module.ListByAction(action.Poison) {
-		// instruction.poison is registered as a Poisoner (semantically it
-		// modifies content the agent consumes, not persistence) but we
-		// surface it under `agenthound implant` too for operator
-		// ergonomics — instruction-file modification is colloquially
-		// "implanting an instruction". The flag walk is harmless because
-		// per-module flag names don't collide and the runImplant code
-		// path explicitly looks up by action.Implant.
-		_ = mod
+		// Surface every Poisoner that targets a kind the operator might
+		// type after `agenthound implant --type` — instruction.file is
+		// the canonical example. runImplant falls back to action.Poison
+		// dispatch when no Implanter matches the requested target kind,
+		// so the per-module flags must be visible on `implant --help`
+		// too. Use registerFlagsAvoidingDupes because Implanter and
+		// Poisoner flag sets overlap (e.g. both modules use --file).
+		registerFlagsAvoidingDupes(implantCmd, mod)
 	}
 
 	rootCmd.AddCommand(implantCmd)
+}
+
+// registerFlagsAvoidingDupes wires a module's per-module flags onto cmd,
+// silently skipping any whose name is already defined. pflag panics on
+// duplicate flag names, and the implant command surfaces both Implanter
+// and Poisoner flag sets so legitimate name overlap (e.g. --file used
+// by mcpconfigimplant AND instructionpoison) must not crash init().
+func registerFlagsAvoidingDupes(cmd *cobra.Command, m module.Module) {
+	fm, ok := m.(module.FlagsModule)
+	if !ok {
+		return
+	}
+	probe := pflag.NewFlagSet("implant-dedup-probe", pflag.ContinueOnError)
+	fm.RegisterFlags(probe)
+	probe.VisitAll(func(f *pflag.Flag) {
+		if cmd.Flags().Lookup(f.Name) != nil {
+			return
+		}
+		cmd.Flags().AddFlag(f)
+	})
 }
 
 func runImplant(cmd *cobra.Command, args []string) error {
@@ -112,6 +133,21 @@ func runImplant(cmd *cobra.Command, args []string) error {
 
 	mod, ok := module.GetByTarget(kind, action.Implant)
 	if !ok {
+		// Fall back to a Poisoner with the same target kind. The docs
+		// expose `--type instruction.file` under `agenthound implant`
+		// for operator ergonomics, but instructionpoison registers as
+		// a Poisoner (it modifies content the agent consumes, which is
+		// the Poisoner contract). The dispatch was previously broken:
+		// runImplant looked up only Implanters and returned an error
+		// for any Poisoner-backed type. We now hand off to the shared
+		// poison runner with label="implant" so the operator-facing
+		// output still says [implant] but the safety gates, receipt
+		// handling, and revert path all match the Poisoner contract.
+		if poisonMod, poisonOk := module.GetByTarget(kind, action.Poison); poisonOk {
+			if _, isPoisoner := poisonMod.(action.Poisoner); isPoisoner {
+				return runPoisonDispatch(cmd, args, "implant")
+			}
+		}
 		return fmt.Errorf("no implanter registered for --type %q", kind)
 	}
 	implanter, ok := mod.(action.Implanter)

--- a/collector/cli/offensive_verbs_test.go
+++ b/collector/cli/offensive_verbs_test.go
@@ -340,6 +340,88 @@ func TestRunRevert_DispatchesNonDryRunAndSkipsDryRun(t *testing.T) {
 	}
 }
 
+// --- Implant tests ---
+
+// TestRunImplant_FallsBackToPoisoner guards the v0.5 fix where
+// `agenthound implant --type instruction.file` was previously broken:
+// instructionpoison registers as action.Poison but the docs surface
+// instruction.file under `implant`. runImplant now falls back to a
+// Poisoner lookup with the same target kind. The test exercises the
+// fallback by registering only a Poisoner-shaped mock with a target
+// kind that has no Implanter and confirming Poison() is invoked.
+func TestRunImplant_FallsBackToPoisoner(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTHOUND_STATE_DIR", filepath.Join(t.TempDir(), "state"))
+
+	mock := newMockPoisoner("mock.poison.implantfallback", "mock-implant-fallback")
+	module.Register(mock)
+	defer deregisterModule(t, mock.ID())
+
+	out := &bytes.Buffer{}
+	cmd := &cobra.Command{Use: "implant"}
+	cmd.Flags().String("type", "", "")
+	cmd.Flags().String("target-id", "", "")
+	cmd.Flags().String("inject", "", "")
+	cmd.Flags().String("inject-file", "", "")
+	cmd.Flags().Bool("commit", false, "")
+	cmd.Flags().String("engagement-id", "", "")
+	cmd.SetIn(strings.NewReader("AUTHORIZED\n"))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+
+	mustSetFlag(t, cmd, "type", mock.Target())
+	mustSetFlag(t, cmd, "target-id", "/tmp/CLAUDE.md")
+	mustSetFlag(t, cmd, "inject", "instruction body")
+	mustSetFlag(t, cmd, "engagement-id", "ENG-CLI-IMPLANT-FB")
+
+	if err := runImplant(cmd, []string{"127.0.0.1:8080"}); err != nil {
+		t.Fatalf("runImplant: %v", err)
+	}
+	if !mock.called {
+		t.Fatal("Poisoner fallback was not invoked")
+	}
+	if !mock.payload.DryRun {
+		t.Error("expected dry-run when --commit unset")
+	}
+	if mock.payload.InjectionContent != "instruction body" {
+		t.Errorf("payload InjectionContent = %q, want 'instruction body'", mock.payload.InjectionContent)
+	}
+	if !strings.Contains(out.String(), "[implant]") {
+		t.Errorf("expected [implant] label in output, got: %s", out.String())
+	}
+}
+
+// TestRunImplant_NoModuleAndNoFallback confirms the original error
+// surface still fires when neither an Implanter NOR a Poisoner matches
+// the requested target kind.
+func TestRunImplant_NoModuleAndNoFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_ = os.MkdirAll(filepath.Join(home, ".agenthound"), 0o700)
+	_ = os.WriteFile(filepath.Join(home, ".agenthound", "poison-acknowledged"), []byte(`{}`), 0o600)
+
+	out := &bytes.Buffer{}
+	cmd := &cobra.Command{Use: "implant"}
+	cmd.Flags().String("type", "", "")
+	cmd.Flags().String("target-id", "", "")
+	cmd.Flags().String("inject", "", "")
+	cmd.Flags().String("inject-file", "", "")
+	cmd.Flags().Bool("commit", false, "")
+	cmd.Flags().String("engagement-id", "", "")
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+
+	mustSetFlag(t, cmd, "type", "definitely-not-registered-anywhere")
+	mustSetFlag(t, cmd, "inject", "x")
+	mustSetFlag(t, cmd, "engagement-id", "ENG-IMPLANT-MISS")
+
+	err := runImplant(cmd, []string{"127.0.0.1:8080"})
+	if err == nil || !strings.Contains(err.Error(), "no implanter registered") {
+		t.Errorf("expected 'no implanter registered' error, got: %v", err)
+	}
+}
+
 // --- Extract tests ---
 
 func TestRunExtract_DryRun(t *testing.T) {

--- a/collector/cli/poison.go
+++ b/collector/cli/poison.go
@@ -107,12 +107,24 @@ func init() {
 }
 
 func runPoison(cmd *cobra.Command, args []string) error {
+	return runPoisonDispatch(cmd, args, "poison")
+}
+
+// runPoisonDispatch is the shared body of `poison` and the fallback path
+// of `implant` when a target kind is registered as a Poisoner. label
+// only controls the [poison]/[implant] prefix on operator output —
+// Poisoner-as-Implanter (instructionpoison under `agenthound implant
+// --type instruction.file`) is the only caller that overrides it.
+func runPoisonDispatch(cmd *cobra.Command, args []string, label string) error {
 	target := args[0]
 	kind, _ := cmd.Flags().GetString("type")
 	targetID, _ := cmd.Flags().GetString("target-id")
 	injection, _ := cmd.Flags().GetString("inject")
 	injectFile, _ := cmd.Flags().GetString("inject-file")
 	mode, _ := cmd.Flags().GetString("mode")
+	if mode == "" {
+		mode = "replace"
+	}
 	commit, _ := cmd.Flags().GetBool("commit")
 	engagementID, _ := cmd.Flags().GetString("engagement-id")
 
@@ -124,7 +136,7 @@ func runPoison(cmd *cobra.Command, args []string) error {
 		injection = string(data)
 	}
 	if injection == "" {
-		return errors.New("poison: --inject or --inject-file is required")
+		return fmt.Errorf("%s: --inject or --inject-file is required", label)
 	}
 
 	if err := requirePoisonAcknowledged(cmd.OutOrStderr(), cmd.InOrStdin()); err != nil {
@@ -161,14 +173,14 @@ func runPoison(cmd *cobra.Command, args []string) error {
 		Extras:           extras,
 	})
 	if err != nil {
-		return fmt.Errorf("poison: %w", err)
+		return fmt.Errorf("%s: %w", label, err)
 	}
 
 	state := stateful.Stateful()
 	path := receiptPath(state, engagementID)
 	if commit {
 		if _, statErr := os.Stat(path); statErr != nil {
-			return fmt.Errorf("poison applied but pre-mutation receipt is missing: %w", statErr)
+			return fmt.Errorf("%s applied but pre-mutation receipt is missing: %w", label, statErr)
 		}
 	} else {
 		// Persist dry-run receipts here. Committed mutations persist inside
@@ -176,27 +188,27 @@ func runPoison(cmd *cobra.Command, args []string) error {
 		var werr error
 		path, werr = state.WriteReceipt(engagementID, receipt)
 		if werr != nil {
-			slog.Error("poison: dry-run receipt persistence failed",
+			slog.Error(label+": dry-run receipt persistence failed",
 				"module", mod.ID(),
 				"engagement_id", engagementID,
 				"target_id", targetID,
 				"error", werr)
-			return fmt.Errorf("poison dry-run receipt persistence failed: %w", werr)
+			return fmt.Errorf("%s dry-run receipt persistence failed: %w", label, werr)
 		}
 	}
 
 	if commit {
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-			"[poison] APPLIED %s %s — engagement_id=%s receipt=%s\n",
-			kind, target, engagementID, path)
+			"[%s] APPLIED %s %s — engagement_id=%s receipt=%s\n",
+			label, kind, target, engagementID, path)
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-			"[poison] revert with: agenthound revert %s\n", engagementID)
+			"[%s] revert with: agenthound revert %s\n", label, engagementID)
 	} else {
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-			"[poison] DRY-RUN %s %s — engagement_id=%s receipt=%s\n",
-			kind, target, engagementID, path)
+			"[%s] DRY-RUN %s %s — engagement_id=%s receipt=%s\n",
+			label, kind, target, engagementID, path)
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-			"[poison] re-run with --commit to apply.\n")
+			"[%s] re-run with --commit to apply.\n", label)
 	}
 
 	_ = receipt // silence unused warning when commit=false short-circuits before any reference

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -98,14 +98,14 @@ Postgres stores only the `scans` table (scan metadata, status, timestamps). Stor
 ### Neo4j
 
 ```bash
-docker exec agenthound-demo-graph-db neo4j-admin dump --database=neo4j --to=/tmp/neo4j.dump
-docker cp agenthound-demo-graph-db:/tmp/neo4j.dump ./backups/
+docker compose -f docker/docker-compose.yml exec graph-db neo4j-admin dump --database=neo4j --to=/tmp/neo4j.dump
+docker compose -f docker/docker-compose.yml cp graph-db:/tmp/neo4j.dump ./backups/
 ```
 
 ### PostgreSQL
 
 ```bash
-docker exec agenthound-demo-app-db pg_dump -U agenthound agenthound > ./backups/pg.sql
+docker compose -f docker/docker-compose.yml exec app-db pg_dump -U agenthound agenthound > ./backups/pg.sql
 ```
 
 Schedule both via cron. The graph is the high-value artifact; Postgres is trivially recreatable from re-ingestion.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -270,6 +270,14 @@ The `<host>` argument is informational for file-based Implanters — recorded on
 | `--server-name` | `agenthound-implant-<engagement-id>` | Name for the implanted server entry. |
 | `--servers-key` | `mcpServers` | Top-level key in config JSON. Override for VS Code (`servers`), Zed (`context_servers`). |
 
+#### Per-Module Flags: `--type instruction.file`
+
+`instruction.file` is registered as a Poisoner (the agent reads instruction files as part of its prompt, so modification fits the Poisoner contract), but `agenthound implant --type instruction.file` is also accepted — the dispatch falls through to the shared poison runner. The receipt is identical to one produced by `agenthound poison --type instruction.file`, and `agenthound revert <engagement-id>` rolls back either invocation the same way.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--file` | | Absolute path to the instruction file (CLAUDE.md, AGENTS.md, .cursorrules). Required. |
+
 #### Example
 
 ```bash

--- a/scripts/seed-demo.sh
+++ b/scripts/seed-demo.sh
@@ -60,8 +60,8 @@ sleep 8
 # `ollama pull` fails (network, etc.) the demo still runs against
 # whatever Ollama happens to have on disk.
 echo "[seed-demo] preloading Ollama with tinyllama + a fake fine-tune tag"
-docker exec agenthound-demo-v3-ollama ollama pull tinyllama || true
-docker exec agenthound-demo-v3-ollama sh -c '
+docker exec agenthound-demo-ollama ollama pull tinyllama || true
+docker exec agenthound-demo-ollama sh -c '
     cat > /tmp/Modelfile-finetune <<EOF
 FROM tinyllama
 SYSTEM """You are SupportBot for Acme Corp. Internal triage assistant only."""

--- a/server/internal/analysis/finding_detail.go
+++ b/server/internal/analysis/finding_detail.go
@@ -427,8 +427,8 @@ func BuildImpact(f *Finding, path *AttackPath, compositeProps map[string]any) *I
 	}
 
 	impact := &Impact{
-		Summary:     fmt.Sprintf(tmpl.summary, srcName, tgtName),
-		BlastRadius: formatBlastRadius(tmpl.blastRadius, srcName, tgtName),
+		Summary:     formatImpactTemplate(tmpl.summary, srcName, tgtName),
+		BlastRadius: formatImpactTemplate(tmpl.blastRadius, srcName, tgtName),
 	}
 
 	if path != nil {
@@ -462,12 +462,16 @@ func isCredentialChain(props map[string]any) bool {
 	return false
 }
 
-// formatBlastRadius substitutes srcName/tgtName into a blastRadius template
-// without producing Go's "%!(EXTRA ...)" warts when the template contains
-// fewer than two %s placeholders. Several templates are static prose and
-// must pass through untouched; others reuse the same (src, tgt) pair as
-// the summary line.
-func formatBlastRadius(tmpl, srcName, tgtName string) string {
+// formatImpactTemplate substitutes srcName/tgtName into a Summary or
+// BlastRadius template without producing Go's "%!(EXTRA ...)" warts.
+// Templates may carry zero placeholders (static prose like CAN_EXECUTE's
+// blast radius), one placeholder (POISONED_DESCRIPTION's summary names
+// only the tool), or two (CAN_REACH names both ends of the chain).
+// Calling fmt.Sprintf with extra args produces a literal trailing
+// "%!(EXTRA string=...)" in the output, which is what users were
+// previously seeing on POISONED_DESCRIPTION / POISONED_INSTRUCTIONS
+// findings.
+func formatImpactTemplate(tmpl, srcName, tgtName string) string {
 	switch strings.Count(tmpl, "%s") {
 	case 0:
 		return tmpl

--- a/server/internal/analysis/finding_detail.go
+++ b/server/internal/analysis/finding_detail.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/adithyan-ak/agenthound/server/internal/graph"
 )
@@ -111,6 +112,24 @@ RETURN [n IN [ext, int, h, s, a, t, r] | {id: n.objectid, name: n.name, kinds: l
        [{kind: 'DELEGATES_TO', source: ext.objectid, target: int.objectid, properties: {}}] + [rel IN [r1, r2, r3, r4, r5] | {kind: type(rel), source: startNode(rel).objectid, target: endNode(rel).objectid, properties: properties(rel)}] AS edges
 LIMIT 1`,
 	},
+	// CAN_REACH_CREDENTIAL_CHAIN reconstructs the cross-service path emitted
+	// by processors/cross_service_credential_chain.go. The composite edge
+	// has the AgentInstance as source and the upstream provider Credential
+	// as target; the chain is joined by Credential.value_hash, not by a
+	// graph edge. We re-traverse the same join here so the UI can show
+	// what the user followed: agent -> mcp server -> env-var credential
+	// (==value_hash==) -> litellm gateway -> upstream provider credential.
+	"CAN_REACH_CREDENTIAL_CHAIN": {
+		`MATCH (a:AgentInstance {objectid: $source})-[r1:TRUSTS_SERVER]->(s:MCPServer)
+      -[r2:HAS_ENV_VAR]->(c1:Credential)
+MATCH (gw:LiteLLMGateway)-[r3:EXPOSES_CREDENTIAL]->(c1master:Credential)
+WHERE c1master.value_hash = c1.value_hash AND c1master.objectid <> c1.objectid
+MATCH (gw)-[r4:EXPOSES_CREDENTIAL]->(c2:Credential {objectid: $target})
+RETURN [n IN [a, s, c1, c1master, gw, c2] | {id: n.objectid, name: n.name, kinds: labels(n), properties: properties(n)}] AS nodes,
+       [rel IN [r1, r2, r3, r4] | {kind: type(rel), source: startNode(rel).objectid, target: endNode(rel).objectid, properties: properties(rel)}] +
+       [{kind: 'VALUE_HASH_MATCH', source: c1.objectid, target: c1master.objectid, properties: {merge_value_hash: c1.value_hash, is_synthetic: true}}] AS edges
+LIMIT 1`,
+	},
 	"CAN_EXFILTRATE_VIA": {
 		`MATCH (a:AgentInstance {objectid: $source})-[:TRUSTS_SERVER]->(s1:MCPServer)
       -[r1:PROVIDES_TOOL]->(outbound:MCPTool {objectid: $target})
@@ -184,8 +203,10 @@ func ReconstructAttackPath(ctx context.Context, db graph.GraphDB, f *Finding, co
 
 	edgeKind := f.EdgeKind
 	if edgeKind == "CAN_REACH" {
-		crossProtocol := boolVal(compositeProps, "cross_protocol")
-		if crossProtocol {
+		if isCredentialChain(compositeProps) {
+			queries = append(queries, pathQueriesByEdgeKind["CAN_REACH_CREDENTIAL_CHAIN"]...)
+		}
+		if boolVal(compositeProps, "cross_protocol") {
 			queries = append(queries, pathQueriesByEdgeKind["CAN_REACH_CROSS_PROTOCOL"]...)
 		}
 	}
@@ -343,6 +364,10 @@ var impactTemplates = map[string]struct {
 		summary:     "External A2A agent %s can reach %s resource across protocol boundaries (A2A -> MCP).",
 		blastRadius: "Any prompt running in %s context can access %s.",
 	},
+	"CAN_REACH_CREDENTIAL_CHAIN": {
+		summary:     "Agent %s can reach upstream provider credential %s through a value_hash collision in a LiteLLM gateway.",
+		blastRadius: "Compromise of agent %s's MCP env-var credential exposes upstream provider key %s, enabling lateral movement to every service the gateway fronts.",
+	},
 	"CAN_EXFILTRATE_VIA": {
 		summary:     "Agent %s has access to sensitive data and can exfiltrate it via %s tool with outbound capability.",
 		blastRadius: "Data from resources with sensitive data can be sent to external destinations.",
@@ -375,8 +400,13 @@ var impactTemplates = map[string]struct {
 
 func BuildImpact(f *Finding, path *AttackPath, compositeProps map[string]any) *Impact {
 	edgeKind := f.EdgeKind
-	if edgeKind == "CAN_REACH" && boolVal(compositeProps, "cross_protocol") {
-		edgeKind = "CAN_REACH_CROSS_PROTOCOL"
+	if edgeKind == "CAN_REACH" {
+		switch {
+		case isCredentialChain(compositeProps):
+			edgeKind = "CAN_REACH_CREDENTIAL_CHAIN"
+		case boolVal(compositeProps, "cross_protocol"):
+			edgeKind = "CAN_REACH_CROSS_PROTOCOL"
+		}
 	}
 
 	srcName := f.SourceName
@@ -398,7 +428,7 @@ func BuildImpact(f *Finding, path *AttackPath, compositeProps map[string]any) *I
 
 	impact := &Impact{
 		Summary:     fmt.Sprintf(tmpl.summary, srcName, tgtName),
-		BlastRadius: tmpl.blastRadius,
+		BlastRadius: formatBlastRadius(tmpl.blastRadius, srcName, tgtName),
 	}
 
 	if path != nil {
@@ -411,4 +441,39 @@ func BuildImpact(f *Finding, path *AttackPath, compositeProps map[string]any) *I
 	}
 
 	return impact
+}
+
+// isCredentialChain returns true when compositeProps describe a finding
+// emitted by processors/cross_service_credential_chain.go. We branch on
+// source_collector (canonical) and fall back to via_gateway/merge_value_hash
+// presence for older edges that may pre-date the source_collector tag.
+func isCredentialChain(props map[string]any) bool {
+	if props == nil {
+		return false
+	}
+	if sc, _ := props["source_collector"].(string); sc == "cross_service_credential_chain" {
+		return true
+	}
+	if gw, _ := props["via_gateway"].(string); gw != "" {
+		if mh, _ := props["merge_value_hash"].(string); mh != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// formatBlastRadius substitutes srcName/tgtName into a blastRadius template
+// without producing Go's "%!(EXTRA ...)" warts when the template contains
+// fewer than two %s placeholders. Several templates are static prose and
+// must pass through untouched; others reuse the same (src, tgt) pair as
+// the summary line.
+func formatBlastRadius(tmpl, srcName, tgtName string) string {
+	switch strings.Count(tmpl, "%s") {
+	case 0:
+		return tmpl
+	case 1:
+		return fmt.Sprintf(tmpl, srcName)
+	default:
+		return fmt.Sprintf(tmpl, srcName, tgtName)
+	}
 }

--- a/server/internal/analysis/finding_detail_test.go
+++ b/server/internal/analysis/finding_detail_test.go
@@ -513,3 +513,154 @@ func TestBuildImpact_NilPath(t *testing.T) {
 		t.Errorf("Summary = %q, expected to contain source name", impact.Summary)
 	}
 }
+
+// TestBuildImpact_BlastRadiusInterpolated guards against the regression
+// where BlastRadius leaked literal "%s" placeholders to the UI because
+// BuildImpact assigned the template raw instead of running it through
+// fmt.Sprintf. Both CAN_REACH templates contain two %s placeholders for
+// (srcName, tgtName); a passing test asserts both names interpolate.
+func TestBuildImpact_BlastRadiusInterpolated(t *testing.T) {
+	cases := []struct {
+		name           string
+		compositeProps map[string]any
+	}{
+		{name: "plain CAN_REACH", compositeProps: nil},
+		{name: "cross protocol", compositeProps: map[string]any{"cross_protocol": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Finding{
+				EdgeKind:   "CAN_REACH",
+				SourceID:   "agent-1",
+				SourceName: "TestAgent",
+				TargetID:   "res-1",
+				TargetName: "ProdDB",
+			}
+			impact := BuildImpact(f, nil, tc.compositeProps)
+			if impact == nil {
+				t.Fatal("expected impact, got nil")
+			}
+			if strings.Contains(impact.BlastRadius, "%s") {
+				t.Errorf("BlastRadius leaked %%s placeholder: %q", impact.BlastRadius)
+			}
+			if !strings.Contains(impact.BlastRadius, "TestAgent") {
+				t.Errorf("BlastRadius = %q, expected source name to be interpolated", impact.BlastRadius)
+			}
+			if !strings.Contains(impact.BlastRadius, "ProdDB") {
+				t.Errorf("BlastRadius = %q, expected target name to be interpolated", impact.BlastRadius)
+			}
+		})
+	}
+}
+
+// TestBuildImpact_PreservesStaticBlastRadius confirms that templates
+// without %s placeholders pass through formatBlastRadius unchanged, so
+// the helper does not produce Go's "%!(EXTRA ...)" warts on edge kinds
+// like CAN_EXECUTE whose BlastRadius is static prose.
+func TestBuildImpact_PreservesStaticBlastRadius(t *testing.T) {
+	f := &Finding{
+		EdgeKind:   "CAN_EXECUTE",
+		SourceID:   "tool-1",
+		SourceName: "ShellExec",
+		TargetID:   "host-1",
+		TargetName: "prod-host",
+	}
+	impact := BuildImpact(f, nil, nil)
+	if impact == nil {
+		t.Fatal("expected impact, got nil")
+	}
+	if strings.Contains(impact.BlastRadius, "%") {
+		t.Errorf("BlastRadius contains stray %% (Sprintf wart?): %q", impact.BlastRadius)
+	}
+	if impact.BlastRadius != "Full host compromise is possible through any agent with access to this tool." {
+		t.Errorf("BlastRadius template was mutated: %q", impact.BlastRadius)
+	}
+}
+
+// TestReconstructAttackPath_CredentialChain guards the cross-service
+// credential-chain reconstruction added so finding-detail responses no
+// longer return null AttackPath for the v0.2 demo's flagship finding.
+// The mock returns a credential-chain shaped row only when the cypher
+// query is the credential-chain variant; the test asserts that variant
+// fires when compositeProps carry source_collector or via_gateway tags.
+func TestReconstructAttackPath_CredentialChain(t *testing.T) {
+	triedCredentialChain := false
+	mock := &graph.MockGraphDB{
+		QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
+			if strings.Contains(cypher, "LiteLLMGateway") && strings.Contains(cypher, "value_hash") {
+				triedCredentialChain = true
+				return []map[string]any{
+					{
+						"nodes": []any{
+							map[string]any{"id": "agent-1", "name": "DevAgent", "kinds": []any{"AgentInstance"}, "properties": map[string]any{}},
+							map[string]any{"id": "srv-1", "name": "Server1", "kinds": []any{"MCPServer"}, "properties": map[string]any{}},
+							map[string]any{"id": "c1-1", "name": "OPENAI_API_KEY", "kinds": []any{"Credential"}, "properties": map[string]any{}},
+							map[string]any{"id": "c1m-1", "name": "master-key", "kinds": []any{"Credential"}, "properties": map[string]any{}},
+							map[string]any{"id": "gw-1", "name": "litellm-gw", "kinds": []any{"LiteLLMGateway"}, "properties": map[string]any{}},
+							map[string]any{"id": "c2-1", "name": "openai-upstream", "kinds": []any{"Credential"}, "properties": map[string]any{}},
+						},
+						"edges": []any{
+							map[string]any{"source": "agent-1", "target": "srv-1", "kind": "TRUSTS_SERVER", "properties": map[string]any{}},
+							map[string]any{"source": "srv-1", "target": "c1-1", "kind": "HAS_ENV_VAR", "properties": map[string]any{}},
+							map[string]any{"source": "gw-1", "target": "c1m-1", "kind": "EXPOSES_CREDENTIAL", "properties": map[string]any{}},
+							map[string]any{"source": "gw-1", "target": "c2-1", "kind": "EXPOSES_CREDENTIAL", "properties": map[string]any{}},
+							map[string]any{"source": "c1-1", "target": "c1m-1", "kind": "VALUE_HASH_MATCH", "properties": map[string]any{"is_synthetic": true}},
+						},
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	f := &Finding{EdgeKind: "CAN_REACH", SourceID: "agent-1", TargetID: "c2-1"}
+	compositeProps := map[string]any{
+		"source_collector":  "cross_service_credential_chain",
+		"via_gateway":       "litellm-gw",
+		"merge_value_hash":  "abcd1234",
+		"upstream_provider": "openai",
+	}
+	path, err := ReconstructAttackPath(context.Background(), mock, f, compositeProps)
+	if err != nil {
+		t.Fatalf("ReconstructAttackPath() error = %v", err)
+	}
+	if !triedCredentialChain {
+		t.Error("expected credential-chain query to be tried")
+	}
+	if path == nil {
+		t.Fatal("expected reconstructed path, got nil")
+	}
+	if len(path.Nodes) != 6 {
+		t.Errorf("got %d nodes, want 6 (agent, server, c1, c1master, gateway, c2)", len(path.Nodes))
+	}
+}
+
+// TestBuildImpact_CredentialChain confirms the dedicated impact
+// template fires for credential-chain findings instead of the generic
+// CAN_REACH template that gives the operator no information about the
+// upstream provider exposure.
+func TestBuildImpact_CredentialChain(t *testing.T) {
+	f := &Finding{
+		EdgeKind:   "CAN_REACH",
+		SourceID:   "agent-1",
+		SourceName: "DevAgent",
+		TargetID:   "c2-1",
+		TargetName: "openai-upstream",
+	}
+	compositeProps := map[string]any{
+		"source_collector": "cross_service_credential_chain",
+	}
+	impact := BuildImpact(f, nil, compositeProps)
+	if impact == nil {
+		t.Fatal("expected impact, got nil")
+	}
+	if !strings.Contains(impact.Summary, "value_hash") {
+		t.Errorf("Summary = %q, expected credential-chain template mentioning value_hash", impact.Summary)
+	}
+	if !strings.Contains(impact.BlastRadius, "openai-upstream") {
+		t.Errorf("BlastRadius = %q, expected upstream credential name to be interpolated", impact.BlastRadius)
+	}
+	if strings.Contains(impact.BlastRadius, "%s") {
+		t.Errorf("BlastRadius leaked placeholder: %q", impact.BlastRadius)
+	}
+}

--- a/server/internal/analysis/finding_detail_test.go
+++ b/server/internal/analysis/finding_detail_test.go
@@ -635,6 +635,69 @@ func TestReconstructAttackPath_CredentialChain(t *testing.T) {
 	}
 }
 
+// TestBuildImpact_SummaryNoExtraWart guards against the regression
+// where Impact.Summary leaked Go's literal "%!(EXTRA string=...)" to
+// the UI for edge kinds whose summary template contains fewer than
+// two %s placeholders. Before the fix, BuildImpact called
+// fmt.Sprintf(tmpl.summary, srcName, tgtName) unconditionally;
+// POISONED_DESCRIPTION and POISONED_INSTRUCTIONS only have one %s, so
+// the second arg landed in the formatted output as the wart.
+func TestBuildImpact_SummaryNoExtraWart(t *testing.T) {
+	cases := []struct {
+		name     string
+		edgeKind string
+		srcName  string
+		tgtName  string
+		wantSrc  bool // template should interpolate srcName
+	}{
+		{
+			name:     "POISONED_DESCRIPTION (1 placeholder)",
+			edgeKind: "POISONED_DESCRIPTION",
+			srcName:  "MyTool",
+			tgtName:  "MyTarget",
+			wantSrc:  true,
+		},
+		{
+			name:     "POISONED_INSTRUCTIONS (1 placeholder)",
+			edgeKind: "POISONED_INSTRUCTIONS",
+			srcName:  "/path/to/CLAUDE.md",
+			tgtName:  "agent-1",
+			wantSrc:  true,
+		},
+		{
+			name:     "CAN_REACH (2 placeholders)",
+			edgeKind: "CAN_REACH",
+			srcName:  "TestAgent",
+			tgtName:  "ProdDB",
+			wantSrc:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Finding{
+				EdgeKind:   tc.edgeKind,
+				SourceID:   "src",
+				SourceName: tc.srcName,
+				TargetID:   "tgt",
+				TargetName: tc.tgtName,
+			}
+			impact := BuildImpact(f, nil, nil)
+			if impact == nil {
+				t.Fatal("expected impact, got nil")
+			}
+			if strings.Contains(impact.Summary, "%!(EXTRA") {
+				t.Errorf("Summary leaked Sprintf wart: %q", impact.Summary)
+			}
+			if strings.Contains(impact.Summary, "%s") {
+				t.Errorf("Summary leaked %%s placeholder: %q", impact.Summary)
+			}
+			if tc.wantSrc && !strings.Contains(impact.Summary, tc.srcName) {
+				t.Errorf("Summary = %q, expected source name %q to be interpolated", impact.Summary, tc.srcName)
+			}
+		})
+	}
+}
+
 // TestBuildImpact_CredentialChain confirms the dedicated impact
 // template fires for credential-chain findings instead of the generic
 // CAN_REACH template that gives the operator no information about the

--- a/server/internal/api/handlers/openapi.yaml
+++ b/server/internal/api/handlers/openapi.yaml
@@ -143,13 +143,15 @@ components:
           items:
             $ref: "#/components/schemas/Edge"
 
-    SearchResult:
+    SearchResultItem:
       type: object
       properties:
-        nodes:
-          type: array
-          items:
-            $ref: "#/components/schemas/Node"
+        id:
+          type: string
+        name:
+          type: string
+        kind:
+          type: string
 
     NeighborhoodResponse:
       type: object
@@ -401,7 +403,7 @@ components:
           type: string
         status:
           type: string
-          enum: [pending, running, completed, failed]
+          enum: [pending, running, completed, completed_with_errors, failed]
         started_at:
           type: string
           format: date-time
@@ -562,7 +564,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SearchResult"
+                type: array
+                items:
+                  $ref: "#/components/schemas/SearchResultItem"
 
   /graph/nodes:
     get:
@@ -627,13 +631,13 @@ paths:
           required: true
           schema:
             type: string
-        - name: hops
+        - name: depth
           in: query
           schema:
             type: integer
             default: 1
             minimum: 1
-            maximum: 5
+            maximum: 3
         - name: limit
           in: query
           schema:
@@ -882,7 +886,7 @@ paths:
   /analysis/prebuilt:
     get:
       summary: List pre-built queries
-      description: Returns metadata for all 17 pre-built security queries.
+      description: Returns metadata for all 18 pre-built security queries.
       operationId: listPreBuilt
       tags: [Analysis]
       responses:

--- a/server/ui/src/api/explorer.ts
+++ b/server/ui/src/api/explorer.ts
@@ -40,8 +40,7 @@ export async function fetchAllFindings(): Promise<Finding[]> {
     severities.map((sev) =>
       api
         .get("analysis/findings", { searchParams: { severity: sev } })
-        .json<Finding[]>()
-        .catch(() => [] as Finding[]),
+        .json<Finding[]>(),
     ),
   );
   return results.flat();

--- a/server/ui/src/components/explorer/InfoCard.tsx
+++ b/server/ui/src/components/explorer/InfoCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { EyeOff, Eye } from "lucide-react";
 import { useExplorerStore } from "@/store/explorer";
 import { useExplorerGraph } from "@/hooks/useExplorerGraph";
+import { useBlastRadius } from "@/hooks/useBlastRadius";
 import { getLens } from "@/lib/explorer/lens-config";
 import { buildExplorerGraph } from "@/lib/explorer/graph-builder";
 import { SEVERITY } from "@/theme/tokens";
@@ -13,10 +14,29 @@ export function InfoCard() {
   const subPresets = useExplorerStore((s) => s.subPresets[activeLens] ?? []);
   const showOrphans = useExplorerStore((s) => s.showOrphans);
   const toggleShowOrphans = useExplorerStore((s) => s.toggleShowOrphans);
+  const blastRadiusSourceId = useExplorerStore((s) => s.blastRadiusSourceId);
+  const blastDirection = useExplorerStore((s) => s.blastRadiusDirection);
+  const blastMaxHops = useExplorerStore((s) => s.blastRadiusMaxHops);
+
+  const { data: blastData } = useBlastRadius(
+    activeLens === "blast-radius" ? blastRadiusSourceId : null,
+    blastDirection,
+    blastMaxHops,
+  );
 
   const metrics = useMemo(() => {
     if (!data) return null;
     const lens = getLens(activeLens);
+
+    const blastRadius =
+      activeLens === "blast-radius" && blastData && blastRadiusSourceId
+        ? {
+            sourceId: blastRadiusSourceId,
+            nodeIds: blastData.nodeIdSet,
+            edgeKeys: blastData.edgeKeySet,
+          }
+        : undefined;
+
     const built = buildExplorerGraph(
       { nodes: data.nodes, edges: data.edges },
       {
@@ -24,11 +44,12 @@ export function InfoCard() {
         activeLensId: activeLens,
         subPresets,
         findings: data.findings,
+        blastRadius,
         showOrphans,
       },
     );
     return built.metrics;
-  }, [data, activeLens, subPresets, showOrphans]);
+  }, [data, activeLens, subPresets, showOrphans, blastData, blastRadiusSourceId]);
 
   const lens = getLens(activeLens);
 


### PR DESCRIPTION
## Summary

Resolves 9 of 10 audit findings that were independently validated as 100% true positives. The 10th (CLI module flags) was rejected as a false positive after verifying Go's init-order guarantees.

Each fix is committed atomically; verdicts came from parallel adversarial validators that tried to refute the claims and only confirmed with concrete file:line evidence.

### Fixes

1. **`[fix] cli: implant --type instruction.file falls back to Poisoner`** — `agenthound implant --type instruction.file` always errored with "no implanter registered" because `instructionpoison` registers as Poisoner. `runImplant` now falls back to a Poisoner lookup and hands off to a shared `runPoisonDispatch`. Per-module flag registration now skips duplicates so `--file` overlap doesn't panic init().
2. **`[fix] analysis: credential-chain reconstruction + blast_radius %s leak`** — adds `CAN_REACH_CREDENTIAL_CHAIN` reconstruction query so cross_service_credential_chain findings have explorable paths instead of `attack_path: null`. Also routes `BlastRadius` through `formatBlastRadius` so the literal `%s` placeholder no longer leaks to every CAN_REACH finding's UI.
3. **`[fix] ui: surface findings fetch errors and align InfoCard with canvas`** — `fetchAllFindings` no longer swallows per-severity HTTP errors to `[]` (a failed Critical fetch silently rendered "no critical findings"). InfoCard now consumes the `blastRadius` option so its metrics match the canvas in the blast-radius lens.
4. **`[fix] api: sync OpenAPI spec with live handlers`** — fixes 4 spec/handler divergences: graph search shape (`{nodes:[]}` vs bare array), neighborhood param (`hops` max 5 vs `depth` max 3), scan status enum (missing `completed_with_errors`), prebuilt count (17 vs 18).
5. **`[fix] ops: CI embed path, demo seed container, prod backup docs`** — CI's `cp -r` nested to `dist/dist` so validated builds shipped the "UI not built" fallback page. Demo seed targeted the pre-rename container `agenthound-demo-v3-ollama`. Backup docs referenced container names the production compose never produces; switched to `docker compose exec <service>`.

### Validated false positive (NOT in this PR)

- **CLI module flags missing** — REJECTED. Go guarantees imported package `init()` (which calls `module.Register`) runs before the importing `cli` package's `init()` that registers flags. `--help` shows all documented per-module flags at runtime; rejecting this finding avoided breaking working code.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./... -race -short -count=1` all pass
- [x] `bash scripts/deps-check.sh` clean (no chi/pgx/neo4j leakage into collector)
- [x] `bash scripts/size-check.sh` collector binary 9.9 MiB, within +10% baseline
- [x] `npm run build` (server/ui) — typecheck + bundle clean
- [x] New regression tests:
  - `TestRunImplant_FallsBackToPoisoner` — happy path for the new fallback
  - `TestRunImplant_NoModuleAndNoFallback` — original error still fires when nothing matches
  - `TestReconstructAttackPath_CredentialChain` — credential-chain query fires on `source_collector` / `via_gateway` props
  - `TestBuildImpact_BlastRadiusInterpolated` — `%s` regression guard for plain + cross-protocol CAN_REACH
  - `TestBuildImpact_PreservesStaticBlastRadius` — `formatBlastRadius` doesn't `%!(EXTRA ...)` static templates
  - `TestBuildImpact_CredentialChain` — dedicated credential-chain template fires

## Risk

Low across the board. The implant fallback preserves all safety gates (sentinel, `--commit=false`, receipt persistence) by routing through the same Poisoner dispatch. UI changes are purely fixes (failures now visible; metrics now consistent). OpenAPI/docs/CI changes are content-level. The credential-chain reconstruction is additive — it only fires on findings that were previously returning null path.