### PR TITLE
feat(ui): connect findings and explorer into one investigation surface

### DIFF
--- a/server/ui/src/entities/edge/index.ts
+++ b/server/ui/src/entities/edge/index.ts
@@ -1,2 +1,3 @@
 export * from "./api";
 export * from "./styles";
+export * from "./semantics";

--- a/server/ui/src/entities/edge/semantics.ts
+++ b/server/ui/src/entities/edge/semantics.ts
@@ -1,0 +1,113 @@
+// Edge semantics — the single source of truth for what an edge *means* and how
+// it is exploited. Previously this content was duplicated in
+// `features/findings/lib/edge-exploits.ts` and `features/inspector/ui/
+// EdgeEvidence.tsx`; both now re-import from here so the dossier (hop timeline),
+// the inspector, and the explorer (edge tooltip + edge drawer) all speak the
+// same language for every edge kind.
+
+export interface EdgeExploit {
+  title: string;
+  detail: string;
+}
+
+/** Plain-English exploit explanation per edge kind. */
+export const EDGE_EXPLOIT: Record<string, EdgeExploit> = {
+  CAN_REACH: {
+    title: "Transitive reachability",
+    detail:
+      "This agent can reach the target resource through a chain of trusted servers and tools. An attacker controlling the agent can invoke this chain end-to-end without any additional privilege escalation.",
+  },
+  CAN_EXFILTRATE_VIA: {
+    title: "Exfiltration route",
+    detail:
+      "The source agent has access to sensitive data AND has a tool with outbound network capability. This combination allows silent exfiltration — the agent can read the data and send it out in a single interaction.",
+  },
+  CAN_EXECUTE: {
+    title: "Shell / code execution",
+    detail:
+      "This tool is classified as having shell_access or code_execution capability. An attacker invoking this tool through the agent gains command execution on the target host.",
+  },
+  POISONED_DESCRIPTION: {
+    title: "Tool description injection",
+    detail:
+      "This tool's description contains prompt-injection patterns. An LLM reading the tool list may follow instructions hidden in the description rather than the user's intent.",
+  },
+  POISONED_INSTRUCTIONS: {
+    title: "Instruction file poisoning",
+    detail:
+      "An instruction file loaded by the agent (AGENTS.md / CLAUDE.md / cursorrules / etc.) contains suspicious imperative overrides or hidden Unicode.",
+  },
+  SHADOWS: {
+    title: "Tool name shadowing",
+    detail:
+      "This tool's description references another server's tool by name, creating a confused-deputy risk where the LLM may call the wrong tool.",
+  },
+  CAN_IMPERSONATE: {
+    title: "Agent impersonation",
+    detail:
+      "This A2A agent's skill descriptions are >80% similar to another agent's. A downstream caller may be tricked into delegating to the wrong agent.",
+  },
+  HAS_ACCESS_TO: {
+    title: "Direct resource access",
+    detail:
+      "Based on capability surface and URI scheme match, this tool can read or write this resource.",
+  },
+  TRUSTS_SERVER: {
+    title: "Configured trust",
+    detail:
+      "This agent's config file declares trust in this MCP server. The agent will send all tool lists and invoke all listed tools without further authentication checks on the user side.",
+  },
+  DELEGATES_TO: {
+    title: "A2A delegation",
+    detail:
+      "This A2A agent delegates tasks to the target. Any capability the target has becomes transitively available to the source agent.",
+  },
+};
+
+/**
+ * Short relationship phrase per edge kind — used by the explorer legend and
+ * edge tooltip so a line on the canvas reads as a sentence
+ * ("agent → can reach → resource") rather than an anonymous colored stroke.
+ */
+export const EDGE_DESCRIPTION: Record<string, string> = {
+  TRUSTS_SERVER: "Agent trusts MCP server",
+  PROVIDES_TOOL: "Server provides tool",
+  PROVIDES_RESOURCE: "Server provides resource",
+  PROVIDES_PROMPT: "Server provides prompt template",
+  ADVERTISES_SKILL: "A2A agent advertises skill",
+  DELEGATES_TO: "Agent delegates to agent",
+  AUTHENTICATES_WITH: "Authenticates with identity",
+  USES_CREDENTIAL: "Identity uses credential",
+  RUNS_ON: "Runs on host",
+  CONFIGURED_IN: "Configured in file",
+  HAS_ENV_VAR: "Has credential env var",
+  LOADS_INSTRUCTIONS: "Loads instruction file",
+  SAME_AUTH_DOMAIN: "Shares auth domain",
+  EXPOSES: "Exposes AI service",
+  EXPOSES_CREDENTIAL: "Exposes credential material",
+  PROVIDES_MODEL: "Serves model artifact",
+  EXTRACTED_FROM: "Extracted from model",
+  HAS_ACCESS_TO: "Tool can access resource",
+  CAN_EXECUTE: "Tool can execute on host",
+  SHADOWS: "Tool shadows another tool",
+  POISONED_DESCRIPTION: "Poisoned tool description",
+  POISONED_INSTRUCTIONS: "Poisoned instruction file",
+  CAN_REACH: "Agent can reach resource",
+  CAN_EXFILTRATE_VIA: "Agent can exfiltrate via tool",
+  CAN_IMPERSONATE: "Agent can impersonate agent",
+};
+
+/** Human-readable label for an edge kind (e.g. "CAN REACH"). */
+export function edgeLabel(kind: string): string {
+  return kind.replace(/_/g, " ");
+}
+
+/** Short relationship phrase, falling back to the humanized kind. */
+export function edgeDescription(kind: string): string {
+  return EDGE_DESCRIPTION[kind] ?? edgeLabel(kind);
+}
+
+/** Exploit explanation for an edge kind, if one is defined. */
+export function edgeExploit(kind: string): EdgeExploit | undefined {
+  return EDGE_EXPLOIT[kind];
+}

--- a/server/ui/src/features/explorer/ExplorerPage.tsx
+++ b/server/ui/src/features/explorer/ExplorerPage.tsx
@@ -8,6 +8,9 @@ import { StatusStrip } from "./ui/StatusStrip";
 import { ChainRibbon } from "./ui/ChainRibbon";
 import { BlastRadiusRings } from "./ui/BlastRadiusRings";
 import { NodeDetailDrawer } from "./ui/NodeDetailDrawer";
