### PR TITLE
[fix] resolve 6 remaining audit findings (ingest, explorer, build, docs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ seed: preflight-server-running
 demo: preflight-demo
 	@bash scripts/seed-demo.sh
 
-release:
+release: ui-build
 	goreleaser release --clean --snapshot
 
 standard: preflight-docker

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -490,6 +490,7 @@ agenthound-server query --shortest-path --from AgentInstance:claude --to MCPReso
 | `cross-protocol-paths` | Critical Paths | critical |
 | `exfiltration-routes` | Critical Paths | critical |
 | `credential-chain` | Critical Paths | critical |
+| `litellm-credential-leak` | Critical Paths | critical |
 | `unpinned-shell` | Combined | critical |
 | `poisoned-tools` | Vulnerabilities | high |
 | `tool-shadowing` | Vulnerabilities | high |

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -214,7 +214,8 @@ Lower weight = easier to exploit = higher risk. Used by Dijkstra weighted-path q
 | Edge | Weight | Condition |
 |------|--------|-----------|
 | `TRUSTS_SERVER` | 0.1 | auth_method = none |
-| `TRUSTS_SERVER` | 0.3 | auth_method = static_key |
+| `TRUSTS_SERVER` | 0.3 | auth_method = apiKey |
+| `TRUSTS_SERVER` | 0.5 | auth_method = bearer |
 | `TRUSTS_SERVER` | 0.7 | auth_method = oauth |
 | `TRUSTS_SERVER` | 0.9 | auth_method = mtls |
 | `PROVIDES_TOOL` | 0.1 | Always (tools are always available once trusted) |

--- a/server/internal/ingest/validator.go
+++ b/server/internal/ingest/validator.go
@@ -92,6 +92,23 @@ func (v *Validator) Validate(data *ingest.IngestData) error {
 				Message: fmt.Sprintf("invalid edge kind %q", edge.Kind),
 			})
 		}
+		// source_kind/target_kind are interpolated as Neo4j labels in the graph
+		// writer's MATCH clause (labels cannot be query-parameterized), so any
+		// non-empty value MUST be an allowed node kind. This mirrors the node
+		// kind check above and the analysis handlers' validNodeKind guard,
+		// closing the same Cypher-injection class on the ingest path.
+		if edge.SourceKind != "" && !ingest.AllowedNodeKinds[edge.SourceKind] {
+			errs = append(errs, FieldError{
+				Path:    fmt.Sprintf("graph.edges[%d].source_kind", i),
+				Message: fmt.Sprintf("invalid source_kind %q", edge.SourceKind),
+			})
+		}
+		if edge.TargetKind != "" && !ingest.AllowedNodeKinds[edge.TargetKind] {
+			errs = append(errs, FieldError{
+				Path:    fmt.Sprintf("graph.edges[%d].target_kind", i),
+				Message: fmt.Sprintf("invalid target_kind %q", edge.TargetKind),
+			})
+		}
 	}
 
 	if len(errs) > 0 {

--- a/server/internal/ingest/validator_test.go
+++ b/server/internal/ingest/validator_test.go
@@ -141,6 +141,32 @@ func TestValidatorRejectsCompositeEdgeKind(t *testing.T) {
 	assertValidationError(t, err, "graph.edges[0].kind")
 }
 
+func TestValidatorRejectsInvalidEdgeSourceKind(t *testing.T) {
+	v := NewValidator()
+	data := validIngestData()
+	data.Graph.Edges[0].SourceKind = "MCPServer) WITH edge MATCH (z) DETACH DELETE z //"
+	err := v.Validate(data)
+	assertValidationError(t, err, "graph.edges[0].source_kind")
+}
+
+func TestValidatorRejectsInvalidEdgeTargetKind(t *testing.T) {
+	v := NewValidator()
+	data := validIngestData()
+	data.Graph.Edges[0].TargetKind = "MCPTool {x:1}) DETACH DELETE n //"
+	err := v.Validate(data)
+	assertValidationError(t, err, "graph.edges[0].target_kind")
+}
+
+func TestValidatorAcceptsValidExplicitEdgeKinds(t *testing.T) {
+	v := NewValidator()
+	data := validIngestData()
+	data.Graph.Edges[0].SourceKind = "MCPServer"
+	data.Graph.Edges[0].TargetKind = "MCPTool"
+	if err := v.Validate(data); err != nil {
+		t.Fatalf("expected explicit valid edge kinds to validate, got: %v", err)
+	}
+}
+
 func TestValidatorCollectsAllErrors(t *testing.T) {
 	v := NewValidator()
 	data := &ingest.IngestData{

--- a/server/ui/src/entities/scan/queries.ts
+++ b/server/ui/src/entities/scan/queries.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import { qk } from "@shared/api/query-keys";
 import { deleteScan, fetchScans, uploadScan } from "./api";
 
@@ -13,16 +18,36 @@ export function useScans(limit = SCANS_LIST_LIMIT) {
   });
 }
 
-// Mutations replicate today's post-write refetch target ONLY: the scan-manager
-// list. They deliberately do NOT invalidate the dashboard scan widgets (a
-// separately-listed, out-of-scope behavioral change).
+// A scan import or delete mutates the underlying graph, so EVERY graph-derived
+// cache — not just the scan list — must be refetched, otherwise the dashboard,
+// explorer, findings, and query views can show pre-write data for up to the
+// query staleTime. These prefix keys invalidate all parameterized variants
+// (e.g. both the manager's ["scans",50] and the dashboard's ["scans",20]).
+const GRAPH_DERIVED_KEY_PREFIXES: readonly (readonly string[])[] = [
+  ["scans"],
+  ["graph"],
+  ["nodes"],
+  ["node"],
+  ["edges"],
+  ["findings"],
+  ["finding-detail"],
+  ["prebuilt-queries"],
+  ["prebuilt"],
+  ["explorer"],
+  ["health"],
+];
+
+function invalidateGraphDerivedQueries(queryClient: QueryClient) {
+  for (const queryKey of GRAPH_DERIVED_KEY_PREFIXES) {
+    void queryClient.invalidateQueries({ queryKey });
+  }
+}
+
 export function useDeleteScan() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => deleteScan(id),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: qk.scans(SCANS_LIST_LIMIT) });
