### PR TITLE
fix(cli): correct discover long-help default probe ports

### DIFF
--- a/collector/cli/discover.go
+++ b/collector/cli/discover.go
@@ -34,8 +34,9 @@ MCP servers (JSON-RPC initialize) and A2A agents (well-known agent-card).
 
 Unlike 'agenthound scan', which sweeps a fixed AI-service port set and
 fingerprints each open port, 'agenthound discover' issues protocol-specific
-HTTP probes against likely web ports (3000/8080/8443 for MCP, 80/443 for A2A)
-and emits :MCPServer and :A2AAgent nodes for each positive match.
+HTTP probes against likely web ports (3000/8000/8080/8443 for MCP,
+80/443/3000/8080 for A2A) and emits :MCPServer and :A2AAgent nodes for each
+positive match.
 
 Example:
 

--- a/collector/cli/discover_test.go
+++ b/collector/cli/discover_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/modules/protoscan"
+)
+
+// joinPorts renders a port slice in the "/"-separated form used in the
+// discover long-help prose (e.g. {3000,8000} -> "3000/8000").
+func joinPorts(ports []int) string {
+	parts := make([]string, len(ports))
+	for i, p := range ports {
+		parts[i] = strconv.Itoa(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// TestDiscoverLongHelpMatchesDefaultPorts guards the discover long-help
+// prose against drift from the actual default probe port sets. Before the
+// fix the prose listed only "3000/8080/8443" for MCP and "80/443" for A2A,
+// omitting 8000 (MCP) and 3000/8080 (A2A) that protoscan.DefaultMCPPorts /
+// DefaultA2APorts actually probe. Deriving the expected strings from the
+// constants keeps this test correct if the defaults ever change.
+func TestDiscoverLongHelpMatchesDefaultPorts(t *testing.T) {
+	mcp := joinPorts(protoscan.DefaultMCPPorts)
+	a2a := joinPorts(protoscan.DefaultA2APorts)
+
+	if !strings.Contains(discoverCmd.Long, mcp) {
+		t.Errorf("discover long help missing MCP default ports %q\nLong:\n%s", mcp, discoverCmd.Long)
+	}
+	if !strings.Contains(discoverCmd.Long, a2a) {
+		t.Errorf("discover long help missing A2A default ports %q\nLong:\n%s", a2a, discoverCmd.Long)
+	}
+}


### PR DESCRIPTION
## Summary

Independent validation of two reported collector CLI issues. Only one was a true positive; this PR fixes it.

### Issue 2 (TRUE POSITIVE — fixed here)
`discover` long help understated the default probe ports:
- prose said MCP `3000/8080/8443`, A2A `80/443`
- actual defaults (`protoscan.DefaultMCPPorts` / `DefaultA2APorts`, and the per-flag `--mcp-ports`/`--a2a-ports` help) are MCP `3000,8000,8080,8443` and A2A `80,443,3000,8080`

The prose is corrected to `3000/8000/8080/8443` (MCP) and `80/443/3000/8080` (A2A). A regression test (`TestDiscoverLongHelpMatchesDefaultPorts`) derives the expected strings directly from the `protoscan` constants, so the help can't silently drift from the defaults again. Verified the test fails on the pre-fix prose and passes after.

### Issue 1 (NOT a true positive — no change)
Claim: per-module flags (`--include-weights`, `--weights-dir`, `--servers-key`, `--update-method`, `--confidence-threshold`, `--file`) are registered during `collector/cli` package init before the blank-imported modules register, so Cobra rejects them.

This does not reproduce on the built binary. Go guarantees every blank-imported module's `init()` runs before `main()`, and `GODEBUG=inittrace=1` on the real binary shows every Looter/Poisoner/Implanter/Extractor module initializes *before* `collector/cli`. So `module.ListByAction(...)` sees a fully populated registry. Confirmed three ways: the flags appear in `--help`, they parse and dispatch (no "unknown flag"), and the init trace orders modules ahead of `collector/cli`. No fix made.

## Test plan
- [x] `go test ./collector/cli/ -race` — pass
- [x] `go test ./collector/... ./modules/... ./sdk/...` — pass
- [x] `gofmt -l collector/cli/` — clean
- [x] `go vet ./collector/...` — clean
- [x] `go build ./...` — clean
- [x] Regression test fails on pre-fix prose, passes after fix

Made with [Cursor](https://cursor.com)