+import { EdgeDetailDrawer } from "./ui/EdgeDetailDrawer";
+import { EdgeTooltip } from "./ui/EdgeTooltip";
+import { ExplorerDeepLink } from "./ui/ExplorerDeepLink";
 import { ExplorerNodeContextMenu } from "./ui/ExplorerNodeContextMenu";
 
 export function ExplorerPage() {
@@ -41,7 +44,10 @@ function ExplorerWorkspace() {
       <InfoCard metrics={vm.lensMetrics} />
       <Legend />
       <ChainRibbon />
+      <ExplorerDeepLink />
       <NodeDetailDrawer />
+      <EdgeDetailDrawer />
+      <EdgeTooltip />
       <StatusStrip totals={vm.totals} />
       <ExplorerNodeContextMenu />
     </>

--- a/server/ui/src/features/explorer/model/graph/build-edges.ts
+++ b/server/ui/src/features/explorer/model/graph/build-edges.ts
@@ -1,9 +1,40 @@
 import type { APIEdge, APINode } from "@entities/graph/dto";
 import type { Finding } from "@entities/finding/model";
+import { getEdgeColor } from "@entities/edge";
 import type { SeverityLevel } from "../lens-config";
 import type { BuildOptions, BundledEdge, LensEdgeData, LogicalEdge } from "./types";
 import { edgeKey, bundleKey } from "./edge-key";
 import { isCrossProtocolEdge } from "./protocol";
+import { SEVERITY, EDGE_COLORS, NODE_KIND_COLORS } from "@shared/theme/tokens";
+
+const SEVERITY_COLOR: Record<SeverityLevel, string> = {
+  critical: SEVERITY.critical.solid,
+  high: SEVERITY.high.solid,
+  medium: SEVERITY.medium.solid,
+  low: SEVERITY.low.solid,
+  info: SEVERITY.info.solid,
+};
+
+/**
+ * Resolve an edge's final stroke color from the lens coloring policy. Mirrors
+ * the legend's decoder so the canvas and legend never disagree:
+ *   - cross-protocol edges → A2A purple (the differentiator)
+ *   - severity-coloring lens with a finding → severity color
+ *   - severity-coloring lens, no finding → neutral structure slate (recede)
+ *   - non-severity lens → the edge's category color (trust / structure / attack)
+ */
+export function resolveEdgeColor(
+  kind: string,
+  severity: SeverityLevel | null,
+  isCrossProtocol: boolean,
+  colorBySeverity: boolean,
+): string {
+  if (isCrossProtocol) return NODE_KIND_COLORS.A2AAgent;
+  if (colorBySeverity) {
+    return severity ? SEVERITY_COLOR[severity] : EDGE_COLORS.structure;
+  }
+  return getEdgeColor(kind);
+}
 
 export function severityRank(severity: SeverityLevel | null): number {
   switch (severity) {
@@ -176,6 +207,13 @@ export function buildLogicalEdges(
     touchedNodeIds.add(primary.source);
     touchedNodeIds.add(primary.target);
 
+    const color = resolveEdgeColor(
+      primary.kind,
+      topSeverity,
+      crossProtocol,
+      lens.colorEdgesBySeverity,
+    );
+
     edges.push({
       id: edgeId,
       source: primary.source,
@@ -195,6 +233,7 @@ export function buildLogicalEdges(
         dim,
         emphasized: false,
         showFlowDot,
+        color,
       } satisfies LensEdgeData,
     });
   }

--- a/server/ui/src/features/explorer/model/graph/types.ts
+++ b/server/ui/src/features/explorer/model/graph/types.ts
@@ -44,6 +44,14 @@ export interface LensEdgeData extends Record<string, unknown> {
   dim: boolean;
   emphasized: boolean;
   showFlowDot: boolean;
+  /**
+   * Final resolved stroke color, computed once at build time from the lens'
+   * coloring policy: cross-protocol → purple; severity lens with a finding →
+   * severity color; otherwise the edge's category color (trust/structure/
+   * attack). Centralizing it here keeps the renderer dumb and the legend
+   * honest (the legend decodes the same policy).
+   */
+  color: string;
 }
 
 export interface BundledEdge {

--- a/server/ui/src/features/explorer/model/lens-config.ts
+++ b/server/ui/src/features/explorer/model/lens-config.ts
@@ -359,3 +359,32 @@ export const LENS_MAP: Record<LensId, LensDefinition> = LENS_LIST.reduce(
 export function getLens(id: LensId): LensDefinition {
   return LENS_MAP[id];
 }
+
+/**
+ * Maps a finding's headline edge kind to the lens that best frames it, so a
+ * "View in Explorer" deep-link lands on the right view rather than the default
+ * topology. Credential and poisoning edges get their dedicated lenses; all
+ * other composite/attack edges use Attack Surface; structural edges fall back
+ * to Topology.
+ */
+export function lensForEdgeKind(kind: string): LensId {
+  switch (kind) {
+    case "AUTHENTICATES_WITH":
+    case "USES_CREDENTIAL":
+    case "HAS_ENV_VAR":
+    case "EXPOSES_CREDENTIAL":
+      return "credentials";
+    case "SHADOWS":
+    case "POISONED_DESCRIPTION":
+    case "POISONED_INSTRUCTIONS":
+      return "poisoning";
+    case "HAS_ACCESS_TO":
+    case "CAN_EXECUTE":
+    case "CAN_REACH":
+    case "CAN_EXFILTRATE_VIA":
+    case "CAN_IMPERSONATE":
+      return "attack-surface";
+    default:
+      return "topology";
+  }
+}

--- a/server/ui/src/features/explorer/model/store.ts
+++ b/server/ui/src/features/explorer/model/store.ts
@@ -103,7 +103,7 @@ interface ExplorerActions {
 // leaving genuinely-emitted edges (e.g. CAN_IMPERSONATE, EXPOSES_CREDENTIAL)
 // off by default. `LensId` is imported by lens-config as a type-only import,
 // so this value import introduces no runtime circular dependency.
-const DEFAULT_SUB_PRESETS = Object.fromEntries(
+export const DEFAULT_SUB_PRESETS = Object.fromEntries(
   LENS_LIST.map((lens) => [
     lens.id,
     lens.subPresets.filter((sp) => sp.defaultEnabled).map((sp) => sp.id),

--- a/server/ui/src/features/explorer/model/store.ts
+++ b/server/ui/src/features/explorer/model/store.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import { LENS_LIST } from "./lens-config";
+import type { LensEdgeData } from "./graph";
 
 export type LensId =
   | "topology"
@@ -15,7 +17,8 @@ export type DrawerTab =
   | "properties"
   | "connections"
   | "evidence"
-  | "remediation";
+  | "remediation"
+  | "findings";
 
 export type BlastDirection = "out" | "in" | "both";
 
@@ -25,11 +28,38 @@ export interface HighlightState {
   title?: string;
 }
 
+/** A selected edge carries its full bundled data so the edge drawer can render
+ * every constituent relationship without re-parsing the React-Flow edge id. */
+export interface SelectedEdge {
+  id: string;
+  source: string;
+  target: string;
+  data: LensEdgeData;
+}
+
+/** Edge under the cursor — drives the floating edge tooltip. */
+export interface HoveredEdge {
+  id: string;
+  source: string;
+  target: string;
+  data: LensEdgeData;
+  x: number;
+  y: number;
+}
+
+/** A request to pan/zoom the canvas onto a set of nodes (deep-link focus). */
+export interface PendingFocus {
+  nodeIds: string[];
+  title?: string;
+}
+
 interface ExplorerState {
   activeLens: LensId;
   subPresets: Record<LensId, string[]>;
   selectedNodeId: string | null;
-  selectedEdgeId: string | null;
+  selectedEdge: SelectedEdge | null;
+  hoveredEdge: HoveredEdge | null;
+  pendingFocus: PendingFocus | null;
   drawerOpen: boolean;
   drawerTab: DrawerTab;
   blastRadiusSourceId: string | null;
@@ -49,7 +79,8 @@ interface ExplorerActions {
   setSubPresets: (lens: LensId, presets: string[]) => void;
   toggleSubPreset: (lens: LensId, preset: string) => void;
   selectNode: (id: string | null) => void;
-  selectEdge: (id: string | null) => void;
+  selectEdge: (edge: SelectedEdge | null) => void;
+  setHoveredEdge: (edge: HoveredEdge | null) => void;
   clearSelection: () => void;
   openDrawer: (tab?: DrawerTab) => void;
   closeDrawer: () => void;
@@ -61,6 +92,7 @@ interface ExplorerActions {
   toggleShowOrphans: () => void;
   setHighlight: (highlight: HighlightState | null) => void;
   clearHighlight: () => void;
+  setPendingFocus: (focus: PendingFocus | null) => void;
   openContextMenu: (nodeId: string, x: number, y: number) => void;
   closeContextMenu: () => void;
 }
@@ -79,11 +111,14 @@ const DEFAULT_SUB_PRESETS = Object.fromEntries(
 ) as Record<LensId, string[]>;
 
 export const useExplorerStore = create<ExplorerState & ExplorerActions>()(
-  (set) => ({
+  persist(
+    (set) => ({
       activeLens: "topology",
       subPresets: DEFAULT_SUB_PRESETS,
       selectedNodeId: null,
-      selectedEdgeId: null,
+      selectedEdge: null,
+      hoveredEdge: null,
+      pendingFocus: null,
       drawerOpen: false,
       drawerTab: "properties",
       blastRadiusSourceId: null,
@@ -112,14 +147,19 @@ export const useExplorerStore = create<ExplorerState & ExplorerActions>()(
           };
         }),
 
-      selectNode: (id) => set({ selectedNodeId: id, selectedEdgeId: null }),
+      selectNode: (id) =>
+        set({ selectedNodeId: id, selectedEdge: null }),
 
-      selectEdge: (id) => set({ selectedEdgeId: id, selectedNodeId: null }),
+      selectEdge: (edge) =>
+        set({ selectedEdge: edge, selectedNodeId: null }),
+
+      setHoveredEdge: (edge) => set({ hoveredEdge: edge }),
 
       clearSelection: () =>
         set({
           selectedNodeId: null,
-          selectedEdgeId: null,
+          selectedEdge: null,
+          hoveredEdge: null,
           drawerOpen: false,
           highlight: null,
           contextMenu: null,
@@ -152,9 +192,23 @@ export const useExplorerStore = create<ExplorerState & ExplorerActions>()(
 
       clearHighlight: () => set({ highlight: null }),
 
+      setPendingFocus: (focus) => set({ pendingFocus: focus }),
+
       openContextMenu: (nodeId, x, y) =>
         set({ contextMenu: { nodeId, x, y } }),
 
       closeContextMenu: () => set({ contextMenu: null }),
     }),
+    {
+      // Persist only durable view preferences. Selection / hover / focus /
+      // blast-radius are ephemeral and intentionally excluded so a reload
+      // restores the user's lens + sub-preset choices without restoring a
+      // stale selection.
+      name: "agenthound-explorer-view",
+      partialize: (state) => ({
+        activeLens: state.activeLens,
+        subPresets: state.subPresets,
+      }),
+    },
+  ),
 );

--- a/server/ui/src/features/explorer/ui/ChainRibbon.tsx
+++ b/server/ui/src/features/explorer/ui/ChainRibbon.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
-import { AlertOctagon, ArrowRight, Shield } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { AlertOctagon, ArrowRight, ExternalLink, Shield } from "lucide-react";
 import { useExplorerGraph } from "@features/explorer/model/useExplorerGraph";
 import { useExplorerStore } from "@features/explorer/model/store";
 import {
@@ -10,6 +11,7 @@ import { SEVERITY, SIGNAL_OK } from "@shared/theme/tokens";
 import { cn } from "@shared/lib/utils";
 
 export function ChainRibbon() {
+  const navigate = useNavigate();
   const activeLens = useExplorerStore((s) => s.activeLens);
   const selectNode = useExplorerStore((s) => s.selectNode);
   const selectedNodeId = useExplorerStore((s) => s.selectedNodeId);
@@ -74,6 +76,7 @@ export function ChainRibbon() {
               selectNode(chain.sourceId);
               openDrawer();
             }}
+            onOpenFinding={() => navigate(`/findings/${chain.findingId}`)}
           />
         ))}
       </div>
@@ -85,17 +88,27 @@ function ChainCard({
   chain,
   selected,
   onSelect,
+  onOpenFinding,
 }: {
   chain: CriticalChain;
   selected: boolean;
   onSelect: () => void;
+  onOpenFinding: () => void;
 }) {
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
       className={cn(
-        "relative w-[280px] flex-shrink-0 overflow-hidden rounded-[3px] border p-3 text-left",
-        "transition-[border-color,background-color] duration-150 ease-out",
+        "relative w-[280px] flex-shrink-0 cursor-pointer overflow-hidden rounded-[3px] border p-3 text-left outline-none",
+        "transition-[border-color,background-color] duration-150 ease-out focus-visible:border-primary/60",
         selected
           ? "border-destructive/60 bg-destructive/10"
           : "border-border bg-black/30 hover:border-mauve-7 hover:bg-white/[0.03]",
@@ -115,9 +128,22 @@ function ChainCard({
             Critical
           </span>
         </div>
-        <span className="font-mono text-[9px] tabular-nums text-muted-foreground">
-          {(chain.confidence * 100).toFixed(0)}% conf
-        </span>
+        <div className="flex items-center gap-1.5">
+          <span className="font-mono text-[9px] tabular-nums text-muted-foreground">
+            {(chain.confidence * 100).toFixed(0)}% conf
+          </span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenFinding();
+            }}
+            className="flex h-5 w-5 items-center justify-center rounded-[2px] text-muted-foreground transition-colors hover:bg-white/[0.08] hover:text-primary"
+            aria-label="Open finding detail"
+            title="Open finding detail"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </button>
+        </div>
       </div>
       <div className="mb-1.5 line-clamp-2 text-xs font-semibold text-foreground">{chain.title}</div>
       <div className="flex items-center gap-1.5 font-mono text-[10px] text-muted-foreground">
@@ -126,6 +152,6 @@ function ChainCard({
         <span className="max-w-[80px] truncate">{chain.targetName}</span>
         <span className="ml-auto text-[9px] uppercase">{chain.edgeKind.replace(/_/g, " ")}</span>
       </div>
-    </button>
+    </div>
   );
 }

--- a/server/ui/src/features/explorer/ui/EdgeDetailDrawer.tsx
+++ b/server/ui/src/features/explorer/ui/EdgeDetailDrawer.tsx
@@ -1,0 +1,244 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, X, AlertTriangle, FileSearch } from "lucide-react";
+import { useExplorerStore } from "@features/explorer/model/store";
+import { useExplorerGraph } from "@features/explorer/model/useExplorerGraph";
+import {
+  getEdgeCategory,
+  edgeLabel,
+  edgeDescription,
+  EDGE_EXPLOIT,
+} from "@entities/edge";
+import type { BundledEdge } from "@features/explorer/model/graph";
+import type { Finding } from "@entities/finding/model";
+import { getHexConfig } from "@shared/lib/hex-config";
+import { EDGE_COLORS, SEVERITY, SEVERITY_BY_KEY } from "@shared/theme/tokens";
+import { cn } from "@shared/lib/utils";
+import { useEscapeKey } from "@shared/lib/useEscapeKey";
+
+const HIDDEN_PROPS = new Set(["scan_id", "last_seen", "is_composite"]);
+
+function Endpoint({ id, name, kind }: { id: string; name: string; kind: string }) {
+  const config = getHexConfig(kind);
+  const Icon = config.icon;
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <span
+        className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-[3px] border"
+        style={{ borderColor: config.strokeColor, background: `${config.strokeColor}15` }}
+      >
+        <Icon className="h-3.5 w-3.5" style={{ color: config.strokeColor }} strokeWidth={2.25} />
+      </span>
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate text-xs font-semibold text-foreground" title={name}>
+          {name || id.slice(0, 12)}
+        </span>
+        <span
+          className="font-mono text-[9px] uppercase tracking-[0.12em]"
+          style={{ color: config.strokeColor }}
+        >
+          {config.kindTag}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function RelationshipCard({ edge }: { edge: BundledEdge }) {
+  const category = getEdgeCategory(edge.kind);
+  const color = EDGE_COLORS[category];
+  const exploit = EDGE_EXPLOIT[edge.kind];
+  const props = edge.properties ?? {};
+  const entries = Object.entries(props).filter(
+    ([k, v]) => !HIDDEN_PROPS.has(k) && v != null && v !== "",
+  );
+
+  return (
+    <div
+      className="rounded-[3px] border border-border/70 bg-black/20 p-3"
+      style={{ boxShadow: `inset 2px 0 0 0 ${color}` }}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className="rounded-[2px] border px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.06em]"
+          style={{ color, borderColor: `${color}55`, background: `${color}14` }}
+        >
+          {edgeLabel(edge.kind)}
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {edgeDescription(edge.kind)}
+        </span>
+      </div>
+
+      {exploit && (
+        <div
+          className="mt-2 rounded-[3px] bg-black/30 p-2.5"
+          style={{ boxShadow: `inset 2px 0 0 0 ${SEVERITY.critical.solid}` }}
+        >
+          <div
+            className="mb-1 flex items-center gap-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.08em]"
+            style={{ color: SEVERITY.critical.text }}
+          >
+            <AlertTriangle className="h-3 w-3" />
+            {exploit.title}
+          </div>
+          <p className="text-[11px] leading-relaxed text-foreground/80">{exploit.detail}</p>
+        </div>
+      )}
+
+      {entries.length > 0 && (
+        <div className="mt-2 grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-x-4 gap-y-1">
+          {entries.map(([key, val]) => (
+            <div key={key} className="flex items-baseline gap-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground">
+                {key.replace(/_/g, " ")}
+              </span>
+              <span className="truncate font-mono text-[10px] text-foreground" title={String(val)}>
+                {typeof val === "boolean" ? (val ? "yes" : "no") : String(val)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function EdgeDetailDrawer() {
+  const navigate = useNavigate();
+  const selectedEdge = useExplorerStore((s) => s.selectedEdge);
+  const selectEdge = useExplorerStore((s) => s.selectEdge);
+  const { data } = useExplorerGraph();
+
+  useEscapeKey(() => selectEdge(null), { enabled: !!selectedEdge });
+
+  const nodeById = useMemo(() => {
+    const m = new Map<string, { name: string; kind: string }>();
+    for (const n of data?.nodes ?? []) {
+      const name = String(
+        n.properties?.name ?? n.properties?.uri ?? n.properties?.path ?? n.id.slice(0, 12),
+      );
+      m.set(n.id, { name, kind: n.kinds[0] ?? "" });
+    }
+    return m;
+  }, [data?.nodes]);
+
+  const relatedFindings = useMemo<Finding[]>(() => {
+    if (!selectedEdge || !data) return [];
+    const kinds = new Set(selectedEdge.data.bundledKinds);
+    return data.findings.filter(
+      (f) =>
+        f.source_id === selectedEdge.source &&
+        f.target_id === selectedEdge.target &&
+        kinds.has(f.edge_kind),
+    );
+  }, [selectedEdge, data]);
+
+  if (!selectedEdge) return null;
+
+  const d = selectedEdge.data;
+  const category = getEdgeCategory(d.kind);
+  const color = EDGE_COLORS[category];
+  const src = nodeById.get(selectedEdge.source) ?? { name: selectedEdge.source, kind: d.sourceKind };
+  const tgt = nodeById.get(selectedEdge.target) ?? { name: selectedEdge.target, kind: d.targetKind };
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-auto absolute bottom-0 left-0 right-0 z-30",
+        "border-t border-border bg-card/95 shadow-[0_-8px_40px_-8px_rgba(0,0,0,0.8)] backdrop-blur-md",
+        "animate-in slide-in-from-bottom-4 fade-in duration-200",
+      )}
+      style={{ height: "40vh", minHeight: 320 }}
+      role="dialog"
+      aria-label="Edge details"
+    >
+      <div className="flex h-full flex-col">
+        <div className="relative flex items-center gap-3 border-b border-border bg-black/20 px-4 py-3">
+          <span
+            aria-hidden
+            className="pointer-events-none absolute left-0 top-0 h-px w-14"
+            style={{ background: color, opacity: 0.9 }}
+          />
+          <Endpoint id={selectedEdge.source} name={src.name} kind={src.kind} />
+          <div className="flex flex-col items-center">
+            <span
+              className="rounded-[2px] border px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase tracking-[0.06em]"
+              style={{ color, borderColor: `${color}55`, background: `${color}14` }}
+            >
+              {edgeLabel(d.kind)}
+            </span>
+            <ArrowRight className="mt-1 h-3.5 w-3.5" style={{ color }} />
+          </div>
+          <Endpoint id={selectedEdge.target} name={tgt.name} kind={tgt.kind} />
+
+          <div className="ml-3 flex items-center gap-1.5">
+            {d.isCrossProtocol && (
+              <span className="rounded-[2px] bg-purple-500/15 px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.08em] text-purple-300">
+                cross-protocol
+              </span>
+            )}
+            {d.isComposite && (
+              <span className="rounded-[2px] border border-border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.08em] text-muted-foreground">
+                composite
+              </span>
+            )}
+          </div>
+
+          <button
+            onClick={() => selectEdge(null)}
+            className="ml-auto flex h-7 w-7 items-center justify-center rounded-[3px] text-muted-foreground transition-colors hover:bg-white/[0.06] hover:text-foreground"
+            aria-label="Close edge details"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-auto px-5 py-4">
+          <div className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            {d.bundledEdges.length} relationship{d.bundledEdges.length === 1 ? "" : "s"} on this link
+          </div>
+          <div className="space-y-2">
+            {d.bundledEdges.map((be, i) => (
+              <RelationshipCard key={`${be.kind}-${i}`} edge={be} />
+            ))}
+          </div>
+
+          {relatedFindings.length > 0 && (
+            <div className="mt-4">
+              <div className="mb-2 flex items-center gap-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                <FileSearch className="h-3 w-3" />
+                {relatedFindings.length} finding{relatedFindings.length === 1 ? "" : "s"} on this edge
+              </div>
+              <div className="space-y-1">
+                {relatedFindings.map((f) => {
+                  const sev = SEVERITY_BY_KEY[f.severity] ?? SEVERITY.low;
+                  return (
+                    <button
+                      key={f.id}
+                      onClick={() => navigate(`/findings/${f.id}`)}
+                      className="flex w-full items-center gap-2 rounded-[3px] border border-border bg-black/30 px-2.5 py-2 text-left transition-colors hover:border-mauve-7 hover:bg-white/[0.03]"
+                    >
+                      <span
+                        className="h-2 w-2 flex-shrink-0 rounded-[1px]"
+                        style={{ backgroundColor: sev.solid }}
+                      />
+                      <span
+                        className="w-16 flex-shrink-0 font-mono text-[10px] font-bold uppercase tracking-[0.08em]"
+                        style={{ color: sev.solid }}
+                      >
+                        {f.severity}
+                      </span>
+                      <span className="truncate text-xs text-foreground">{f.title}</span>
+                      <ArrowRight className="ml-auto h-3 w-3 flex-shrink-0 text-primary/50" />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/ui/src/features/explorer/ui/EdgeTooltip.tsx
+++ b/server/ui/src/features/explorer/ui/EdgeTooltip.tsx
@@ -1,0 +1,106 @@
+import { useExplorerStore } from "@features/explorer/model/store";
+import { edgeLabel, edgeDescription, getEdgeCategory } from "@entities/edge";
+import { EDGE_COLORS } from "@shared/theme/tokens";
+import { cn } from "@shared/lib/utils";
+
+const TOOLTIP_WIDTH = 240;
+
+/**
+ * Floating tooltip that follows the cursor while hovering an edge. Turns an
+ * anonymous colored line into a readable relationship — kind, plain-English
+ * meaning, confidence, and the via-path the composite edge summarizes.
+ * Suppressed once the edge is selected (the edge drawer takes over).
+ */
+export function EdgeTooltip() {
+  const hovered = useExplorerStore((s) => s.hoveredEdge);
+  const selectedId = useExplorerStore((s) => s.selectedEdge?.id ?? null);
+
+  if (!hovered || hovered.id === selectedId) return null;
+
+  const d = hovered.data;
+  const category = getEdgeCategory(d.kind);
+  const color = EDGE_COLORS[category];
+
+  const props = d.properties ?? {};
+  const viaServer = props["via_server"] ? String(props["via_server"]) : "";
+  const viaTool = props["via_tool"] ? String(props["via_tool"]) : "";
+  const viaCred = props["via_credential"] ? String(props["via_credential"]) : "";
+  const hops = typeof props["hops"] === "number" ? (props["hops"] as number) : null;
+  const confidence = d.confidence || Number(props["confidence"] ?? 0);
+
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1920;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 1080;
+  const left = Math.min(hovered.x + 16, vw - TOOLTIP_WIDTH - 12);
+  const top = Math.min(hovered.y + 16, vh - 160);
+
+  return (
+    <div
+      className="pointer-events-none fixed z-[60] overflow-hidden rounded-md border border-border bg-card/95 backdrop-blur-md elev-3"
+      style={{ left, top, width: TOOLTIP_WIDTH }}
+    >
+      <span
+        aria-hidden
+        className="pointer-events-none absolute left-0 top-0 h-px w-10"
+        style={{ background: color, opacity: 0.9 }}
+      />
+      <div className="px-3 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-[1px]" style={{ background: color }} />
+          <span
+            className="font-mono text-[11px] font-bold uppercase tracking-[0.08em]"
+            style={{ color }}
+          >
+            {edgeLabel(d.kind)}
+          </span>
+          <span className="ml-auto font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+            {category}
+          </span>
+        </div>
+
+        <div className="mt-1.5 text-[11px] leading-snug text-foreground/85">
+          {edgeDescription(d.kind)}
+        </div>
+
+        {d.bundledCount > 1 && (
+          <div className="mt-1 font-mono text-[10px] text-primary/80">
+            +{d.bundledCount - 1} more relationship
+            {d.bundledCount - 1 === 1 ? "" : "s"} on this link
+          </div>
+        )}
+
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] text-muted-foreground">
+          {confidence > 0 && (
+            <span>
+              conf{" "}
+              <span className="tabular-nums text-foreground/80">
+                {Math.round(confidence * 100)}%
+              </span>
+            </span>
+          )}
+          {hops != null && (
+            <span>
+              <span className="tabular-nums text-foreground/80">{hops}</span> hops
+            </span>
+          )}
+          {d.isCrossProtocol && (
+            <span className="text-purple-300">cross-protocol</span>
+          )}
+          {d.isComposite && <span>composite</span>}
+        </div>
+
+        {(viaServer || viaTool || viaCred) && (
+          <div className="mt-1.5 truncate font-mono text-[10px] text-muted-foreground">
+            via{" "}
+            <span className="text-foreground/80">
+              {[viaServer, viaTool, viaCred].filter(Boolean).join(" / ")}
+            </span>
+          </div>
+        )}
+
+        <div className={cn("mt-2 font-mono text-[9px] uppercase tracking-[0.12em] text-primary/60")}>
+          click to inspect →
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
+++ b/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
@@ -78,6 +78,15 @@ export function ExplorerCanvas({
   reactFlowRef.current = reactFlow;
   const hasInitialLayoutRef = useRef(false);
   const prevShowOrphansRef = useRef(showOrphans);
+  // Refs (not deps) so the async layout effect can read the latest lens / focus
+  // without re-running for unrelated `built` recomputations. lastFitLensRef
+  // tracks the lens we last fit the camera to, so a re-fit fires exactly once
+  // per lens switch.
+  const activeLensRef = useRef(activeLens);
+  activeLensRef.current = activeLens;
+  const pendingFocusRef = useRef(pendingFocus);
+  pendingFocusRef.current = pendingFocus;
+  const lastFitLensRef = useRef(activeLens);
 
   const ownedNodeIds = useMarksStore((s) => s.ownedNodeIds);
   const highValueNodeIds = useMarksStore((s) => s.highValueNodeIds);
@@ -108,6 +117,7 @@ export function ExplorerCanvas({
   useEffect(() => {
     if (!built) return;
     let cancelled = false;
+    const lensAtBuild = activeLensRef.current;
     computeExplorerLayout(built.nodes, built.edges).then((positioned) => {
       if (cancelled) return;
       setNodes(positioned.nodes);
@@ -115,10 +125,26 @@ export function ExplorerCanvas({
       if (!hasInitialLayoutRef.current) {
         hasInitialLayoutRef.current = true;
         setLayoutReady(true);
+        lastFitLensRef.current = lensAtBuild;
         setTimeout(
           () => reactFlowRef.current.fitView({ padding: 0.18, duration: 400 }),
           80,
         );
+        return;
+      }
+      // A lens switch recomputes the node/edge subset and ELK positions, so the
+      // viewport would otherwise stay parked over the previous lens' (now empty
+      // or offscreen) region — reading as "nothing here". Re-fit once per lens
+      // change, after the new layout is committed. Deep-link focus drives its
+      // own targeted fit via pendingFocus, so defer to it when one is queued.
+      if (lensAtBuild !== lastFitLensRef.current) {
+        lastFitLensRef.current = lensAtBuild;
+        if (!pendingFocusRef.current) {
+          setTimeout(
+            () => reactFlowRef.current.fitView({ padding: 0.18, duration: 400 }),
+            80,
+          );
+        }
       }
     });
     return () => {

--- a/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
+++ b/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
@@ -57,6 +57,7 @@ export function ExplorerCanvas({
   const activeLens = useExplorerStore((s) => s.activeLens);
   const selectNode = useExplorerStore((s) => s.selectNode);
   const selectEdge = useExplorerStore((s) => s.selectEdge);
+  const setHoveredEdge = useExplorerStore((s) => s.setHoveredEdge);
   const openDrawer = useExplorerStore((s) => s.openDrawer);
   const clearSelection = useExplorerStore((s) => s.clearSelection);
   const setBlastRadiusSource = useExplorerStore((s) => s.setBlastRadiusSource);
@@ -65,6 +66,8 @@ export function ExplorerCanvas({
   const closeContextMenu = useExplorerStore((s) => s.closeContextMenu);
   const clearHighlight = useExplorerStore((s) => s.clearHighlight);
   const setHighlight = useExplorerStore((s) => s.setHighlight);
+  const pendingFocus = useExplorerStore((s) => s.pendingFocus);
+  const setPendingFocus = useExplorerStore((s) => s.setPendingFocus);
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge<LensEdgeData>>([]);
@@ -157,6 +160,26 @@ export function ExplorerCanvas({
     }
   }, [nodes, showOrphans, layoutReady]);
 
+  // Deep-link / programmatic focus: when an external surface (e.g. a finding's
+  // "View in Explorer") requests focus on a set of nodes, pan/zoom to them once
+  // the layout is ready, then clear the request so it fires exactly once.
+  useEffect(() => {
+    if (!layoutReady || !pendingFocus) return;
+    const ids = new Set(pendingFocus.nodeIds);
+    const present = nodes.filter((n) => ids.has(n.id));
+    if (present.length === 0) return;
+    const timer = setTimeout(() => {
+      reactFlowRef.current.fitView({
+        nodes: present.map((n) => ({ id: n.id })),
+        padding: 0.4,
+        duration: 700,
+        maxZoom: 1.2,
+      });
+      setPendingFocus(null);
+    }, 80);
+    return () => clearTimeout(timer);
+  }, [pendingFocus, nodes, layoutReady, setPendingFocus]);
+
   const onNodeClick: NodeMouseHandler = useCallback(
     (_, node) => {
       selectNode(node.id);
@@ -178,9 +201,38 @@ export function ExplorerCanvas({
 
   const onEdgeClick: EdgeMouseHandler = useCallback(
     (_, edge) => {
-      selectEdge(edge.id);
+      const d = edge.data as LensEdgeData | undefined;
+      if (!d) return;
+      selectEdge({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        data: d,
+      });
+      setHoveredEdge(null);
     },
-    [selectEdge],
+    [selectEdge, setHoveredEdge],
+  );
+
+  const onEdgeMouseMove: EdgeMouseHandler = useCallback(
+    (event, edge) => {
+      const d = edge.data as LensEdgeData | undefined;
+      if (!d || d.dim) return;
+      setHoveredEdge({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        data: d,
+        x: event.clientX,
+        y: event.clientY,
+      });
+    },
+    [setHoveredEdge],
+  );
+
+  const onEdgeMouseLeave: EdgeMouseHandler = useCallback(
+    () => setHoveredEdge(null),
+    [setHoveredEdge],
   );
 
   const onNodeContextMenu: NodeMouseHandler = useCallback(
@@ -243,6 +295,8 @@ export function ExplorerCanvas({
       onEdgesChange={onEdgesChange}
       onNodeClick={onNodeClick}
       onEdgeClick={onEdgeClick}
+      onEdgeMouseMove={onEdgeMouseMove}
+      onEdgeMouseLeave={onEdgeMouseLeave}
       onNodeContextMenu={onNodeContextMenu}
       onPaneClick={onPaneClick}
       nodeTypes={nodeTypes}

--- a/server/ui/src/features/explorer/ui/ExplorerDeepLink.tsx
+++ b/server/ui/src/features/explorer/ui/ExplorerDeepLink.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { Crosshair, ExternalLink, X } from "lucide-react";
+import { useFindingDetail } from "@entities/finding";
+import { useExplorerStore } from "@features/explorer/model/store";
+import { lensForEdgeKind } from "@features/explorer/model/lens-config";
+import { cn } from "@shared/lib/utils";
+import { SEVERITY, SEVERITY_BY_KEY } from "@shared/theme/tokens";
+
+/**
+ * Reads `?finding=<id>` from the URL and focuses the explorer on that finding's
+ * attack path — selects the framing lens, highlights the path nodes/edges, and
+ * pans the camera onto them. This is the context-carrying half of the
+ * dossier ↔ map handoff (the dossier's "View in Explorer" links here). Renders
+ * a dismissible focus banner while active. The param is preserved so the view
+ * is shareable/bookmarkable; the focus is applied once per finding id.
+ */
+export function ExplorerDeepLink() {
+  const [params, setParams] = useSearchParams();
+  const navigate = useNavigate();
+  const findingId = params.get("finding");
+
+  const { data: detail } = useFindingDetail(findingId ?? undefined);
+
+  const setActiveLens = useExplorerStore((s) => s.setActiveLens);
+  const setHighlight = useExplorerStore((s) => s.setHighlight);
+  const setPendingFocus = useExplorerStore((s) => s.setPendingFocus);
+  const clearHighlight = useExplorerStore((s) => s.clearHighlight);
+
+  const appliedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!findingId || !detail) return;
+    if (appliedRef.current === findingId) return;
+    appliedRef.current = findingId;
+
+    const f = detail.finding;
+    const path = detail.attack_path;
+    const nodeIds =
+      path && path.nodes.length > 0
+        ? path.nodes.map((n) => n.id)
+        : [f.source_id, f.target_id];
+    const edgeIds = path
+      ? path.edges.map((e) => `${e.source}|${e.target}|${e.kind}`)
+      : [];
+
+    setActiveLens(lensForEdgeKind(f.edge_kind));
+    setHighlight({ nodeIds, edgeIds, title: f.title });
+    setPendingFocus({ nodeIds, title: f.title });
+  }, [findingId, detail, setActiveLens, setHighlight, setPendingFocus]);
+
+  if (!findingId || !detail) return null;
+
+  const f = detail.finding;
+  const sev = SEVERITY_BY_KEY[f.severity] ?? SEVERITY.low;
+
+  function clear() {
+    clearHighlight();
+    appliedRef.current = null;
+    const next = new URLSearchParams(params);
+    next.delete("finding");
+    setParams(next, { replace: true });
+  }
+
+  return (
+    <div className="pointer-events-auto absolute left-1/2 top-16 z-30 -translate-x-1/2">
+      <div
+        className={cn(
+          "flex items-center gap-3 overflow-hidden rounded-md border border-border bg-card/95 px-3 py-2 backdrop-blur-md elev-2",
+        )}
+        style={{ boxShadow: `inset 2px 0 0 0 ${sev.solid}` }}
+      >
+        <span className="flex items-center gap-1.5">
+          <Crosshair className="h-3.5 w-3.5" style={{ color: sev.solid }} strokeWidth={2.25} />
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            Focused on finding
+          </span>
+        </span>
+        <span className="max-w-[320px] truncate text-xs font-medium text-foreground">
+          {f.title}
+        </span>
+        <button
+          onClick={() => navigate(`/findings/${f.id}`)}
+          className="inline-flex items-center gap-1 rounded-[3px] border border-border bg-black/30 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.06em] text-foreground/80 transition-colors hover:border-primary/50 hover:text-primary"
+        >
+          <ExternalLink className="h-3 w-3" /> Open finding
+        </button>
+        <button
+          onClick={clear}
+          className="flex h-6 w-6 items-center justify-center rounded-[3px] text-muted-foreground transition-colors hover:bg-white/[0.06] hover:text-foreground"
+          aria-label="Clear focus"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/server/ui/src/features/explorer/ui/Legend.tsx
+++ b/server/ui/src/features/explorer/ui/Legend.tsx
@@ -2,43 +2,37 @@ import { useExplorerStore } from "@features/explorer/model/store";
 import { getLens } from "@features/explorer/model/lens-config";
 import { cn } from "@shared/lib/utils";
 import { NODE_KIND_COLORS, SEVERITY, DIMMED } from "@shared/theme/tokens";
-import { EDGE_CATEGORY_COLORS } from "@entities/edge";
+import { getEdgeColor, edgeLabel, edgeDescription } from "@entities/edge";
 
-interface LegendItem {
+interface NodeKeyItem {
   color: string;
   label: string;
-  dashed?: boolean;
-  thick?: boolean;
 }
 
-// Legend palettes derive from the canonical token tables (NODE_KIND_COLORS,
-// SEVERITY, EDGE_CATEGORY_COLORS, DIMMED). Earlier this file duplicated 30+
-// hex literals which silently drifted from tokens.ts; never re-introduce
-// raw hex here — add a token first.
-
-const LEGEND_BY_LENS: Record<string, LegendItem[]> = {
+// Node color key per lens — kept compact (nodes are already labeled on the
+// canvas; this is a reference, not the primary reading aid).
+const NODE_KEY_BY_LENS: Record<string, NodeKeyItem[]> = {
   topology: [
     { color: NODE_KIND_COLORS.AgentInstance, label: "Agent" },
     { color: NODE_KIND_COLORS.MCPServer, label: "MCP Server" },
     { color: NODE_KIND_COLORS.MCPTool, label: "Tool" },
     { color: NODE_KIND_COLORS.MCPResource, label: "Resource" },
-    { color: EDGE_CATEGORY_COLORS.trust, label: "Trust edge" },
   ],
   "attack-surface": [
-    { color: SEVERITY.critical.solid, label: "Critical reach", thick: true },
-    { color: SEVERITY.high.solid, label: "High reach", thick: true },
-    { color: SEVERITY.medium.solid, label: "Medium" },
-    { color: NODE_KIND_COLORS.Identity, label: "Low" },
+    { color: NODE_KIND_COLORS.AgentInstance, label: "Agent" },
+    { color: NODE_KIND_COLORS.MCPTool, label: "Tool" },
+    { color: NODE_KIND_COLORS.MCPResource, label: "Resource" },
+    { color: NODE_KIND_COLORS.Host, label: "Host" },
   ],
   critical: [
-    { color: SEVERITY.critical.solid, label: "Critical path", thick: true },
-    { color: NODE_KIND_COLORS.A2AAgent, label: "Cross-protocol", dashed: true },
-    { color: DIMMED.deep, label: "Dimmed context" },
+    { color: NODE_KIND_COLORS.AgentInstance, label: "Agent" },
+    { color: NODE_KIND_COLORS.MCPTool, label: "Tool" },
+    { color: NODE_KIND_COLORS.MCPResource, label: "Resource" },
   ],
   "cross-protocol": [
-    { color: NODE_KIND_COLORS.A2AAgent, label: "Cross-protocol edge", dashed: true, thick: true },
-    { color: NODE_KIND_COLORS.AgentInstance, label: "A2A Agent" },
+    { color: NODE_KIND_COLORS.A2AAgent, label: "A2A Agent" },
     { color: NODE_KIND_COLORS.MCPServer, label: "MCP Server" },
+    { color: NODE_KIND_COLORS.MCPResource, label: "Resource" },
   ],
   credentials: [
     { color: NODE_KIND_COLORS.Credential, label: "Credential" },
@@ -46,33 +40,71 @@ const LEGEND_BY_LENS: Record<string, LegendItem[]> = {
     { color: NODE_KIND_COLORS.MCPServer, label: "MCP Server" },
   ],
   poisoning: [
-    { color: NODE_KIND_COLORS.InstructionFile, label: "Poisoned tool" },
-    { color: SEVERITY.high.solid, label: "Shadowing" },
-    { color: SEVERITY.critical.solid, label: "Poisoned instructions" },
+    { color: NODE_KIND_COLORS.MCPTool, label: "Tool" },
+    { color: NODE_KIND_COLORS.InstructionFile, label: "Instruction file" },
+    { color: NODE_KIND_COLORS.AgentInstance, label: "Agent" },
   ],
   "blast-radius": [
-    { color: NODE_KIND_COLORS.MCPServer, label: "Source node", thick: true },
+    { color: NODE_KIND_COLORS.MCPServer, label: "Source node" },
     { color: NODE_KIND_COLORS.Identity, label: "Reachable" },
     { color: DIMMED.deep, label: "Out of scope" },
   ],
   chokepoints: [
     { color: NODE_KIND_COLORS.AgentInstance, label: "High centrality" },
-    { color: NODE_KIND_COLORS.ResourceGroup, label: "Medium centrality" },
-    { color: DIMMED.mid, label: "Low centrality" },
+    { color: NODE_KIND_COLORS.ResourceGroup, label: "Medium" },
+    { color: DIMMED.mid, label: "Low" },
   ],
 };
 
+// Special lenses without sub-presets get a one-line edge explanation.
+const SPECIAL_EDGE_NOTE: Record<string, string> = {
+  critical: "Only edges in critical findings — colored by severity.",
+  "blast-radius": "Edges reachable from the source node.",
+  chokepoints: "All structural edges (degree sizes the nodes).",
+};
+
+const MAX_EDGE_ROWS = 7;
+
+function LineSwatch({ color, dashed }: { color: string; dashed?: boolean }) {
+  return (
+    <svg width="22" height="8" className="flex-shrink-0">
+      <line
+        x1="0"
+        y1="4"
+        x2="22"
+        y2="4"
+        stroke={color}
+        strokeWidth={2.25}
+        strokeDasharray={dashed ? "4 3" : undefined}
+      />
+    </svg>
+  );
+}
+
 export function Legend() {
   const activeLens = useExplorerStore((s) => s.activeLens);
+  const enabledPresets = useExplorerStore((s) => s.subPresets[activeLens] ?? []);
   const lens = getLens(activeLens);
-  const items = LEGEND_BY_LENS[activeLens] ?? [];
 
-  if (items.length === 0) return null;
+  const hasSub = lens.subPresets.length > 0;
+  // Reflect what's actually visible: enabled sub-presets, else the lens default.
+  const edgeKinds = hasSub
+    ? enabledPresets.length > 0
+      ? enabledPresets
+      : lens.edgeKinds
+    : lens.edgeKinds;
+
+  const nodeItems = NODE_KEY_BY_LENS[activeLens] ?? [];
+  const severityColored = lens.colorEdgesBySeverity;
+  const note = SPECIAL_EDGE_NOTE[activeLens];
+
+  const shownEdges = edgeKinds.slice(0, MAX_EDGE_ROWS);
+  const overflow = edgeKinds.length - shownEdges.length;
 
   return (
     <div
       className={cn(
-        "pointer-events-auto absolute bottom-9 left-4 z-20 overflow-hidden rounded-md",
+        "pointer-events-auto absolute bottom-9 left-4 z-20 max-h-[60vh] w-[208px] overflow-y-auto rounded-md",
         "border border-border bg-card/95 px-3 py-2.5 backdrop-blur-md elev-2",
       )}
     >
@@ -82,37 +114,96 @@ export function Legend() {
         className="pointer-events-none absolute left-0 top-0 h-px w-10"
         style={{ background: lens.activeTint, opacity: 0.9 }}
       />
-      <div className="mb-2 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-        {lens.shortLabel} legend
+
+      {/* EDGES — the relationship decoder */}
+      <div className="mb-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        {lens.shortLabel} edges
       </div>
-      <div className="space-y-1.5">
-        {items.map((item, i) => (
-          <div key={i} className="flex items-center gap-2">
-            <svg width="28" height="10" className="flex-shrink-0">
-              {item.dashed ? (
-                <line
-                  x1="0"
-                  y1="5"
-                  x2="28"
-                  y2="5"
-                  stroke={item.color}
-                  strokeWidth={item.thick ? 3 : 2}
-                  strokeDasharray="4 3"
-                />
-              ) : (
-                <line
-                  x1="0"
-                  y1="5"
-                  x2="28"
-                  y2="5"
-                  stroke={item.color}
-                  strokeWidth={item.thick ? 3 : 2}
-                />
-              )}
-            </svg>
-            <div className="font-mono text-[10px] text-foreground/80">{item.label}</div>
+
+      {severityColored && (
+        <div className="mb-2 space-y-1">
+          <div className="font-mono text-[8px] uppercase tracking-[0.1em] text-muted-foreground/70">
+            line color = severity
           </div>
-        ))}
+          {(
+            [
+              ["critical", SEVERITY.critical.solid],
+              ["high", SEVERITY.high.solid],
+              ["medium", SEVERITY.medium.solid],
+            ] as const
+          ).map(([label, color]) => (
+            <div key={label} className="flex items-center gap-2">
+              <LineSwatch color={color} />
+              <span className="font-mono text-[10px] capitalize text-foreground/80">{label}</span>
+            </div>
+          ))}
+          <div className="flex items-center gap-2">
+            <LineSwatch color={NODE_KIND_COLORS.A2AAgent} dashed />
+            <span className="font-mono text-[10px] text-foreground/80">cross-protocol</span>
+          </div>
+        </div>
+      )}
+
+      {note && (
+        <p className="mb-2 text-[10px] leading-snug text-muted-foreground">{note}</p>
+      )}
+
+      {!severityColored && shownEdges.length > 0 && (
+        <div className="mb-2 space-y-1">
+          {shownEdges.map((kind) => (
+            <div key={kind} className="flex items-center gap-2" title={edgeDescription(kind)}>
+              <LineSwatch
+                color={getEdgeColor(kind)}
+                dashed={kind === "DELEGATES_TO" || kind === "SAME_AUTH_DOMAIN"}
+              />
+              <span className="truncate font-mono text-[10px] text-foreground/80">
+                {edgeLabel(kind).toLowerCase()}
+              </span>
+            </div>
+          ))}
+          {overflow > 0 && (
+            <div className="font-mono text-[9px] text-muted-foreground/70">+{overflow} more</div>
+          )}
+        </div>
+      )}
+
+      {/* When severity-colored, still list which relationships are in scope. */}
+      {severityColored && shownEdges.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-1">
+          {shownEdges.map((kind) => (
+            <span
+              key={kind}
+              title={edgeDescription(kind)}
+              className="rounded-[2px] border border-border bg-black/30 px-1 py-0.5 font-mono text-[8px] uppercase tracking-[0.04em] text-muted-foreground"
+            >
+              {edgeLabel(kind)}
+            </span>
+          ))}
+          {overflow > 0 && (
+            <span className="font-mono text-[8px] text-muted-foreground/70">+{overflow}</span>
+          )}
+        </div>
+      )}
+
+      {/* NODES — compact color key */}
+      {nodeItems.length > 0 && (
+        <>
+          <div className="mb-1.5 mt-2 border-t border-border/60 pt-2 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            nodes
+          </div>
+          <div className="space-y-1">
+            {nodeItems.map((item) => (
+              <div key={item.label} className="flex items-center gap-2">
+                <span className="h-2 w-2 flex-shrink-0 rounded-[1px]" style={{ background: item.color }} />
+                <span className="font-mono text-[10px] text-foreground/80">{item.label}</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      <div className="mt-2 border-t border-border/60 pt-1.5 font-mono text-[8px] uppercase tracking-[0.1em] text-muted-foreground/70">
+        hover a line to read · click to inspect
       </div>
     </div>
   );

--- a/server/ui/src/features/explorer/ui/Legend.tsx
+++ b/server/ui/src/features/explorer/ui/Legend.tsx
@@ -152,10 +152,7 @@ export function Legend() {
         <div className="mb-2 space-y-1">
           {shownEdges.map((kind) => (
             <div key={kind} className="flex items-center gap-2" title={edgeDescription(kind)}>
-              <LineSwatch
-                color={getEdgeColor(kind)}
-                dashed={kind === "DELEGATES_TO" || kind === "SAME_AUTH_DOMAIN"}
-              />
+              <LineSwatch color={getEdgeColor(kind)} />
               <span className="truncate font-mono text-[10px] text-foreground/80">
                 {edgeLabel(kind).toLowerCase()}
               </span>

--- a/server/ui/src/features/explorer/ui/LensBar.tsx
+++ b/server/ui/src/features/explorer/ui/LensBar.tsx
@@ -1,9 +1,29 @@
 import { useState } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { ChevronDown, Check } from "lucide-react";
+import { ChevronDown, Check, RotateCcw } from "lucide-react";
 import { LENS_LIST, type LensDefinition } from "@features/explorer/model/lens-config";
-import { useExplorerStore, type LensId } from "@features/explorer/model/store";
+import {
+  DEFAULT_SUB_PRESETS,
+  useExplorerStore,
+  type LensId,
+} from "@features/explorer/model/store";
 import { cn } from "@shared/lib/utils";
+
+/**
+ * A lens is "filtered" when its enabled sub-presets resolve to a different set
+ * of visible edge kinds than the lens default. An empty selection is NOT
+ * filtered: the graph builder treats "none enabled" as "show the full lens set"
+ * (see build-edges.ts), so it matches the default's visible scope.
+ */
+function lensIsFiltered(lens: LensDefinition, enabled: string[]): boolean {
+  if (lens.subPresets.length === 0) return false;
+  const effective = (ids: string[]) => (ids.length === 0 ? lens.edgeKinds : ids);
+  const current = effective(enabled);
+  const base = effective(DEFAULT_SUB_PRESETS[lens.id] ?? []);
+  return (
+    current.length !== base.length || current.some((k) => !base.includes(k))
+  );
+}
 
 interface LensPillProps {
   lens: LensDefinition;
@@ -15,9 +35,11 @@ function LensPill({ lens, active, onClick }: LensPillProps) {
   const Icon = lens.icon;
   const subPresets = useExplorerStore((s) => s.subPresets[lens.id] ?? []);
   const toggleSubPreset = useExplorerStore((s) => s.toggleSubPreset);
+  const setSubPresets = useExplorerStore((s) => s.setSubPresets);
   const [open, setOpen] = useState(false);
 
   const hasSubPresets = lens.subPresets.length > 0;
+  const isFiltered = lensIsFiltered(lens, subPresets);
 
   const pillClasses = cn(
     "group relative flex items-center gap-1.5 rounded-[3px] border px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.06em]",
@@ -44,6 +66,13 @@ function LensPill({ lens, active, onClick }: LensPillProps) {
   return (
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <div className={pillClasses} style={pillStyle}>
+        {isFiltered && (
+          <span
+            aria-hidden
+            title="Filtered — sub-presets differ from default"
+            className="pointer-events-none absolute -right-1 -top-1 h-2 w-2 rounded-full bg-amber-400 ring-2 ring-card"
+          />
+        )}
         <button onClick={onClick} className="flex items-center gap-1.5">
           <Icon className="h-3.5 w-3.5" strokeWidth={2.25} />
           <span>{lens.label}</span>
@@ -112,6 +141,22 @@ function LensPill({ lens, active, onClick }: LensPillProps) {
               </DropdownMenu.Item>
             );
           })}
+          <DropdownMenu.Separator className="my-1 h-px bg-border/60" />
+          <DropdownMenu.Item
+            disabled={!isFiltered}
+            onSelect={(e) => {
+              e.preventDefault();
+              setSubPresets(lens.id, DEFAULT_SUB_PRESETS[lens.id] ?? []);
+            }}
+            className={cn(
+              "flex items-center gap-2 rounded-[3px] px-2 py-1.5 font-mono text-[11px] uppercase tracking-[0.06em] outline-none transition-colors",
+              "cursor-pointer text-muted-foreground hover:text-foreground focus:bg-white/[0.05] data-[highlighted]:bg-white/[0.05]",
+              "data-[disabled]:pointer-events-none data-[disabled]:cursor-default data-[disabled]:opacity-40",
+            )}
+          >
+            <RotateCcw className="h-3 w-3" strokeWidth={2.25} />
+            Reset to default
+          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/server/ui/src/features/explorer/ui/NodeDetailDrawer.tsx
+++ b/server/ui/src/features/explorer/ui/NodeDetailDrawer.tsx
@@ -9,10 +9,12 @@ import { PropertiesTab } from "./drawer/PropertiesTab";
 import { ConnectionsTab } from "./drawer/ConnectionsTab";
 import { EvidenceTab } from "./drawer/EvidenceTab";
 import { RemediationTab } from "./drawer/RemediationTab";
+import { FindingsTab } from "./drawer/FindingsTab";
 
 const TABS: Array<{ id: DrawerTab; label: string }> = [
   { id: "properties", label: "Properties" },
   { id: "connections", label: "Connections" },
+  { id: "findings", label: "Findings" },
   { id: "evidence", label: "Evidence" },
   { id: "remediation", label: "Remediation" },
 ];
@@ -126,6 +128,9 @@ export function NodeDetailDrawer() {
               {drawerTab === "properties" && <PropertiesTab node={node} />}
               {drawerTab === "connections" && (
                 <ConnectionsTab nodeId={selectedNodeId} edges={edges} />
+              )}
+              {drawerTab === "findings" && (
+                <FindingsTab nodeId={selectedNodeId} />
               )}
               {drawerTab === "evidence" && <EvidenceTab node={node} />}
               {drawerTab === "remediation" && (

--- a/server/ui/src/features/explorer/ui/StatusStrip.tsx
+++ b/server/ui/src/features/explorer/ui/StatusStrip.tsx
@@ -35,7 +35,7 @@ export function StatusStrip({ totals }: { totals: ExplorerTotals }) {
       </div>
       <div className="hidden items-center gap-2 sm:flex">
         <span className="text-primary/60">▸</span>
-        <span>Drag · scroll to zoom · click a node</span>
+        <span>Drag · scroll to zoom · click a node or edge</span>
       </div>
     </div>
   );

--- a/server/ui/src/features/explorer/ui/drawer/FindingsTab.tsx
+++ b/server/ui/src/features/explorer/ui/drawer/FindingsTab.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
+import { useFindings, SEVERITY_RANK } from "@entities/finding";
+import { edgeLabel } from "@entities/edge";
+import { SEVERITY, SEVERITY_BY_KEY } from "@shared/theme/tokens";
+
+/**
+ * Lists the findings that touch this node (as source or target) with a
+ * deep-link into the dossier — the node-level half of the map → findings
+ * handoff. Uses the shared findings cache, so it is free once the page has
+ * loaded.
+ */
+export function FindingsTab({ nodeId }: { nodeId: string }) {
+  const navigate = useNavigate();
+  const { data: findings, isLoading } = useFindings();
+
+  const related = useMemo(() => {
+    return (findings ?? [])
+      .filter((f) => f.source_id === nodeId || f.target_id === nodeId)
+      .sort(
+        (a, b) =>
+          (SEVERITY_RANK[a.severity] ?? 4) - (SEVERITY_RANK[b.severity] ?? 4) ||
+          b.confidence - a.confidence,
+      );
+  }, [findings, nodeId]);
+
+  if (isLoading) {
+    return (
+      <div className="font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
+        Loading findings…
+      </div>
+    );
+  }
+
+  if (related.length === 0) {
+    return (
+      <div className="font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
+        No findings reference this node.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+        {related.length} finding{related.length === 1 ? "" : "s"} on this node
+      </div>
+      {related.map((f) => {
+        const sev = SEVERITY_BY_KEY[f.severity] ?? SEVERITY.low;
+        const direction = f.source_id === nodeId ? "outbound" : "inbound";
+        return (
+          <button
+            key={f.id}
+            onClick={() => navigate(`/findings/${f.id}`)}
+            className="flex w-full items-center gap-2.5 rounded-[3px] border border-border bg-black/30 px-3 py-2 text-left transition-colors hover:border-mauve-7 hover:bg-white/[0.03]"
+          >
+            <span
+              className="h-2 w-2 flex-shrink-0 rounded-[1px]"
+              style={{ backgroundColor: sev.solid, boxShadow: `0 0 6px -1px ${sev.solid}` }}
+            />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate text-xs font-medium text-foreground">{f.title}</span>
+              <span className="truncate font-mono text-[10px] text-muted-foreground">
+                {edgeLabel(f.edge_kind)} · {direction} ·{" "}
+                {Math.round(f.confidence * 100)}% conf
+              </span>
+            </div>
+            <span
+              className="flex-shrink-0 font-mono text-[9px] font-bold uppercase tracking-[0.08em]"
+              style={{ color: sev.solid }}
+            >
+              {f.severity}
+            </span>
+            <ArrowRight className="h-3.5 w-3.5 flex-shrink-0 text-primary/50" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/server/ui/src/features/explorer/ui/edges/LensEdge.tsx
+++ b/server/ui/src/features/explorer/ui/edges/LensEdge.tsx
@@ -1,24 +1,12 @@
 import { memo, useId } from "react";
 import { BaseEdge, getBezierPath, type EdgeProps } from "@xyflow/react";
 import type { LensEdgeData } from "@features/explorer/model/graph";
-import type { SeverityLevel } from "@features/explorer/model/lens-config";
-import { SEVERITY, EDGE_COLORS, NODE_KIND_COLORS } from "@shared/theme/tokens";
-
-const SEVERITY_COLORS: Record<SeverityLevel, string> = {
-  critical: SEVERITY.critical.solid,
-  high: SEVERITY.high.solid,
-  medium: SEVERITY.medium.solid,
-  low: SEVERITY.low.solid,
-  info: SEVERITY.info.solid,
-};
-
-const NEUTRAL_COLOR: string = EDGE_COLORS.structure;
-const CROSS_PROTOCOL_COLOR: string = NODE_KIND_COLORS.A2AAgent;
+import { useExplorerStore } from "@features/explorer/model/store";
+import { edgeLabel } from "@entities/edge";
+import { EDGE_COLORS } from "@shared/theme/tokens";
 
 function edgeColor(data: LensEdgeData): string {
-  if (data.isCrossProtocol) return CROSS_PROTOCOL_COLOR;
-  if (data.severity) return SEVERITY_COLORS[data.severity];
-  return NEUTRAL_COLOR;
+  return data.color ?? EDGE_COLORS.structure;
 }
 
 function edgeStroke(data: LensEdgeData): {
@@ -43,7 +31,13 @@ function LensEdgeComponent(props: EdgeProps) {
   const d = (data ?? {}) as LensEdgeData;
   const pathId = useId();
 
-  const [path] = getBezierPath({
+  // Each edge self-identifies hover/selection from the store so only the
+  // matching edge re-renders (selector returns a boolean).
+  const isSelected = useExplorerStore((s) => s.selectedEdge?.id === props.id);
+  const isHovered = useExplorerStore((s) => s.hoveredEdge?.id === props.id);
+  const active = (isSelected || isHovered) && !d.dim;
+
+  const [path, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
     sourcePosition,
@@ -54,11 +48,28 @@ function LensEdgeComponent(props: EdgeProps) {
   });
 
   const color = edgeColor(d);
-  const { width, dashArray } = edgeStroke(d);
-  const opacity = d.dim ? 0.06 : d.showFlowDot ? 1 : 0.75;
+  const stroke = edgeStroke(d);
+  const width = active ? stroke.width + 1 : stroke.width;
+  const dashArray = stroke.dashArray;
+  const opacity = d.dim ? 0.06 : active ? 1 : d.showFlowDot ? 1 : 0.75;
+
+  const extra = d.bundledCount > 1 ? ` +${d.bundledCount - 1}` : "";
+  const labelText = (edgeLabel(d.kind) + extra).toUpperCase();
+  const labelWidth = labelText.length * 5.7 + 14;
 
   return (
     <>
+      {active && (
+        <path
+          d={path}
+          fill="none"
+          stroke={color}
+          strokeWidth={width + 4}
+          strokeLinecap="round"
+          opacity={0.2}
+          style={{ pointerEvents: "none" }}
+        />
+      )}
       <BaseEdge
         id={props.id}
         path={path}
@@ -112,18 +123,45 @@ function LensEdgeComponent(props: EdgeProps) {
           </circle>
         </>
       )}
-      {d.bundledCount > 1 && !d.dim && (
-        <text
-          x={(sourceX + targetX) / 2}
-          y={(sourceY + targetY) / 2 - 6}
-          fill={color}
-          fontSize={10}
-          fontWeight={600}
-          textAnchor="middle"
-          style={{ pointerEvents: "none", opacity }}
-        >
-          ×{d.bundledCount}
-        </text>
+      {active ? (
+        <g style={{ pointerEvents: "none" }}>
+          <rect
+            x={labelX - labelWidth / 2}
+            y={labelY - 9}
+            width={labelWidth}
+            height={17}
+            rx={3}
+            fill="#0B1220"
+            stroke={color}
+            strokeOpacity={0.55}
+          />
+          <text
+            x={labelX}
+            y={labelY + 3}
+            fill={color}
+            fontSize={9}
+            fontWeight={700}
+            textAnchor="middle"
+            style={{ letterSpacing: "0.04em" }}
+          >
+            {labelText}
+          </text>
+        </g>
+      ) : (
+        d.bundledCount > 1 &&
+        !d.dim && (
+          <text
+            x={(sourceX + targetX) / 2}
+            y={(sourceY + targetY) / 2 - 6}
+            fill={color}
+            fontSize={10}
+            fontWeight={600}
+            textAnchor="middle"
+            style={{ pointerEvents: "none", opacity }}
+          >
+            ×{d.bundledCount}
+          </text>
+        )
       )}
     </>
   );

--- a/server/ui/src/features/explorer/ui/edges/LensEdge.tsx
+++ b/server/ui/src/features/explorer/ui/edges/LensEdge.tsx
@@ -3,7 +3,7 @@ import { BaseEdge, getBezierPath, type EdgeProps } from "@xyflow/react";
 import type { LensEdgeData } from "@features/explorer/model/graph";
 import { useExplorerStore } from "@features/explorer/model/store";
 import { edgeLabel } from "@entities/edge";
-import { EDGE_COLORS } from "@shared/theme/tokens";
+import { EDGE_COLORS, EXPLORER_HEX_FILL } from "@shared/theme/tokens";
 
 function edgeColor(data: LensEdgeData): string {
   return data.color ?? EDGE_COLORS.structure;
@@ -131,7 +131,7 @@ function LensEdgeComponent(props: EdgeProps) {
             width={labelWidth}
             height={17}
             rx={3}
-            fill="#0B1220"
+            fill={EXPLORER_HEX_FILL}
             stroke={color}
             strokeOpacity={0.55}
           />

--- a/server/ui/src/features/findings/lib/copy-report.ts
+++ b/server/ui/src/features/findings/lib/copy-report.ts
@@ -1,5 +1,32 @@
 import type { Finding, AttackPath, RemediationStep } from "@entities/finding/model";
 
+/**
+ * Campaign export: a markdown summary table of multiple findings (the register
+ * selection). Path-level detail requires per-finding fetches, so this stays a
+ * summary — id, severity, relationship, endpoints, OWASP, confidence.
+ */
+export function buildFindingsTableMarkdown(findings: Finding[]): string {
+  const lines: string[] = [];
+  lines.push(`## AgentHound Findings (${findings.length})`);
+  lines.push("");
+  lines.push(
+    "| Severity | Finding | Relationship | Source → Target | OWASP | Conf |",
+  );
+  lines.push("|----------|---------|--------------|-----------------|-------|------|");
+  for (const f of findings) {
+    const src = f.source_name || f.source_id.slice(0, 12);
+    const tgt = f.target_name || f.target_id.slice(0, 12);
+    const owasp = f.owasp_map.join(", ") || "—";
+    lines.push(
+      `| ${f.severity.toUpperCase()} | ${f.title} | ${f.edge_kind} | ${src} → ${tgt} | ${owasp} | ${Math.round(
+        f.confidence * 100,
+      )}% |`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
 export function buildMarkdownReport(
   finding: Finding,
   path: AttackPath | null,

--- a/server/ui/src/features/findings/lib/edge-exploits.ts
+++ b/server/ui/src/features/findings/lib/edge-exploits.ts
@@ -1,52 +1,5 @@
-export const EDGE_EXPLOIT: Record<string, { title: string; detail: string }> = {
-  CAN_REACH: {
-    title: "Transitive reachability",
-    detail:
-      "This agent can reach the target resource through a chain of trusted servers and tools. An attacker controlling the agent can invoke this chain end-to-end without any additional privilege escalation.",
-  },
-  CAN_EXFILTRATE_VIA: {
-    title: "Exfiltration route",
-    detail:
-      "The source agent has access to sensitive data AND has a tool with outbound network capability. This combination allows silent exfiltration — the agent can read the data and send it out in a single interaction.",
-  },
-  CAN_EXECUTE: {
-    title: "Shell / code execution",
-    detail:
-      "This tool is classified as having shell_access or code_execution capability. An attacker invoking this tool through the agent gains command execution on the target host.",
-  },
-  POISONED_DESCRIPTION: {
-    title: "Tool description injection",
-    detail:
-      "This tool's description contains prompt-injection patterns. An LLM reading the tool list may follow instructions hidden in the description rather than the user's intent.",
-  },
-  POISONED_INSTRUCTIONS: {
-    title: "Instruction file poisoning",
-    detail:
-      "An instruction file loaded by the agent (AGENTS.md / CLAUDE.md / cursorrules / etc.) contains suspicious imperative overrides or hidden Unicode.",
-  },
-  SHADOWS: {
-    title: "Tool name shadowing",
-    detail:
-      "This tool's description references another server's tool by name, creating a confused-deputy risk where the LLM may call the wrong tool.",
-  },
-  CAN_IMPERSONATE: {
-    title: "Agent impersonation",
-    detail:
-      "This A2A agent's skill descriptions are >80% similar to another agent's. A downstream caller may be tricked into delegating to the wrong agent.",
-  },
-  HAS_ACCESS_TO: {
-    title: "Direct resource access",
-    detail:
-      "Based on capability surface and URI scheme match, this tool can read or write this resource.",
-  },
-  TRUSTS_SERVER: {
-    title: "Configured trust",
-    detail:
-      "This agent's config file declares trust in this MCP server. The agent will send all tool lists and invoke all listed tools without further authentication checks on the user side.",
-  },
-  DELEGATES_TO: {
-    title: "A2A delegation",
-    detail:
-      "This A2A agent delegates tasks to the target. Any capability the target has becomes transitively available to the source agent.",
-  },
-};
+// Re-export of the canonical edge-exploit map. The content now lives in
+// `@entities/edge` (semantics.ts) so the dossier hop timeline, the inspector,
+// and the explorer edge surfaces share one source of truth. Kept as a thin
+// re-export to preserve existing `../lib/edge-exploits` import sites.
+export { EDGE_EXPLOIT, type EdgeExploit } from "@entities/edge";

--- a/server/ui/src/features/findings/ui/AttackPathDiagram.tsx
+++ b/server/ui/src/features/findings/ui/AttackPathDiagram.tsx
@@ -13,6 +13,9 @@ interface AttackPathDiagramProps {
   targetId: string;
   targetName: string;
   targetKind: string;
+  /** Shared hop focus with the hop-evidence timeline (the path "spine"). */
+  activeHop?: number | null;
+  onHopSelect?: (index: number) => void;
 }
 
 export function AttackPathDiagram({
@@ -24,6 +27,8 @@ export function AttackPathDiagram({
   targetId,
   targetName,
   targetKind,
+  activeHop,
+  onHopSelect,
 }: AttackPathDiagramProps) {
   const hasPath = !!path && path.nodes.length > 0;
 
@@ -53,7 +58,16 @@ export function AttackPathDiagram({
             return (
               <div key={node.id} className="flex items-center">
                 <PathHexNode node={node} isFirst={isFirst} isLast={isLast} severity={severity} />
-                {!isLast && edgeKind && <PathEdgeArrow kind={edgeKind} />}
+                {!isLast && edgeKind && (
+                  <PathEdgeArrow
+                    kind={edgeKind}
+                    index={i}
+                    active={activeHop === i}
+                    onClick={
+                      hasPath && onHopSelect ? () => onHopSelect(i) : undefined
+                    }
+                  />
+                )}
               </div>
             );
           })}

--- a/server/ui/src/features/findings/ui/FindingDetailPage.tsx
+++ b/server/ui/src/features/findings/ui/FindingDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Skeleton } from "@shared/ui/primitives/skeleton";
 import { Stack, Sidebar } from "@shared/ui/layout";
 import { isEditableTarget } from "@shared/lib";
@@ -18,6 +18,15 @@ export function FindingDetailPage() {
   const navigate = useNavigate();
   const { data: detail, isLoading, error } = useFindingDetail(findingId);
   const { prevId, nextId } = useFindingsNavigation(findingId);
+
+  // Shared hop focus links the attack-path strip and the hop-evidence timeline
+  // into a single "spine": selecting a hop in one expands/scrolls the other.
+  const [activeHop, setActiveHop] = useState<number | null>(null);
+
+  // Reset the focused hop when navigating between findings.
+  useEffect(() => {
+    setActiveHop(null);
+  }, [findingId]);
 
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -101,6 +110,8 @@ export function FindingDetailPage() {
             targetId={f.target_id}
             targetName={f.target_name}
             targetKind={f.target_kind}
+            activeHop={activeHop}
+            onHopSelect={setActiveHop}
           />
 
           <Sidebar
@@ -114,7 +125,13 @@ export function FindingDetailPage() {
                 <FindingReferences finding={f} />
               </Stack>
             }
-            main={<HopEvidenceTimeline path={detail.attack_path} />}
+            main={
+              <HopEvidenceTimeline
+                path={detail.attack_path}
+                activeHop={activeHop}
+                onHopSelect={setActiveHop}
+              />
+            }
           />
         </Stack>
       </div>

--- a/server/ui/src/features/findings/ui/FindingHeader.tsx
+++ b/server/ui/src/features/findings/ui/FindingHeader.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { useState, type ReactNode } from "react";
 import { ArrowLeft, ArrowRight, Compass, Copy, Check } from "lucide-react";
 import { MiniHexIcon } from "./MiniHexIcon";
+import { TriageControl } from "./TriageControl";
 import { cn } from "@shared/lib/utils";
 import { SEVERITY, SEVERITY_BY_KEY } from "@shared/theme/tokens";
 import type { FindingDetail } from "@entities/finding/model";
@@ -146,8 +147,12 @@ export function FindingHeader({ detail, prevId, nextId, onCopyReport }: FindingH
           </div>
 
           {/* Actions */}
-          <div className="flex shrink-0 flex-col gap-2">
-            <button className={consoleBtn} onClick={() => navigate("/explorer")}>
+          <div className="flex shrink-0 flex-col items-end gap-2">
+            <TriageControl findingId={f.id} />
+            <button
+              className={consoleBtn}
+              onClick={() => navigate(`/explorer?finding=${f.id}`)}
+            >
               <Compass className="h-3.5 w-3.5" /> View in Explorer
             </button>
             <button className={consoleBtn} onClick={handleCopy}>

--- a/server/ui/src/features/findings/ui/FindingsListPage.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.tsx
@@ -294,10 +294,21 @@ export function FindingsListPage() {
     });
   }
 
+  // Toggle only the currently-visible rows, preserving any selection that lives
+  // outside the active filter. `selected` can retain ids that are no longer in
+  // `ordered` after a filter change, so the header state must be derived from
+  // the visible rows — never from `selected.size` alone.
   function toggleSelectAll() {
     setSelected((prev) => {
-      if (prev.size === ordered.length) return new Set();
-      return new Set(ordered.map((f) => f.id));
+      const next = new Set(prev);
+      const allVisibleSelected =
+        ordered.length > 0 && ordered.every((f) => prev.has(f.id));
+      if (allVisibleSelected) {
+        for (const f of ordered) next.delete(f.id);
+      } else {
+        for (const f of ordered) next.add(f.id);
+      }
+      return next;
     });
   }
 
@@ -321,7 +332,9 @@ export function FindingsListPage() {
     );
   }
 
-  const allSelected = ordered.length > 0 && selected.size === ordered.length;
+  const allSelected =
+    ordered.length > 0 && ordered.every((f) => selected.has(f.id));
+  const someSelected = !allSelected && ordered.some((f) => selected.has(f.id));
 
   // Renders a single finding row; `globalIndex` indexes into `ordered` so the
   // keyboard cursor and ref array line up across groups.
@@ -579,6 +592,9 @@ export function FindingsListPage() {
                     <th className="w-9 px-3 py-2">
                       <input
                         type="checkbox"
+                        ref={(el) => {
+                          if (el) el.indeterminate = someSelected;
+                        }}
                         checked={allSelected}
                         onChange={toggleSelectAll}
                         className="h-3.5 w-3.5 cursor-pointer accent-primary"

--- a/server/ui/src/features/findings/ui/FindingsListPage.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.tsx
@@ -1,66 +1,353 @@
-import { useMemo, useState, type ReactNode } from "react";
-import { useNavigate } from "react-router-dom";
-import { ArrowRight, Search, ShieldAlert } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import {
+  ArrowDown,
+  ArrowRight,
+  ArrowUp,
+  ChevronsUpDown,
+  Copy,
+  Check,
+  GitBranchPlus,
+  Search,
+  ShieldAlert,
+  X,
+} from "lucide-react";
 import { useFindings, SEVERITY_RANK } from "@entities/finding";
 import type { Finding } from "@entities/finding/model";
+import { edgeLabel } from "@entities/edge";
+import {
+  useTriageStore,
+  TRIAGE_ORDER,
+  TRIAGE_META,
+  type TriageStatus,
+} from "@shared/model/triage";
+import { buildFindingsTableMarkdown } from "../lib/copy-report";
+import { isEditableTarget } from "@shared/lib";
 import { Skeleton } from "@shared/ui/primitives/skeleton";
 import { MiniHexIcon } from "./MiniHexIcon";
+import { TriageControl } from "./TriageControl";
 import { MeterBar, WidgetCard } from "@shared/ui/widgets";
 import { cn } from "@shared/lib/utils";
-import { ACCENT, SEVERITY, SEVERITY_BY_KEY, severityColor, CHART_THEME } from "@shared/theme/tokens";
+import {
+  ACCENT,
+  SEVERITY,
+  SEVERITY_BY_KEY,
+  severityColor,
+  CHART_THEME,
+} from "@shared/theme/tokens";
 
 const SEVERITY_LEVELS = ["critical", "high", "medium", "low"] as const;
+
+type GroupBy =
+  | "none"
+  | "severity"
+  | "target"
+  | "source"
+  | "category"
+  | "owasp"
+  | "edge_kind"
+  | "triage";
+
+type SortKey = "severity" | "confidence" | "category" | "triage" | "title";
+type SortDir = "asc" | "desc";
+
+const GROUP_OPTIONS: Array<{ value: GroupBy; label: string }> = [
+  { value: "none", label: "No grouping" },
+  { value: "severity", label: "Group: Severity" },
+  { value: "target", label: "Group: Target" },
+  { value: "source", label: "Group: Source" },
+  { value: "category", label: "Group: Category" },
+  { value: "owasp", label: "Group: OWASP" },
+  { value: "edge_kind", label: "Group: Relationship" },
+  { value: "triage", label: "Group: Triage" },
+];
+
+const CONF_OPTIONS = [0, 50, 75, 90];
 
 function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
 
+const A2A = (k: string) => k.startsWith("A2A");
+const MCP = (k: string) => k.startsWith("MCP");
+function isCrossProtocol(f: Finding): boolean {
+  return (
+    (A2A(f.source_kind) && MCP(f.target_kind)) ||
+    (MCP(f.source_kind) && A2A(f.target_kind))
+  );
+}
+
+const DEFAULT_DIR: Record<SortKey, SortDir> = {
+  severity: "asc",
+  confidence: "desc",
+  category: "asc",
+  triage: "asc",
+  title: "asc",
+};
+
 export function FindingsListPage() {
   const navigate = useNavigate();
-  const [activeSeverities, setActiveSeverities] = useState<Set<string>>(new Set());
-  const [search, setSearch] = useState("");
+  const [params, setParams] = useSearchParams();
 
   const { data: findings, isLoading } = useFindings();
+  const triageMap = useTriageStore((s) => s.status);
+  const setStatus = useTriageStore((s) => s.setStatus);
 
-  function toggleSeverity(level: string) {
-    setActiveSeverities((prev) => {
-      const next = new Set(prev);
-      if (next.has(level)) next.delete(level);
-      else next.add(level);
-      return next;
-    });
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const rowRefs = useRef<Array<HTMLTableRowElement | null>>([]);
+
+  // --- filter state lives in the URL (shareable / bookmarkable) ---
+  const search = params.get("q") ?? "";
+  const activeSeverities = useMemo(
+    () => new Set((params.get("sev") ?? "").split(",").filter(Boolean)),
+    [params],
+  );
+  const activeTriage = useMemo(
+    () => new Set((params.get("triage") ?? "").split(",").filter(Boolean)),
+    [params],
+  );
+  const groupBy = (params.get("group") as GroupBy) ?? "none";
+  const xproto = params.get("xproto") === "1";
+  const minConf = Number(params.get("conf") ?? 0);
+
+  // --- ephemeral local state ---
+  const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>({
+    key: "severity",
+    dir: "asc",
+  });
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [cursor, setCursor] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  function patch(updates: Record<string, string | null>) {
+    const next = new URLSearchParams(params);
+    for (const [k, v] of Object.entries(updates)) {
+      if (v == null || v === "") next.delete(k);
+      else next.set(k, v);
+    }
+    setParams(next, { replace: true });
   }
 
+  function toggleCsv(key: string, current: Set<string>, value: string) {
+    const next = new Set(current);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    patch({ [key]: Array.from(next).join(",") });
+  }
+
+  const statusOf = (id: string): TriageStatus => triageMap[id] ?? "new";
+
   const counts = useMemo(() => {
-    const c: Record<string, number> = { critical: 0, high: 0, medium: 0, low: 0 };
-    for (const f of findings ?? []) c[f.severity] = (c[f.severity] ?? 0) + 1;
+    const c = { critical: 0, high: 0, medium: 0, low: 0, xproto: 0 };
+    for (const f of findings ?? []) {
+      if (
+        f.severity === "critical" ||
+        f.severity === "high" ||
+        f.severity === "medium" ||
+        f.severity === "low"
+      ) {
+        c[f.severity] += 1;
+      }
+      if (isCrossProtocol(f)) c.xproto += 1;
+    }
     return c;
   }, [findings]);
 
   const filtered = useMemo(() => {
     if (!findings) return [];
     const q = search.toLowerCase();
-    return findings
-      .filter((f) => {
-        if (activeSeverities.size > 0 && !activeSeverities.has(f.severity)) return false;
-        if (q) {
-          return (
-            f.title.toLowerCase().includes(q) ||
-            f.description.toLowerCase().includes(q) ||
-            f.source_name.toLowerCase().includes(q) ||
-            f.target_name.toLowerCase().includes(q)
-          );
-        }
-        return true;
-      })
-      .sort(
-        (a, b) =>
-          (SEVERITY_RANK[a.severity] ?? 4) - (SEVERITY_RANK[b.severity] ?? 4) ||
-          b.confidence - a.confidence,
+    return findings.filter((f) => {
+      if (activeSeverities.size > 0 && !activeSeverities.has(f.severity)) return false;
+      if (activeTriage.size > 0 && !activeTriage.has(statusOf(f.id))) return false;
+      if (xproto && !isCrossProtocol(f)) return false;
+      if (minConf > 0 && f.confidence * 100 < minConf) return false;
+      if (q) {
+        return (
+          f.title.toLowerCase().includes(q) ||
+          f.description.toLowerCase().includes(q) ||
+          f.source_name.toLowerCase().includes(q) ||
+          f.target_name.toLowerCase().includes(q) ||
+          f.edge_kind.toLowerCase().includes(q)
+        );
+      }
+      return true;
+    });
+  }, [findings, search, activeSeverities, activeTriage, xproto, minConf, triageMap]);
+
+  const sorted = useMemo(() => {
+    const arr = [...filtered];
+    const factor = sort.dir === "asc" ? 1 : -1;
+    arr.sort((a, b) => {
+      let r = 0;
+      switch (sort.key) {
+        case "severity":
+          r = (SEVERITY_RANK[a.severity] ?? 4) - (SEVERITY_RANK[b.severity] ?? 4);
+          break;
+        case "confidence":
+          r = a.confidence - b.confidence;
+          break;
+        case "category":
+          r = a.category.localeCompare(b.category);
+          break;
+        case "title":
+          r = a.title.localeCompare(b.title);
+          break;
+        case "triage":
+          r =
+            TRIAGE_ORDER.indexOf(statusOf(a.id)) -
+            TRIAGE_ORDER.indexOf(statusOf(b.id));
+          break;
+      }
+      if (r === 0) r = b.confidence - a.confidence;
+      return r * factor;
+    });
+    return arr;
+  }, [filtered, sort, triageMap]);
+
+  // Grouping → ordered sections + a flat ordered list for keyboard nav.
+  const { groups, ordered } = useMemo(() => {
+    if (groupBy === "none") {
+      return { groups: null as null | Array<[string, Finding[]]>, ordered: sorted };
+    }
+    const map = new Map<string, Finding[]>();
+    for (const f of sorted) {
+      const label =
+        groupBy === "severity"
+          ? f.severity
+          : groupBy === "target"
+            ? f.target_name || f.target_id.slice(0, 12)
+            : groupBy === "source"
+              ? f.source_name || f.source_id.slice(0, 12)
+              : groupBy === "category"
+                ? f.category || "—"
+                : groupBy === "owasp"
+                  ? f.owasp_map[0] ?? "—"
+                  : groupBy === "edge_kind"
+                    ? f.edge_kind
+                    : statusOf(f.id);
+      const list = map.get(label) ?? [];
+      list.push(f);
+      map.set(label, list);
+    }
+    let entries = Array.from(map.entries());
+    if (groupBy === "severity") {
+      entries = entries.sort(
+        (a, b) => (SEVERITY_RANK[a[0]] ?? 4) - (SEVERITY_RANK[b[0]] ?? 4),
       );
-  }, [findings, activeSeverities, search]);
+    } else if (groupBy === "triage") {
+      entries = entries.sort(
+        (a, b) =>
+          TRIAGE_ORDER.indexOf(a[0] as TriageStatus) -
+          TRIAGE_ORDER.indexOf(b[0] as TriageStatus),
+      );
+    }
+    return { groups: entries, ordered: entries.flatMap(([, list]) => list) };
+  }, [sorted, groupBy, triageMap]);
 
   const total = findings?.length ?? 0;
+
+  // Keep the keyboard cursor in range as the result set changes.
+  useEffect(() => {
+    setCursor((c) => Math.max(0, Math.min(c, ordered.length - 1)));
+  }, [ordered.length]);
+
+  // Keyboard navigation (j/k move, Enter open, / search, x select, Esc clear).
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "/" && !isEditableTarget(e.target)) {
+        e.preventDefault();
+        searchRef.current?.focus();
+        return;
+      }
+      if (isEditableTarget(e.target)) return;
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setCursor((c) => Math.min(c + 1, ordered.length - 1));
+      } else if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setCursor((c) => Math.max(c - 1, 0));
+      } else if (e.key === "Enter") {
+        const f = ordered[cursor];
+        if (f) navigate(`/findings/${f.id}`);
+      } else if (e.key === "x") {
+        const f = ordered[cursor];
+        if (f) toggleSelect(f.id);
+      } else if (e.key === "Escape") {
+        setSelected(new Set());
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [ordered, cursor, navigate]);
+
+  useEffect(() => {
+    rowRefs.current[cursor]?.scrollIntoView({ block: "nearest" });
+  }, [cursor]);
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleSelectAll() {
+    setSelected((prev) => {
+      if (prev.size === ordered.length) return new Set();
+      return new Set(ordered.map((f) => f.id));
+    });
+  }
+
+  function exportSelected() {
+    const chosen = ordered.filter((f) => selected.has(f.id));
+    if (chosen.length === 0) return;
+    void navigator.clipboard.writeText(buildFindingsTableMarkdown(chosen));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  function bulkSetStatus(status: TriageStatus) {
+    for (const id of selected) setStatus(id, status);
+  }
+
+  function setSortKey(key: SortKey) {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: DEFAULT_DIR[key] },
+    );
+  }
+
+  const allSelected = ordered.length > 0 && selected.size === ordered.length;
+
+  // Renders a single finding row; `globalIndex` indexes into `ordered` so the
+  // keyboard cursor and ref array line up across groups.
+  let runningIndex = -1;
+  function renderRow(f: Finding) {
+    runningIndex += 1;
+    const idx = runningIndex;
+    return (
+      <FindingRow
+        key={f.id}
+        index={idx}
+        finding={f}
+        selected={selected.has(f.id)}
+        highlighted={idx === cursor}
+        crossProtocol={isCrossProtocol(f)}
+        onToggleSelect={() => toggleSelect(f.id)}
+        onClick={() => {
+          setCursor(idx);
+          navigate(`/findings/${f.id}`);
+        }}
+        rowRef={(el) => {
+          rowRefs.current[idx] = el;
+        }}
+      />
+    );
+  }
 
   return (
     <div className="dashboard-bg min-h-full p-3 sm:p-4 lg:p-5">
@@ -106,13 +393,19 @@ export function FindingsListPage() {
                   />
                 );
               })}
+              <RegisterSeg
+                label="X-Proto"
+                value={pad2(counts.xproto)}
+                color={CHART_THEME.tooltip.text}
+                dim={counts.xproto === 0}
+              />
             </div>
             <div className="ml-auto flex items-center gap-2 self-stretch border-l border-border/70 px-3.5 py-2">
               <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
                 Showing
               </span>
               <span className="font-mono text-[11px] font-semibold tabular-nums text-primary">
-                {pad2(filtered.length)}
+                {pad2(ordered.length)}
               </span>
               <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
                 / {pad2(total)}
@@ -121,11 +414,11 @@ export function FindingsListPage() {
           </div>
         </header>
 
-        {/* ---------- Toolbar: filters + search ---------- */}
+        {/* ---------- Toolbar row 1: severity + cross-protocol + search ---------- */}
         <div className="flex flex-wrap items-center gap-2">
           <FilterChip
             active={activeSeverities.size === 0}
-            onClick={() => setActiveSeverities(new Set())}
+            onClick={() => patch({ sev: null })}
             color={ACCENT}
             label="All"
           />
@@ -133,23 +426,112 @@ export function FindingsListPage() {
             <FilterChip
               key={lvl}
               active={activeSeverities.has(lvl)}
-              onClick={() => toggleSeverity(lvl)}
+              onClick={() => toggleCsv("sev", activeSeverities, lvl)}
               color={severityColor(lvl)}
               label={SEVERITY[lvl].label}
             />
           ))}
+          <span className="mx-1 h-5 w-px bg-border/70" />
+          <button
+            onClick={() => patch({ xproto: xproto ? null : "1" })}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-[3px] border px-2.5 py-1 font-mono text-[11px] font-medium uppercase tracking-[0.08em] transition-colors",
+              xproto
+                ? "border-purple-500/60 bg-purple-500/15 text-purple-300"
+                : "border-border bg-black/30 text-muted-foreground hover:border-mauve-7 hover:text-foreground",
+            )}
+            title="Show only cross-protocol findings (A2A ↔ MCP)"
+          >
+            <GitBranchPlus className="h-3 w-3" />
+            Cross-protocol
+          </button>
 
           <div className="relative ml-auto">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <input
+              ref={searchRef}
               type="text"
-              placeholder="search findings…"
+              placeholder="search findings…  (/)"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => patch({ q: e.target.value })}
               className="h-8 w-72 rounded-[3px] border border-border bg-black/30 pl-8 pr-3 font-mono text-xs text-foreground placeholder:text-muted-foreground/70 focus-visible:border-primary/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
             />
           </div>
         </div>
+
+        {/* ---------- Toolbar row 2: triage + group + confidence ---------- */}
+        <div className="flex flex-wrap items-center gap-2">
+          <FilterChip
+            active={activeTriage.size === 0}
+            onClick={() => patch({ triage: null })}
+            color={ACCENT}
+            label="Any status"
+          />
+          {TRIAGE_ORDER.map((s) => (
+            <FilterChip
+              key={s}
+              active={activeTriage.has(s)}
+              onClick={() => toggleCsv("triage", activeTriage, s)}
+              color={TRIAGE_META[s].color}
+              label={TRIAGE_META[s].label}
+            />
+          ))}
+          <span className="mx-1 h-5 w-px bg-border/70" />
+          <select
+            value={groupBy}
+            onChange={(e) => patch({ group: e.target.value === "none" ? null : e.target.value })}
+            className="h-8 rounded-[3px] border border-border bg-black/30 px-2 font-mono text-[11px] uppercase tracking-[0.06em] text-foreground/80 focus-visible:border-primary/50 focus-visible:outline-none"
+          >
+            {GROUP_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={String(minConf)}
+            onChange={(e) => patch({ conf: e.target.value === "0" ? null : e.target.value })}
+            className="h-8 rounded-[3px] border border-border bg-black/30 px-2 font-mono text-[11px] uppercase tracking-[0.06em] text-foreground/80 focus-visible:border-primary/50 focus-visible:outline-none"
+            title="Minimum confidence"
+          >
+            {CONF_OPTIONS.map((c) => (
+              <option key={c} value={String(c)}>
+                conf ≥ {c}%
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* ---------- Selection / bulk action bar ---------- */}
+        {selected.size > 0 && (
+          <div className="flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/[0.06] px-3 py-2">
+            <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-primary">
+              {pad2(selected.size)} selected
+            </span>
+            <span className="mx-1 h-4 w-px bg-border/70" />
+            <BulkStatusMenu onPick={bulkSetStatus} />
+            <button
+              onClick={exportSelected}
+              className="inline-flex items-center gap-1.5 rounded-[3px] border border-border bg-black/30 px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.06em] text-foreground/80 transition-colors hover:border-primary/50 hover:text-primary"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-3.5 w-3.5 text-emerald-400" /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="h-3.5 w-3.5" /> Export selected
+                </>
+              )}
+            </button>
+            <button
+              onClick={() => setSelected(new Set())}
+              className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <X className="h-3 w-3" /> Clear
+            </button>
+          </div>
+        )}
 
         {/* ---------- Register table ---------- */}
         {isLoading ? (
@@ -160,7 +542,7 @@ export function FindingsListPage() {
               ))}
             </div>
           </WidgetCard>
-        ) : filtered.length === 0 ? (
+        ) : ordered.length === 0 ? (
           <WidgetCard title="Threat Register" icon={ShieldAlert}>
             <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
               <span className="flex h-12 w-12 items-center justify-center rounded-[4px] bg-primary/10 ring-1 ring-inset ring-primary/20">
@@ -186,7 +568,7 @@ export function FindingsListPage() {
             flush
             action={
               <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-                {pad2(filtered.length)} <span className="text-muted-foreground/50">/</span> {pad2(total)}
+                {pad2(ordered.length)} <span className="text-muted-foreground/50">/</span> {pad2(total)}
               </span>
             }
           >
@@ -194,24 +576,33 @@ export function FindingsListPage() {
               <table className="w-full border-collapse text-left">
                 <thead>
                   <tr className="border-b border-border bg-black/20">
+                    <th className="w-9 px-3 py-2">
+                      <input
+                        type="checkbox"
+                        checked={allSelected}
+                        onChange={toggleSelectAll}
+                        className="h-3.5 w-3.5 cursor-pointer accent-primary"
+                        aria-label="Select all"
+                      />
+                    </th>
                     <Th className="w-10 pr-2 text-right">#</Th>
-                    <Th>Severity</Th>
+                    <SortHeader label="Severity" active={sort.key === "severity"} dir={sort.dir} onClick={() => setSortKey("severity")} />
+                    <SortHeader label="Triage" active={sort.key === "triage"} dir={sort.dir} onClick={() => setSortKey("triage")} />
                     <Th>Finding</Th>
                     <Th>Flow</Th>
-                    <Th>Category</Th>
+                    <SortHeader label="Category" active={sort.key === "category"} dir={sort.dir} onClick={() => setSortKey("category")} />
                     <Th>OWASP</Th>
-                    <Th className="text-right">Confidence</Th>
+                    <SortHeader label="Confidence" active={sort.key === "confidence"} dir={sort.dir} onClick={() => setSortKey("confidence")} className="text-right" />
                   </tr>
                 </thead>
                 <tbody>
-                  {filtered.map((f, i) => (
-                    <FindingRow
-                      key={f.id}
-                      index={i}
-                      finding={f}
-                      onClick={() => navigate(`/findings/${f.id}`)}
-                    />
-                  ))}
+                  {groups
+                    ? groups.map(([label, list]) => (
+                        <GroupSection key={label} groupBy={groupBy} label={label} count={list.length}>
+                          {list.map((f) => renderRow(f))}
+                        </GroupSection>
+                      ))
+                    : ordered.map((f) => renderRow(f))}
                 </tbody>
               </table>
             </div>
@@ -299,23 +690,158 @@ function Th({ children, className }: { children: ReactNode; className?: string }
   );
 }
 
+function SortHeader({
+  label,
+  active,
+  dir,
+  onClick,
+  className,
+}: {
+  label: string;
+  active: boolean;
+  dir: SortDir;
+  onClick: () => void;
+  className?: string;
+}) {
+  return (
+    <th className={cn("px-3 py-2", className)}>
+      <button
+        onClick={onClick}
+        className={cn(
+          "inline-flex items-center gap-1 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] transition-colors",
+          active ? "text-primary" : "text-muted-foreground hover:text-foreground",
+          className?.includes("text-right") && "flex-row-reverse",
+        )}
+      >
+        {label}
+        {active ? (
+          dir === "asc" ? (
+            <ArrowUp className="h-3 w-3" />
+          ) : (
+            <ArrowDown className="h-3 w-3" />
+          )
+        ) : (
+          <ChevronsUpDown className="h-3 w-3 opacity-40" />
+        )}
+      </button>
+    </th>
+  );
+}
+
+function GroupSection({
+  groupBy,
+  label,
+  count,
+  children,
+}: {
+  groupBy: GroupBy;
+  label: string;
+  count: number;
+  children: ReactNode;
+}) {
+  const display =
+    groupBy === "triage"
+      ? TRIAGE_META[label as TriageStatus]?.label ?? label
+      : groupBy === "edge_kind"
+        ? edgeLabel(label)
+        : label;
+  const color =
+    groupBy === "severity"
+      ? severityColor(label)
+      : groupBy === "triage"
+        ? TRIAGE_META[label as TriageStatus]?.color ?? ACCENT
+        : ACCENT;
+  return (
+    <>
+      <tr className="border-b border-border/60 bg-black/30">
+        <td colSpan={9} className="px-3 py-1.5" style={{ boxShadow: `inset 2px 0 0 0 ${color}` }}>
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground/80">
+            {display}
+          </span>
+          <span className="ml-2 font-mono text-[10px] tabular-nums text-muted-foreground">
+            {count}
+          </span>
+        </td>
+      </tr>
+      {children}
+    </>
+  );
+}
+
+function BulkStatusMenu({ onPick }: { onPick: (s: TriageStatus) => void }) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button className="inline-flex items-center gap-1.5 rounded-[3px] border border-border bg-black/30 px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.06em] text-foreground/80 transition-colors hover:border-primary/50 hover:text-primary">
+          Set status
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={6}
+          className="z-50 min-w-[170px] rounded-md border border-border bg-card/95 p-1 backdrop-blur-md elev-3"
+        >
+          {TRIAGE_ORDER.map((s) => {
+            const m = TRIAGE_META[s];
+            return (
+              <DropdownMenu.Item
+                key={s}
+                onSelect={() => onPick(s)}
+                className="flex cursor-pointer items-center gap-2 rounded-[3px] px-2 py-1.5 text-xs outline-none focus:bg-white/[0.05] data-[highlighted]:bg-white/[0.05]"
+              >
+                <span className="h-2 w-2 rounded-[1px]" style={{ backgroundColor: m.color }} />
+                <span className="text-foreground/90">{m.label}</span>
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
 function FindingRow({
   index,
   finding: f,
+  selected,
+  highlighted,
+  crossProtocol,
+  onToggleSelect,
   onClick,
+  rowRef,
 }: {
   index: number;
   finding: Finding;
+  selected: boolean;
+  highlighted: boolean;
+  crossProtocol: boolean;
+  onToggleSelect: () => void;
   onClick: () => void;
+  rowRef: (el: HTMLTableRowElement | null) => void;
 }) {
   const color = (SEVERITY_BY_KEY[f.severity] ?? SEVERITY.low).solid;
   const conf = Math.round(f.confidence * 100);
 
   return (
     <tr
+      ref={rowRef}
       onClick={onClick}
-      className="cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-white/[0.03]"
+      className={cn(
+        "cursor-pointer border-b border-border/60 transition-colors last:border-0",
+        highlighted ? "bg-primary/[0.07]" : "hover:bg-white/[0.03]",
+        selected && "bg-primary/[0.05]",
+      )}
     >
+      <td className="px-3 py-3 align-middle" onClick={(e) => e.stopPropagation()}>
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={onToggleSelect}
+          className="h-3.5 w-3.5 cursor-pointer accent-primary"
+          aria-label={`Select ${f.title}`}
+        />
+      </td>
       <td
         className="px-3 py-3 text-right align-middle font-mono text-[10px] tabular-nums text-muted-foreground/60"
         style={{ boxShadow: `inset 2px 0 0 0 ${color}` }}
@@ -336,6 +862,9 @@ function FindingRow({
           </span>
         </span>
       </td>
+      <td className="px-3 py-3 align-middle">
+        <TriageControl findingId={f.id} compact />
+      </td>
       <td className="max-w-sm px-3 py-3 align-middle">
         <p className="truncate text-[13px] font-medium text-foreground">{f.title}</p>
         <p className="truncate text-xs text-muted-foreground">{f.description}</p>
@@ -343,10 +872,18 @@ function FindingRow({
       <td className="px-3 py-3 align-middle">
         <div className="flex items-center gap-1.5 font-mono text-[11px]">
           <MiniHexIcon kind={f.source_kind} />
-          <span className="max-w-[110px] truncate text-foreground/80">{f.source_name}</span>
+          <span className="max-w-[100px] truncate text-foreground/80">{f.source_name}</span>
           <ArrowRight className="h-3 w-3 shrink-0 text-primary/50" />
           <MiniHexIcon kind={f.target_kind} />
-          <span className="max-w-[110px] truncate text-foreground/80">{f.target_name}</span>
+          <span className="max-w-[100px] truncate text-foreground/80">{f.target_name}</span>
+          {crossProtocol && (
+            <span
+              className="ml-1 rounded-[2px] bg-purple-500/15 px-1 py-0.5 font-mono text-[8px] font-bold uppercase tracking-[0.06em] text-purple-300"
+              title="Cross-protocol (A2A ↔ MCP)"
+            >
+              X-PROTO
+            </span>
+          )}
         </div>
       </td>
       <td className="px-3 py-3 align-middle">

--- a/server/ui/src/features/findings/ui/HopEvidenceTimeline.tsx
+++ b/server/ui/src/features/findings/ui/HopEvidenceTimeline.tsx
@@ -1,17 +1,25 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, ListTree } from "lucide-react";
 import { WidgetCard } from "@shared/ui/widgets";
 import { Grid } from "@shared/ui/layout";
 import { getEdgeCategory } from "@entities/edge";
 import { EDGE_EXPLOIT } from "../lib/edge-exploits";
 import { EDGE_COLORS, SEVERITY } from "@shared/theme/tokens";
+import { cn } from "@shared/lib/utils";
 import type { AttackPath } from "@entities/finding/model";
 
 interface HopEvidenceTimelineProps {
   path: AttackPath | null;
+  /** Shared hop focus with the attack-path strip (the path "spine"). */
+  activeHop?: number | null;
+  onHopSelect?: (index: number) => void;
 }
 
-export function HopEvidenceTimeline({ path }: HopEvidenceTimelineProps) {
+export function HopEvidenceTimeline({
+  path,
+  activeHop,
+  onHopSelect,
+}: HopEvidenceTimelineProps) {
   const edges = path?.edges ?? [];
   const nodeMap = new Map((path?.nodes ?? []).map((n) => [n.id, n]));
 
@@ -24,6 +32,20 @@ export function HopEvidenceTimeline({ path }: HopEvidenceTimelineProps) {
     return initial;
   });
 
+  const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  // When a hop is focused from the strip, expand it and scroll it into view.
+  useEffect(() => {
+    if (activeHop == null) return;
+    setExpanded((prev) => {
+      if (prev.has(activeHop)) return prev;
+      const next = new Set(prev);
+      next.add(activeHop);
+      return next;
+    });
+    rowRefs.current[activeHop]?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [activeHop]);
+
   function toggle(index: number) {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -31,6 +53,7 @@ export function HopEvidenceTimeline({ path }: HopEvidenceTimelineProps) {
       else next.add(index);
       return next;
     });
+    onHopSelect?.(index);
   }
 
   if (edges.length === 0) {
@@ -66,10 +89,18 @@ export function HopEvidenceTimeline({ path }: HopEvidenceTimelineProps) {
           const tgtName = (tgtNode?.properties?.name as string) || edge.target.slice(0, 16);
 
           return (
-            <div key={i}>
+            <div
+              key={i}
+              ref={(el) => {
+                rowRefs.current[i] = el;
+              }}
+            >
               <button
                 onClick={() => toggle(i)}
-                className="flex w-full items-center gap-2 px-3.5 py-2.5 text-left transition-colors hover:bg-white/[0.03]"
+                className={cn(
+                  "flex w-full items-center gap-2 px-3.5 py-2.5 text-left transition-colors",
+                  activeHop === i ? "bg-white/[0.05]" : "hover:bg-white/[0.03]",
+                )}
                 style={{ boxShadow: `inset 2px 0 0 0 ${color}` }}
               >
                 {isOpen ? (

--- a/server/ui/src/features/findings/ui/PathEdgeArrow.tsx
+++ b/server/ui/src/features/findings/ui/PathEdgeArrow.tsx
@@ -2,28 +2,66 @@ import { memo } from "react";
 import { ChevronRight } from "lucide-react";
 import { getEdgeCategory } from "@entities/edge";
 import { EDGE_COLORS } from "@shared/theme/tokens";
+import { cn } from "@shared/lib/utils";
 
 interface PathEdgeArrowProps {
   kind: string;
+  /** Hop index in the path; enables click-to-focus when onClick is provided. */
+  index?: number;
+  active?: boolean;
+  onClick?: () => void;
 }
 
-function PathEdgeArrowComponent({ kind }: PathEdgeArrowProps) {
+function PathEdgeArrowComponent({ kind, active, onClick }: PathEdgeArrowProps) {
   const category = getEdgeCategory(kind);
   const color = EDGE_COLORS[category as keyof typeof EDGE_COLORS] ?? EDGE_COLORS.structure;
 
-  return (
-    <div className="flex min-w-[64px] flex-shrink-0 flex-col items-center justify-center px-1">
+  const content = (
+    <>
       <div
-        className="mb-1 whitespace-nowrap rounded-[2px] border bg-black/50 px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-[0.08em]"
-        style={{ color, borderColor: `${color}55` }}
+        className={cn(
+          "mb-1 whitespace-nowrap rounded-[2px] border px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-[0.08em] transition-colors",
+          active && "ring-1",
+        )}
+        style={{
+          color,
+          borderColor: `${color}55`,
+          backgroundColor: active ? `${color}1f` : undefined,
+        }}
       >
         {kind.replace(/_/g, " ")}
       </div>
       <div className="flex w-full items-center">
-        <div className="flex-1 border-t border-dashed" style={{ borderColor: `${color}99` }} />
+        <div
+          className="flex-1 border-t border-dashed"
+          style={{ borderColor: active ? color : `${color}99` }}
+        />
         <ChevronRight className="-ml-0.5 h-3 w-3 flex-shrink-0" style={{ color }} />
       </div>
-    </div>
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div className="flex min-w-[64px] flex-shrink-0 flex-col items-center justify-center px-1">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={`Focus hop · ${kind.replace(/_/g, " ")}`}
+      className={cn(
+        "flex min-w-[64px] flex-shrink-0 flex-col items-center justify-center rounded-[3px] px-1 py-1 outline-none transition-colors",
+        "hover:bg-white/[0.04] focus-visible:bg-white/[0.06]",
+        active && "bg-white/[0.05]",
+      )}
+    >
+      {content}
+    </button>
   );
 }
 

--- a/server/ui/src/features/findings/ui/TriageControl.tsx
+++ b/server/ui/src/features/findings/ui/TriageControl.tsx
@@ -1,0 +1,87 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  useTriageStore,
+  TRIAGE_ORDER,
+  TRIAGE_META,
+  type TriageStatus,
+} from "@shared/model/triage";
+import { cn } from "@shared/lib/utils";
+
+interface TriageControlProps {
+  findingId: string;
+  /** Compact = inline register cell; full = dossier header. */
+  compact?: boolean;
+}
+
+/**
+ * Status dropdown shared by the findings register (inline, compact) and the
+ * dossier header (full). Reads/writes the persisted triage store. Stops click
+ * propagation so it can live inside a clickable table row without triggering
+ * row navigation.
+ */
+export function TriageControl({ findingId, compact = false }: TriageControlProps) {
+  const status = useTriageStore((s) => s.status[findingId] ?? "new");
+  const setStatus = useTriageStore((s) => s.setStatus);
+  const meta = TRIAGE_META[status as TriageStatus];
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-[3px] border font-mono uppercase tracking-[0.06em] transition-colors",
+            "border-border bg-black/30 text-foreground/80 hover:border-mauve-7 hover:text-foreground",
+            compact ? "px-1.5 py-0.5 text-[9px]" : "px-2.5 py-1 text-[11px]",
+          )}
+          aria-label="Set triage status"
+        >
+          <span
+            className="h-1.5 w-1.5 flex-shrink-0 rounded-[1px]"
+            style={{ backgroundColor: meta.color, boxShadow: `0 0 6px -1px ${meta.color}` }}
+          />
+          <span style={{ color: meta.color }}>{compact ? meta.short : meta.label}</span>
+          <ChevronDown className="h-3 w-3 opacity-60" strokeWidth={2.5} />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={6}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "z-50 min-w-[180px] rounded-md border border-border bg-card/95 p-1 backdrop-blur-md elev-3",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        >
+          <div className="px-2 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+            Triage status
+          </div>
+          {TRIAGE_ORDER.map((s) => {
+            const m = TRIAGE_META[s];
+            const active = s === status;
+            return (
+              <DropdownMenu.Item
+                key={s}
+                onSelect={() => setStatus(findingId, s)}
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded-[3px] px-2 py-1.5 text-xs outline-none",
+                  "focus:bg-white/[0.05] data-[highlighted]:bg-white/[0.05]",
+                )}
+              >
+                <span
+                  className="h-2 w-2 flex-shrink-0 rounded-[1px]"
+                  style={{ backgroundColor: m.color }}
+                />
+                <span className="flex-1 text-foreground/90">{m.label}</span>
+                {active && <Check className="h-3.5 w-3.5 text-primary" strokeWidth={3} />}
+              </DropdownMenu.Item>
+            );
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/server/ui/src/features/inspector/ui/EdgeEvidence.tsx
+++ b/server/ui/src/features/inspector/ui/EdgeEvidence.tsx
@@ -6,11 +6,10 @@ import {
   Shield,
   Zap,
 } from "lucide-react";
-import { useEdges } from "@entities/edge";
+import { useEdges, getEdgeCategory, EDGE_EXPLOIT } from "@entities/edge";
 import { Badge } from "@shared/ui/primitives/badge";
 import { Skeleton } from "@shared/ui/primitives/skeleton";
 import { Switcher } from "@shared/ui/layout";
-import { getEdgeCategory } from "@entities/edge";
 import { cn } from "@shared/lib/utils";
 
 interface EdgeEvidenceProps {
@@ -22,59 +21,6 @@ function parseEdgeId(id: string): { source: string; target: string; kind: string
   if (!m || !m[1] || !m[2] || !m[3]) return null;
   return { source: m[1], target: m[2], kind: m[3] };
 }
-
-const EDGE_EXPLOIT: Record<string, { title: string; detail: string }> = {
-  CAN_REACH: {
-    title: "Transitive reachability",
-    detail:
-      "This agent can reach the target resource through a chain of trusted servers and tools. An attacker controlling the agent can invoke this chain end-to-end without any additional privilege escalation.",
-  },
-  CAN_EXFILTRATE_VIA: {
-    title: "Exfiltration route",
-    detail:
-      "The source agent has access to sensitive data AND has a tool with outbound network capability. This combination allows silent exfiltration — the agent can read the data and send it out in a single interaction.",
-  },
-  CAN_EXECUTE: {
-    title: "Shell / code execution",
-    detail:
-      "This tool is classified as having shell_access or code_execution capability. An attacker invoking this tool through the agent gains command execution on the target host.",
-  },
-  POISONED_DESCRIPTION: {
-    title: "Tool description injection",
-    detail:
-      "This tool's description contains prompt-injection patterns. An LLM reading the tool list may follow instructions hidden in the description rather than the user's intent.",
-  },
-  POISONED_INSTRUCTIONS: {
-    title: "Instruction file poisoning",
-    detail:
-      "An instruction file loaded by the agent (AGENTS.md / CLAUDE.md / cursorrules / etc.) contains suspicious imperative overrides or hidden Unicode.",
-  },
-  SHADOWS: {
-    title: "Tool name shadowing",
-    detail:
-      "This tool's description references another server's tool by name, creating a confused-deputy risk where the LLM may call the wrong tool.",
-  },
-  CAN_IMPERSONATE: {
-    title: "Agent impersonation",
-    detail:
-      "This A2A agent's skill descriptions are >80% similar to another agent's. A downstream caller may be tricked into delegating to the wrong agent.",
-  },
-  HAS_ACCESS_TO: {
-    title: "Direct resource access",
-    detail:
-      "Based on capability surface and URI scheme match, this tool can read or write this resource.",
-  },
-  TRUSTS_SERVER: {
-    title: "Configured trust",
-    detail:
-      "This agent's config file declares trust in this MCP server. The agent will send all tool lists and invoke all listed tools without further authentication checks on the user side.",
-  },
-  DELEGATES_TO: {
-    title: "A2A delegation",
-    detail:
-      "This A2A agent delegates tasks to the target. Any capability the target has becomes transitively available to the source agent.",
-  },
-};
 
 export function EdgeEvidence({ edgeId }: EdgeEvidenceProps) {
   const parsed = parseEdgeId(edgeId);

--- a/server/ui/src/shared/model/triage.ts
+++ b/server/ui/src/shared/model/triage.ts
@@ -1,0 +1,90 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { SEVERITY, ACCENT, SIGNAL_OK } from "@shared/theme/tokens";
+
+/**
+ * Finding triage workflow state (shared kernel).
+ *
+ * A red-team engagement works a register of findings over time; this slice
+ * tracks per-finding triage status + a freeform note so progress survives
+ * reloads. Lives in shared (not the findings feature) so the explorer can also
+ * read it later without a cross-feature import. Persisted under its own key.
+ *
+ * "new" is the implicit default (absence of an entry), so a fresh scan's
+ * findings all read as New without seeding the map.
+ */
+export type TriageStatus =
+  | "new"
+  | "triaging"
+  | "confirmed"
+  | "accepted-risk"
+  | "false-positive";
+
+export const TRIAGE_ORDER: TriageStatus[] = [
+  "new",
+  "triaging",
+  "confirmed",
+  "accepted-risk",
+  "false-positive",
+];
+
+export interface TriageMeta {
+  label: string;
+  short: string;
+  color: string;
+}
+
+export const TRIAGE_META: Record<TriageStatus, TriageMeta> = {
+  new: { label: "New", short: "NEW", color: "#8B92A5" },
+  triaging: { label: "Triaging", short: "TRIAGE", color: ACCENT },
+  confirmed: { label: "Confirmed", short: "CONFIRMED", color: SEVERITY.critical.solid },
+  "accepted-risk": { label: "Accepted risk", short: "ACCEPTED", color: SEVERITY.info.solid },
+  "false-positive": { label: "False positive", short: "FALSE+", color: SIGNAL_OK },
+};
+
+interface TriageState {
+  status: Record<string, TriageStatus>;
+  notes: Record<string, string>;
+}
+
+interface TriageActions {
+  setStatus: (id: string, status: TriageStatus) => void;
+  setNote: (id: string, note: string) => void;
+  getStatus: (id: string) => TriageStatus;
+  getNote: (id: string) => string;
+  reset: () => void;
+}
+
+export const useTriageStore = create<TriageState & TriageActions>()(
+  persist(
+    (set, get) => ({
+      status: {},
+      notes: {},
+
+      setStatus: (id, status) =>
+        set((state) => {
+          const next = { ...state.status };
+          if (status === "new") delete next[id];
+          else next[id] = status;
+          return { status: next };
+        }),
+
+      setNote: (id, note) =>
+        set((state) => {
+          const next = { ...state.notes };
+          if (note.trim() === "") delete next[id];
+          else next[id] = note;
+          return { notes: next };
+        }),
+
+      getStatus: (id) => get().status[id] ?? "new",
+      getNote: (id) => get().notes[id] ?? "",
+
+      reset: () => set({ status: {}, notes: {} }),
+    }),
+    {
+      name: "agenthound-triage",
+      partialize: (state) => ({ status: state.status, notes: state.notes }),
+    },
+  ),
+);

--- a/server/ui/src/shared/model/triage.ts
+++ b/server/ui/src/shared/model/triage.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { SEVERITY, ACCENT, SIGNAL_OK } from "@shared/theme/tokens";
+import { SEVERITY, ACCENT, SIGNAL_OK, TRIAGE_NEUTRAL } from "@shared/theme/tokens";
 
 /**
  * Finding triage workflow state (shared kernel).
@@ -35,7 +35,7 @@ export interface TriageMeta {
 }
 
 export const TRIAGE_META: Record<TriageStatus, TriageMeta> = {
-  new: { label: "New", short: "NEW", color: "#8B92A5" },
+  new: { label: "New", short: "NEW", color: TRIAGE_NEUTRAL },
   triaging: { label: "Triaging", short: "TRIAGE", color: ACCENT },
   confirmed: { label: "Confirmed", short: "CONFIRMED", color: SEVERITY.critical.solid },
   "accepted-risk": { label: "Accepted risk", short: "ACCEPTED", color: SEVERITY.info.solid },

--- a/server/ui/src/shared/theme/tokens.ts
+++ b/server/ui/src/shared/theme/tokens.ts
@@ -153,6 +153,7 @@ export const ACCENT = "#F5A623"; // amber phosphor — primary highlight / hero 
 export const ACCENT_BRIGHT = "#FFB020"; // hotter amber — focus / leading edge
 export const ACCENT_DIM = "#7A5A1E"; // amber, recessed — unfilled instrument ticks
 export const SIGNAL_OK = "#3FB950"; // operational / OK only
+export const TRIAGE_NEUTRAL = "#8B92A5"; // slate-gray — untouched "new" triage status
 
 // Recharts theme constants — carbon panel surfaces, amber-led series.
 export const CHART_THEME = {


### PR DESCRIPTION
## Summary

Treats the **findings register**, the **finding dossier**, and the **explorer** as one investigation surface for red teamers — *what / why / what's next* — instead of three disconnected destinations. The core fix: AgentHound's semantic edges (the moat — `CAN_REACH`, `CAN_EXECUTE`, `CAN_EXFILTRATE_VIA`, …) are now legible on the graph, and findings ↔ graph are linked bidirectionally with carried context.

### Explorer
- **Edges talk now:** hover → floating tooltip (relationship, plain-English meaning, confidence, `via` path, cross-protocol); click → new **Edge Detail drawer** explaining every bundled relationship with exploit text, properties, and **deep links to the findings on that edge**.
- Edge color resolved centrally (trust / structure / attack vs. finding severity); the **legend is now a per-lens edge decoder** that reflects enabled sub-presets (fixes the old "blue trust line that rendered slate" mismatch). Selected/hovered edges show their relationship label inline.
- Active lens + sub-presets **persist**; **deep-link focus** via `/explorer?finding=<id>` (auto-selects lens, highlights the path, fits the camera, shows a focus banner).

### Findings
- **Persisted triage state** (New / Triaging / Confirmed / Accepted-risk / False-positive) with a register column + dossier header control.
- **Register power-ups:** sortable columns, group-by (severity/target/source/category/OWASP/relationship/triage), cross-protocol filter + badge + count, confidence threshold, multi-select **campaign export**, **keyboard nav** (`j`/`k`/`Enter`/`x`/`/`), and URL-synced shareable filters.
- **Dossier path "spine":** the attack-path strip and hop-evidence timeline share an active hop (click one → the other expands/scrolls).
- **Reverse links:** Critical-lens chain cards, the edge drawer, and a new node **Findings tab** all deep-link into the dossier.

### Shared / cleanup
- Single **edge-semantics module** dedupes the two copies of `EDGE_EXPLOIT`.
- Removed stale `components/findings` + `lib/findings` duplicate trees (verified unreferenced).

No backend/Go changes; UI only.

## Test plan
- [x] `npm run build` (tsc + vite) — passes
- [x] `npm run lint` (architecture boundaries) — clean
- [x] `npm test` (vitest) — **77/77 pass**
- [ ] Findings: group-by, cross-protocol filter, column sort, set triage, multi-select → Export; `/` then `j`/`k`/`Enter`
- [ ] Dossier: click a hop in the path strip (timeline expands) → "View in Explorer" lands focused
- [ ] Explorer: hover edges (tooltip), click an edge (drawer + findings), node → Findings tab, Critical lens chain card ↗ → dossier
- [ ] Reload persists lens/sub-presets; register filter URL is shareable

Made with [Cursor](https://cursor.com)