### PR TITLE
[fix] Four validated findings: public-IP gate, langserve dispatch, looter contract, receipt read

### DIFF
--- a/collector/cli/loot.go
+++ b/collector/cli/loot.go
@@ -41,14 +41,17 @@ var lootCmd = &cobra.Command{
 	Short: "Extract latent secrets from a discovered service (read-only)",
 	Long: `Run a registered Looter against a known service endpoint.
 
-Looters are read-only by contract: they issue ONLY GET / HEAD requests.
-The action emits Credential nodes and EXPOSES_CREDENTIAL edges into the
-graph, where the cross_service_credential_chain post-processor joins
-them with Config Collector emissions to surface credential-chain
-findings.
+Looters are read-only by contract: they make no state-mutating requests.
+GET / HEAD is the norm; a few use idempotent, side-effect-free search or
+lookup POSTs that some APIs expose only via POST (e.g. MLflow runs/search,
+Ollama /api/show) — these read without changing target state, and each is
+guarded by a get_only regression test. The action emits Credential nodes
+and EXPOSES_CREDENTIAL edges into the graph, where the
+cross_service_credential_chain post-processor joins them with Config
+Collector emissions to surface credential-chain findings.
 
-v0.2 supports --type litellm against a LiteLLM gateway. Future Looters
-(Ollama, Jupyter, MLflow) land in v0.3+.
+Supported Looters include --type litellm (LiteLLM gateway), ollama,
+jupyter, and mlflow.
 
 Example:
 
@@ -219,7 +222,7 @@ func requireLootAcknowledged(stderr io.Writer, stdin io.Reader) error {
 	_, _ = fmt.Fprintln(stderr)
 	_, _ = fmt.Fprintln(stderr, "[loot] First loot invocation on this machine.")
 	_, _ = fmt.Fprintln(stderr, "[loot] Looters extract credentials from running services. They are read-only —")
-	_, _ = fmt.Fprintln(stderr, "[loot] no mutating HTTP methods — but every probe shows up in the target's audit")
+	_, _ = fmt.Fprintln(stderr, "[loot] no state-mutating HTTP methods — but every probe shows up in the target's audit")
 	_, _ = fmt.Fprintln(stderr, "[loot] log. Coordinate with the target's IR/security team out-of-band BEFORE")
 	_, _ = fmt.Fprintln(stderr, "[loot] running this against any production system. See docs/loot-litellm.md.")
 	_, _ = fmt.Fprint(stderr, "[loot] If you have authorization for this engagement, type AUTHORIZED to proceed: ")

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -573,53 +573,59 @@ func dispatchFingerprints(ctx context.Context, stderr io.Writer, targets []actio
 	for _, t := range targets {
 		host := t.Address
 		// open_ports is the authoritative per-host port list. We derive
-		// the candidate kind per port here via networkscan.PortToKind
+		// the candidate kinds per port here via networkscan.PortToKind
 		// rather than trusting candidate_kinds, which only lists ports
 		// that HAVE a kind mapping — for custom --ports with unmapped
 		// ports the two lists desync by index, which would dispatch a
 		// fingerprinter at the wrong port.
 		ports := splitCSV(t.Meta["open_ports"])
 
-		// Fingerprint each open port whose kind has a registered
-		// fingerprinter. Ports with no PortToKind mapping (custom --ports)
-		// or whose kind has no v0.2 fingerprinter (vLLM, Qdrant, MLflow,
-		// Jupyter, LangServe, OpenWebUI) silently skip.
+		// Fingerprint each open port against every candidate kind that has
+		// a registered fingerprinter. Ports with no PortToKind mapping
+		// (custom --ports) or whose kinds have no registered fingerprinter
+		// silently skip.
 		for _, portStr := range ports {
 			port, err := strconv.Atoi(portStr)
 			if err != nil {
 				continue
 			}
-			kind, ok := networkscan.PortToKind[port]
+			kinds, ok := networkscan.PortToKind[port]
 			if !ok {
 				continue
 			}
-			mod, ok := module.GetByTarget(kind, action.Fingerprint)
-			if !ok {
-				continue
+			// A port may map to multiple candidate kinds (e.g. 8000 →
+			// vLLM AND LangServe). Try each registered fingerprinter in
+			// turn; the rules are mutually exclusive so at most one matches,
+			// but we attempt all so no candidate is silently dead code.
+			for _, kind := range kinds {
+				mod, ok := module.GetByTarget(kind, action.Fingerprint)
+				if !ok {
+					continue
+				}
+				fp, ok := mod.(action.Fingerprinter)
+				if !ok {
+					continue
+				}
+				probed++
+				result, err := fp.Fingerprint(ctx, action.Target{
+					Kind:    "host",
+					Address: fmt.Sprintf("%s:%s", host, portStr),
+					Meta:    t.Meta,
+				})
+				if err != nil {
+					slog.Debug("fingerprint error", "kind", kind, "host", host, "port", portStr, "error", err)
+					continue
+				}
+				if !result.Matched || result.IngestData == nil {
+					continue
+				}
+				matched++
+				_, _ = fmt.Fprintf(stderr,
+					"[fingerprint] %s:%s → %s (version=%s, auth=%s)\n",
+					host, portStr, result.ServiceKind, result.Version, result.AuthMethod)
+				envelope.Graph.Nodes = append(envelope.Graph.Nodes, result.IngestData.Graph.Nodes...)
+				envelope.Graph.Edges = append(envelope.Graph.Edges, result.IngestData.Graph.Edges...)
 			}
-			fp, ok := mod.(action.Fingerprinter)
-			if !ok {
-				continue
-			}
-			probed++
-			result, err := fp.Fingerprint(ctx, action.Target{
-				Kind:    "host",
-				Address: fmt.Sprintf("%s:%s", host, portStr),
-				Meta:    t.Meta,
-			})
-			if err != nil {
-				slog.Debug("fingerprint error", "kind", kind, "host", host, "port", portStr, "error", err)
-				continue
-			}
-			if !result.Matched || result.IngestData == nil {
-				continue
-			}
-			matched++
-			_, _ = fmt.Fprintf(stderr,
-				"[fingerprint] %s:%s → %s (version=%s, auth=%s)\n",
-				host, portStr, result.ServiceKind, result.Version, result.AuthMethod)
-			envelope.Graph.Nodes = append(envelope.Graph.Nodes, result.IngestData.Graph.Nodes...)
-			envelope.Graph.Edges = append(envelope.Graph.Edges, result.IngestData.Graph.Edges...)
 		}
 	}
 	_, _ = fmt.Fprintf(stderr,

--- a/collector/cli/scan_fixes_test.go
+++ b/collector/cli/scan_fixes_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/adithyan-ak/agenthound/modules/networkscan"
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 	"github.com/adithyan-ak/agenthound/sdk/module"
@@ -75,6 +76,97 @@ func TestDispatchFingerprints_DerivesKindFromPort(t *testing.T) {
 	}
 	if len(envelope.Graph.Nodes) != 1 || envelope.Graph.Nodes[0].ID != "sha256:litellm-node" {
 		t.Errorf("matched node not merged into envelope: %+v", envelope.Graph.Nodes)
+	}
+}
+
+// conditionalFingerprinter is a mock that only reports Matched when its
+// shouldMatch flag is set, so a dispatch test can prove that BOTH candidate
+// kinds for a multi-kind port are probed while only the matching one emits.
+type conditionalFingerprinter struct {
+	targetKind  string
+	shouldMatch bool
+	probeCount  int
+	gotAddress  string
+	matchedNode string
+}
+
+func (m *conditionalFingerprinter) ID() string            { return "cond.fingerprint." + m.targetKind }
+func (m *conditionalFingerprinter) Action() action.Action { return action.Fingerprint }
+func (m *conditionalFingerprinter) Target() string        { return m.targetKind }
+func (m *conditionalFingerprinter) Description() string   { return "conditional mock fingerprinter" }
+func (m *conditionalFingerprinter) Version() string       { return "0.0.0" }
+func (m *conditionalFingerprinter) IsDestructive() bool   { return false }
+func (m *conditionalFingerprinter) Fingerprint(ctx context.Context, t action.Target) (*action.FingerprintResult, error) {
+	m.probeCount++
+	m.gotAddress = t.Address
+	if !m.shouldMatch {
+		return &action.FingerprintResult{Matched: false}, nil
+	}
+	return &action.FingerprintResult{
+		Matched:     true,
+		ServiceKind: m.targetKind,
+		IngestData: &ingest.IngestData{
+			Graph: ingest.GraphData{
+				Nodes: []ingest.Node{{ID: m.matchedNode, Kinds: []string{"AIService"}}},
+			},
+		},
+	}, nil
+}
+
+// TestPortToKind_8000IsMultiKind locks in that port 8000 maps to BOTH vLLM and
+// LangServe. Before the fix it was a single string "vllm", which made
+// langservefp dead code on the scan path.
+func TestPortToKind_8000IsMultiKind(t *testing.T) {
+	kinds := networkscan.PortToKind[8000]
+	want := map[string]bool{"vllm": false, "langserve": false}
+	for _, k := range kinds {
+		if _, ok := want[k]; ok {
+			want[k] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("PortToKind[8000] = %v, missing kind %q", kinds, k)
+		}
+	}
+}
+
+// TestDispatchFingerprints_TriesAllCandidateKinds is the Finding 2 regression.
+// Port 8000 maps to both "vllm" and "langserve". dispatchFingerprints must
+// probe BOTH candidate kinds, not just the first. Here vLLM does not match and
+// LangServe does, so the LangServe node must still be emitted — proving the
+// second candidate is reached.
+func TestDispatchFingerprints_TriesAllCandidateKinds(t *testing.T) {
+	vllm := &conditionalFingerprinter{targetKind: "vllm", shouldMatch: false}
+	langserve := &conditionalFingerprinter{targetKind: "langserve", shouldMatch: true, matchedNode: "sha256:langserve-node"}
+	module.Register(vllm)
+	module.Register(langserve)
+	defer deregisterModule(t, vllm.ID())
+	defer deregisterModule(t, langserve.ID())
+
+	targets := []action.Target{{
+		Kind:    "host",
+		Address: "10.0.0.9",
+		Meta: map[string]string{
+			"open_ports":      "8000",
+			"candidate_kinds": "vllm,langserve",
+		},
+	}}
+
+	envelope := &ingest.IngestData{}
+	dispatchFingerprints(context.Background(), io.Discard, targets, envelope)
+
+	if vllm.probeCount != 1 {
+		t.Errorf("vllm probed %d time(s), want exactly 1", vllm.probeCount)
+	}
+	if langserve.probeCount != 1 {
+		t.Errorf("langserve probed %d time(s), want exactly 1 (second candidate must be reached)", langserve.probeCount)
+	}
+	if vllm.gotAddress != "10.0.0.9:8000" || langserve.gotAddress != "10.0.0.9:8000" {
+		t.Errorf("dispatch addresses: vllm=%q langserve=%q, want both 10.0.0.9:8000", vllm.gotAddress, langserve.gotAddress)
+	}
+	if len(envelope.Graph.Nodes) != 1 || envelope.Graph.Nodes[0].ID != "sha256:langserve-node" {
+		t.Errorf("LangServe node not merged into envelope: %+v", envelope.Graph.Nodes)
 	}
 }
 

--- a/docs/contributing/modules.md
+++ b/docs/contributing/modules.md
@@ -9,7 +9,7 @@ Choose the interface that matches your module's purpose:
 | Interface | Action | Contract | Mutating? |
 |-----------|--------|----------|-----------|
 | `Fingerprinter` | `fingerprint` | Probe a target, identify the service kind/version/auth | No |
-| `Looter` | `loot` | Extract secrets/state via GET/HEAD only | No |
+| `Looter` | `loot` | Extract secrets/state read-only (GET/HEAD; idempotent search/lookup POSTs allowed with a `get_only` guard) | No |
 | `Extractor` | `extract` | Pull specific resources by reference (compute-heavy) | No (billing-heavy) |
 | `Poisoner` | `poison` | Inject content into upstream artifacts | **Yes** -- requires Reverter |
 | `Implanter` | `implant` | Plant persistent backdoors in target config | **Yes** -- requires Reverter |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -147,7 +147,7 @@ agenthound discover 10.0.0.0/24 --mcp --output -
 
 ### `agenthound loot`
 
-Extract latent secrets from a discovered service. Looters are **read-only by contract** (GET/HEAD only). Emits Credential nodes and EXPOSES_CREDENTIAL edges for the credential-chain post-processor.
+Extract latent secrets from a discovered service. Looters are **read-only by contract**: no state-mutating requests. GET/HEAD is the norm; a few use idempotent, side-effect-free search/lookup POSTs that some APIs expose only via POST (e.g. MLflow `runs/search`, Ollama `/api/show`), each guarded by a `get_only` regression test. Emits Credential nodes and EXPOSES_CREDENTIAL edges for the credential-chain post-processor.
 
 ```
 agenthound loot <host:port> --type <kind> [flags]

--- a/modules/instructionpoison/poisoner.go
+++ b/modules/instructionpoison/poisoner.go
@@ -33,6 +33,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -283,7 +284,12 @@ func readFileBounded(path string) (content string, hash string, existed bool, mo
 		return "", "", false, 0, fmt.Errorf("file %q too large (%d bytes; cap %d)", path, st.Size(), MaxFileBytes)
 	}
 	data := make([]byte, st.Size())
-	if _, err := f.Read(data); err != nil && err.Error() != "EOF" {
+	// io.ReadFull guarantees the buffer is fully populated; a single
+	// f.Read may under-fill it (io.Reader contract), leaving trailing
+	// zero bytes that would corrupt both the content and its SHA-256 —
+	// load-bearing for the receipt's revert integrity. An empty file
+	// (size 0) yields a nil error without reading.
+	if _, err := io.ReadFull(f, data); err != nil {
 		return "", "", false, 0, err
 	}
 	return string(data), sha256Hex(data), true, st.Mode().Perm(), nil

--- a/modules/mcpconfigimplant/implanter.go
+++ b/modules/mcpconfigimplant/implanter.go
@@ -30,6 +30,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -296,7 +297,12 @@ func readFileBounded(path string) (content string, hash string, existed bool, mo
 		return "", "", false, 0, fmt.Errorf("file %q too large (%d bytes; cap %d)", path, st.Size(), MaxFileBytes)
 	}
 	data := make([]byte, st.Size())
-	if _, err := f.Read(data); err != nil && err.Error() != "EOF" {
+	// io.ReadFull guarantees the buffer is fully populated; a single
+	// f.Read may under-fill it (io.Reader contract), leaving trailing
+	// zero bytes that would corrupt both the content and its SHA-256 —
+	// load-bearing for the receipt's revert integrity. An empty file
+	// (size 0) yields a nil error without reading.
+	if _, err := io.ReadFull(f, data); err != nil {
 		return "", "", false, 0, err
 	}
 	return string(data), sha256Hex(data), true, st.Mode().Perm(), nil

--- a/modules/mlflowloot/get_only_test.go
+++ b/modules/mlflowloot/get_only_test.go
@@ -1,0 +1,69 @@
+package mlflowloot
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestLooter_HTTPMethods enforces the Looter contract (sdk/action.Looter):
+// no state-mutating requests. GET/HEAD is the norm; the SINGLE documented
+// exception is the runs/search query, which the MLflow REST API exposes
+// only via POST (it is an idempotent, side-effect-free read — a search,
+// not a mutation). Any new POST/PUT/PATCH/DELETE/CONNECT call site must be
+// added to the allowlist below WITH a comment explaining why it is
+// read-only-in-effect, or this guard fails. PUT/PATCH/DELETE have no
+// allowlist entry and can never be justified for a Looter.
+//
+// Mirrors modules/ollamaloot/get_only_test.go.
+func TestLooter_HTTPMethods(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join(".", "looter.go"))
+	if err != nil {
+		t.Fatalf("read looter.go: %v", err)
+	}
+
+	mutating := regexp.MustCompile(`"(POST|PUT|PATCH|DELETE|CONNECT)"`)
+	matches := mutating.FindAllStringIndex(string(src), -1)
+	if matches == nil {
+		return // Pure GET path — perfect.
+	}
+
+	type allowed struct {
+		method  string
+		funcCtx string // substring of the surrounding function name
+		why     string
+	}
+	allowlist := []allowed{
+		{
+			method:  "POST",
+			funcCtx: "postJSON",
+			why:     "MLflow runs/search is exposed only via POST; it is a read query (search), no target state changes.",
+		},
+	}
+
+	for _, idx := range matches {
+		prefix := string(src[:idx[0]])
+		lastFunc := strings.LastIndex(prefix, "\nfunc ")
+		if lastFunc < 0 {
+			t.Fatalf("non-allowlisted mutating method at offset %d (no enclosing func)", idx[0])
+		}
+		funcLine := prefix[lastFunc+1:]
+		if nl := strings.Index(funcLine, "\n"); nl > 0 {
+			funcLine = funcLine[:nl]
+		}
+
+		method := string(src[idx[0]+1 : idx[1]-1])
+		var ok bool
+		for _, a := range allowlist {
+			if a.method == method && strings.Contains(funcLine, a.funcCtx) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("non-allowlisted mutating method %q in func: %s (Looter contract; see sdk/action/looter.go)", method, funcLine)
+		}
+	}
+}

--- a/modules/networkscan/expand.go
+++ b/modules/networkscan/expand.go
@@ -138,6 +138,9 @@ func expandCIDR(spec string, opts ExpandOptions) ([]string, error) {
 		if info.IsMulticast {
 			return nil, fmt.Errorf("%w: %s within %s", ErrMulticast, addr, spec)
 		}
+		if info.IsPublic && !opts.AllowPublicTargets {
+			return nil, fmt.Errorf("%w: %s within %s", ErrPublicTarget, addr, spec)
+		}
 		out = append(out, addr.String())
 		next := addr.Next()
 		if !next.IsValid() {

--- a/modules/networkscan/expand_test.go
+++ b/modules/networkscan/expand_test.go
@@ -162,6 +162,30 @@ func TestExpand_CIDR(t *testing.T) {
 			t.Errorf("err = %v, want ErrInvalidCIDR", err)
 		}
 	})
+
+	// Straddling CIDR: 192.168.0.0/15 has a private masked base (192.168.0.0)
+	// but its range spans into 192.169.0.0/16, which is public. The per-IP
+	// gate must catch the public address even though the network base passes.
+	// /15 is below the /16 cap, so AllowLargeCIDR is required to reach the
+	// per-IP enumeration (the cap check fires first otherwise).
+	t.Run("straddling CIDR refused on public address without flag", func(t *testing.T) {
+		_, err := Expand("192.168.0.0/15", ExpandOptions{AllowLargeCIDR: true})
+		if !errors.Is(err, ErrPublicTarget) {
+			t.Errorf("err = %v, want ErrPublicTarget", err)
+		}
+	})
+
+	t.Run("straddling CIDR allowed with public flag", func(t *testing.T) {
+		got, err := Expand("192.168.0.0/15", ExpandOptions{AllowLargeCIDR: true, AllowPublicTargets: true})
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		// /15 = 131072 addresses; just assert the enumeration succeeded and
+		// includes a public address from the straddling half.
+		if len(got) != 131072 {
+			t.Errorf("got %d hosts, want 131072", len(got))
+		}
+	})
 }
 
 func TestExpand_TargetsFile(t *testing.T) {

--- a/modules/networkscan/scanner.go
+++ b/modules/networkscan/scanner.go
@@ -36,18 +36,19 @@ const (
 )
 
 // PortToKind maps each AI-service default port to its candidate service-kind
-// tag. Port 8000 is shared between vLLM and LangServe; v0.2 has no fingerprinter
-// for either, so the entry is omitted (Target.Meta candidate_kinds will list
-// "vllm" via the fallback below — fingerprinters will try both rules at probe
-// time anyway). Operators can override the port set entirely via --ports.
-var PortToKind = map[int]string{
-	11434: "ollama",
-	8000:  "vllm",
-	6333:  "qdrant",
-	5000:  "mlflow",
-	4000:  "litellm",
-	8888:  "jupyter",
-	3000:  "openwebui",
+// tags. Port 8000 is shared between vLLM and LangServe, so it maps to BOTH
+// kinds; dispatch tries each registered fingerprinter in turn. The two rules
+// are mutually exclusive (vLLM matches the OpenAI list shape at /v1/models;
+// LangServe matches "LangServe" in /openapi.json), so at most one matches.
+// Operators can override the port set entirely via --ports.
+var PortToKind = map[int][]string{
+	11434: {"ollama"},
+	8000:  {"vllm", "langserve"},
+	6333:  {"qdrant"},
+	5000:  {"mlflow"},
+	4000:  {"litellm"},
+	8888:  {"jupyter"},
+	3000:  {"openwebui"},
 }
 
 // dialer is the interface tests substitute to exercise the worker pool
@@ -214,8 +215,8 @@ func hostResultToTarget(host string, openPorts, configuredPorts []int) action.Ta
 
 	var kinds []string
 	for _, p := range sortedOpen {
-		if k, ok := PortToKind[p]; ok {
-			kinds = append(kinds, k)
+		if ks, ok := PortToKind[p]; ok {
+			kinds = append(kinds, ks...)
 		}
 	}
 

--- a/sdk/action/looter.go
+++ b/sdk/action/looter.go
@@ -9,10 +9,22 @@ import (
 
 // Looter extracts latent secrets, configuration, or state from a Target
 // WITHOUT modifying it. Looters are read-only by contract: they MUST
-// only issue GET/HEAD requests; mutating methods (POST, PUT, DELETE)
-// are prohibited because they would create side-effects in the target's
-// audit trail and observable state. See docs/plans/sprint3-offensive-primitives.md
-// 4.7 for the full Reverter contract discussion.
+// NOT issue state-mutating requests. GET/HEAD is the norm; PUT, PATCH,
+// and DELETE are always prohibited because they change observable target
+// state.
+//
+// Narrow carve-out: a Looter MAY issue a POST when, and only when, the
+// target API exposes an idempotent, side-effect-free search/lookup query
+// solely via POST (e.g. MLflow's /api/2.0/mlflow/runs/search, Ollama's
+// /api/show). Such a POST reads without mutating. Every Looter that uses
+// one MUST ship a get_only_test.go regression guard that allowlists the
+// specific search/lookup call site (with a justifying comment) and fails
+// on any other non-GET method — see modules/ollamaloot/get_only_test.go
+// and modules/mlflowloot/get_only_test.go for the pattern. This keeps the
+// contract, the code, and the operator-facing CLI claims in agreement.
+//
+// See docs/plans/sprint3-offensive-primitives.md 4.7 for the full
+// Reverter contract discussion.
 //
 // Implementations also implement sdk/module.Module.
 type Looter interface {


### PR DESCRIPTION
## Summary

Fixes four findings validated as true positives against the live code (code + docs as the only source of truth; read-only `architect` agents + direct verification). No false positives — all four genuinely needed fixing. Each is an atomic commit.

| # | Finding | Severity |
|---|---|---|
| 1 | networkscan public-IP gate bypassable for straddling CIDRs | MEDIUM |
| 2 | langservefp unreachable in `scan` (dead detection capability) | MEDIUM |
| 3 | mlflowloot POST contradicted the read-only contract / CLI claims | LOW–MEDIUM |
| 4 | short-read in poison/implant receipt read path | LOW (elevated) |

## Details

### 1. Public-IP gate on straddling CIDRs (`modules/networkscan/expand.go`)
`expandCIDR`'s per-address loop re-checked `IsLinkLocal`/`IsMulticast` but dropped the `IsPublic` check the network-base preflight applies. A CIDR with a private masked base straddling into public space (e.g. `192.168.0.0/15` → `192.169.0.0/16`) enumerated public addresses with **no `--allow-public-targets` and no AUTHORIZED prompt** — `Expand`'s output is the only gate before probing. Now mirrors the preflight inside the loop. Correctly-masked private CIDRs are fully contained in one class, so it only fires for genuinely straddling specs. + straddling-CIDR tests.

### 2. langserve dispatch (`modules/networkscan/scanner.go`, `collector/cli/scan.go`)
`PortToKind` was `map[int]string` (`8000→"vllm"` only) and dispatch resolved one kind per port, so `langservefp` (registered, blank-imported, ships a rule + tests) was **dead code** — a LangServe server on 8000 emitted nothing. Promoted to `map[int][]string` (`8000 → {vllm, langserve}`) and dispatch now iterates every candidate. Rules are mutually exclusive (vLLM `/v1/models` list-shape vs LangServe `/openapi.json`) with distinct node IDs → no double-emission. + dual-dispatch tests.

### 3. Looter read-only contract (`sdk/action/looter.go`, `collector/cli/loot.go`, `modules/mlflowloot/get_only_test.go`)
`mlflowloot` POSTs to `/runs/search` (a read query MLflow exposes only via POST); `ollamaloot` already POSTs to `/api/show`. Both are read-only-in-effect, but the contract and CLI help claimed "ONLY GET / HEAD" / "no mutating HTTP methods" — a false statement operators rely on for authorization. Documented the narrow carve-out (idempotent, side-effect-free search/lookup POSTs, each guarded by a `get_only` test; PUT/PATCH/DELETE still always prohibited), added the missing `mlflowloot` regression guard (mirrors `ollamaloot`'s source-scan allowlist), and corrected the CLI help + docs.

### 4. Short-read in receipt read path (`modules/instructionpoison/poisoner.go`, `modules/mcpconfigimplant/implanter.go`)
`readFileBounded` did a single `f.Read(data)`, ignored `n`, and compared `err.Error() != "EOF"`. A short read (per the `io.Reader` contract) would leave trailing zero bytes corrupting both the read-modify-write content and the receipt's `PreSHA256` — load-bearing for safe revert. Replaced with `io.ReadFull`.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — zero errors
- `go vet ./...` — zero warnings
- `go test ./... -race` — all pass
- `golangci-lint run` (v2.11.4, matches CI) — **0 issues**

New tests fail against the unfixed code (oracle-verified) and pass with the fixes.