-    },
+    onSuccess: () => invalidateGraphDerivedQueries(queryClient),
   });
 }
 
@@ -30,8 +55,6 @@ export function useUploadScan() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (file: File) => uploadScan(file),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: qk.scans(SCANS_LIST_LIMIT) });
-    },
+    onSuccess: () => invalidateGraphDerivedQueries(queryClient),
   });
 }

--- a/server/ui/src/features/explorer/model/useExplorerViewModel.ts
+++ b/server/ui/src/features/explorer/model/useExplorerViewModel.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { useMarksStore } from "@shared/model/marks";
 import { useExplorerStore } from "./store";
 import { useExplorerGraph, type ExplorerRawData } from "./useExplorerGraph";
 import { useBlastRadius } from "./useBlastRadius";
@@ -40,8 +39,6 @@ export function useExplorerViewModel(): ExplorerViewModel {
   const blastDirection = useExplorerStore((s) => s.blastRadiusDirection);
   const blastMaxHops = useExplorerStore((s) => s.blastRadiusMaxHops);
   const highlight = useExplorerStore((s) => s.highlight);
-  const ownedNodeIds = useMarksStore((s) => s.ownedNodeIds);
-  const highValueNodeIds = useMarksStore((s) => s.highValueNodeIds);
 
   const { data: blastData } = useBlastRadius(
     activeLens === "blast-radius" ? blastRadiusSourceId : null,
@@ -49,11 +46,6 @@ export function useExplorerViewModel(): ExplorerViewModel {
     blastMaxHops,
   );
 
-  const ownedSet = useMemo(() => new Set(ownedNodeIds), [ownedNodeIds]);
-  const highValueSet = useMemo(
-    () => new Set(highValueNodeIds),
-    [highValueNodeIds],
-  );
   const highlightSets = useMemo(() => {
     if (!highlight) return null;
     return {
@@ -73,8 +65,6 @@ export function useExplorerViewModel(): ExplorerViewModel {
             blastData,
             blastRadiusSourceId,
             showOrphans,
-            ownedSet,
-            highValueSet,
             highlight: highlightSets,
           })
         : null,
@@ -85,8 +75,6 @@ export function useExplorerViewModel(): ExplorerViewModel {
       blastData,
       blastRadiusSourceId,
       showOrphans,
-      ownedSet,
-      highValueSet,
       highlightSets,
     ],
   );

--- a/server/ui/src/features/explorer/model/view-model.ts
+++ b/server/ui/src/features/explorer/model/view-model.ts
@@ -18,8 +18,11 @@ export interface RenderParams {
   blastData: BlastRadiusData | undefined;
   blastRadiusSourceId: string | null;
   showOrphans: boolean;
-  ownedSet: Set<string>;
-  highValueSet: Set<string>;
+  // Optional: the canvas applies Owned / High-Value marks as a post-layout
+  // overlay (they are pure presentation badges), so the layout-keyed render
+  // build no longer feeds them. Still accepted for direct/unit use.
+  ownedSet?: Set<string>;
+  highValueSet?: Set<string>;
   highlight: { nodeIds: Set<string>; edgeIds: Set<string> } | null;
 }
 

--- a/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
+++ b/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   Background,
@@ -14,9 +14,14 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useExplorerStore } from "@features/explorer/model/store";
+import { useMarksStore } from "@shared/model/marks";
 import { computeExplorerLayout } from "@features/explorer/model/layout";
 import { computeClickNeighbors } from "@features/explorer/model/click-neighbors";
-import type { BuildResult, LensEdgeData } from "@features/explorer/model/graph";
+import type {
+  BuildResult,
+  LensEdgeData,
+  HexNodeData,
+} from "@features/explorer/model/graph";
 import type { ExplorerRawData } from "@features/explorer/model/useExplorerGraph";
 import { useEscapeKey } from "@shared/lib/useEscapeKey";
 import { HexNode } from "./nodes/HexNode";
@@ -70,6 +75,32 @@ export function ExplorerCanvas({
   reactFlowRef.current = reactFlow;
   const hasInitialLayoutRef = useRef(false);
   const prevShowOrphansRef = useRef(showOrphans);
+
+  const ownedNodeIds = useMarksStore((s) => s.ownedNodeIds);
+  const highValueNodeIds = useMarksStore((s) => s.highValueNodeIds);
+  const ownedSet = useMemo(() => new Set(ownedNodeIds), [ownedNodeIds]);
+  const highValueSet = useMemo(
+    () => new Set(highValueNodeIds),
+    [highValueNodeIds],
+  );
+
+  // Owned / High-Value are pure presentation badges (no structural, dim, or
+  // size effect), so they are layered onto the already-positioned nodes here
+  // rather than fed into the ELK-layout build. Toggling a mark updates the
+  // badge instantly with no graph re-layout. Object identity is preserved for
+  // unchanged nodes so only the toggled hex re-renders.
+  const displayNodes = useMemo(
+    () =>
+      nodes.map((n) => {
+        if (n.type !== "hex") return n;
+        const data = n.data as HexNodeData;
+        const owned = ownedSet.has(n.id);
+        const highValue = highValueSet.has(n.id);
+        if (data.owned === owned && data.highValue === highValue) return n;
+        return { ...n, data: { ...data, owned, highValue } };
+      }),
+    [nodes, ownedSet, highValueSet],
+  );
 
   useEffect(() => {
     if (!built) return;
@@ -206,7 +237,7 @@ export function ExplorerCanvas({
 
   return (
     <ReactFlow
-      nodes={nodes}
+      nodes={displayNodes}
       edges={edges}
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}


### PR DESCRIPTION
## Summary

Closes the **6 of 8** verified audit findings still open on `main`. Findings **#2** (finding-detail text) and **#4** (CI dist embed) already shipped via PR #39, so this PR covers the rest. Every change is minimal and behavior-preserving.

| # | Severity | Area | Fix |
|---|----------|------|-----|
| 1 | High | `server/internal/ingest/validator.go` | Validate edge `source_kind`/`target_kind` against `AllowedNodeKinds`. They are interpolated as Neo4j labels in the writer's `MATCH` clause (labels can't be query-parameterized), so this closes the same Cypher-injection class the analysis handlers already guard. +3 tests. |
| 3 | Medium | `features/explorer` | Apply Owned / High-Value marks as a **post-layout overlay** instead of feeding the ELK-layout build, so marking a node no longer triggers a full graph re-layout. |
| 5 | Low | `entities/scan/queries.ts` | Invalidate **all graph-derived caches** on scan import/delete (not just the scan list), so dashboard/explorer/findings/query views show freshly-ingested data immediately. |
| 6 | Low | `Makefile` | `release` now depends on `ui-build` so GoReleaser snapshots embed the freshly-built UI. |
| 7 | Low | `docs/reference/cli.md` | Add the missing `litellm-credential-leak` prebuilt-query row (registry has 18; table listed 17). |
| 8 | Low | `docs/reference/graph-model.md` | Fix `TRUSTS_SERVER` `auth_method` weights (`static_key` → `apiKey`, add `bearer` 0.5) to match `riskscore/weights.go`. |

## Notes on scope / non-breaking guarantees

- **#1** is fixed at the *validator* layer (untrusted ingest input), not the writer — so `TestWriteEdges_ExplicitKindsOverrideRegistry` (which calls the writer directly) stays valid. Every endpoint kind in `EdgeKindEndpoints` is already within `AllowedNodeKinds`, so all legitimate collector output passes.
- **#3** deliberately leaves the *highlight* path in the layout build: highlight also drives orphan **clustering** (a structural change at `build-nodes.ts`), so decoupling it would alter visual behavior. Only Owned/High-Value (pure presentation badges, zero structural/dim/size impact) are overlaid. Node object identity is preserved so only the toggled hex re-renders. `buildRenderGraph` stays mark-capable for the existing unit test.
- **#5** invalidates by key *prefix*, so both the manager's `["scans",50]` and the dashboard's `["scans",20]` refresh. Only triggers refetches of already-correct queries — no behavior depends on stale caches.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (all pass, incl. 3 new validator tests)
- [x] UI `tsc --noEmit` clean
- [x] UI `eslint src/` clean (incl. feature-sliced `boundaries`)
- [x] UI `vitest run` — 74/74 pass
- [x] UI `npm run build` succeeds

Made with [Cursor](https://cursor.com)