### PR TITLE
feat: persisted findings + triage/diff (T0) and moat detectors (T1)

### DIFF
--- a/.claude/rules/graph-schema.md
+++ b/.claude/rules/graph-schema.md
@@ -7,7 +7,7 @@ paths:
 # Graph Schema Rules
 
 - 23 collector-produced node kinds + 2 synthetic (ResourceGroup, TrustZone) = 25 in AllNodeLabels
-- 17 raw edge kinds + 8 composite = 25 in AllowedEdgeKinds
+- 18 raw edge kinds + 12 composite = 30 in AllowedEdgeKinds
 - AIService is an UmbrellaLabel — skip uniqueness constraint in schema-init
 - All properties stored as snake_case. Normalizer converts camelCase from collector JSON.
 - Edge structs carry: Source, Target, Kind, SourceKind, TargetKind, Properties

--- a/.claude/rules/server.md
+++ b/.claude/rules/server.md
@@ -12,5 +12,5 @@ paths:
 - APOC fallback: all APOC-dependent code needs non-APOC fallbacks. APOC only required for Dijkstra.
 - Batch writes: group by (primaryLabel, sortedUmbrellaLabels) tuple. 1000 ops/txn with UNWIND.
 - go:embed constraint: server/ui/dist must be copied to server/internal/api/ui/dist before build.
-- 18 pre-built queries in server/internal/analysis/prebuilt/
-- 11 post-processors in server/internal/analysis/processors/ — execution order is dependency-driven
+- 19 pre-built queries in server/internal/analysis/prebuilt/
+- 15 post-processors in server/internal/analysis/processors/ — execution order is dependency-driven

--- a/docs/architecture/post-processors.md
+++ b/docs/architecture/post-processors.md
@@ -22,17 +22,21 @@ can_impersonate
 
 | # | Processor | Dependencies |
 |---|-----------|--------------|
-| 1 | has_access_to | none |
-| 2 | can_execute | none |
-| 3 | shadows | none |
-| 4 | poisoned_description | none |
-| 5 | poisoned_instructions | none |
-| 6 | can_reach | has_access_to |
-| 7 | cross_service_credential_chain | has_access_to, can_reach |
-| 8 | can_exfiltrate | can_reach |
-| 9 | can_impersonate | none |
-| 10 | cross_protocol | has_access_to |
-| 11 | risk_score | all of 1-10 |
+| 1 | auth_strength | none (pre-pass) |
+| 2 | has_access_to | none |
+| 3 | can_execute | none |
+| 4 | shadows (+ POISONS_CONTEXT) | none |
+| 5 | poisoned_description | none |
+| 6 | poisoned_instructions | none |
+| 7 | taints | none (reads INGESTS_UNTRUSTED + schema_keys) |
+| 8 | can_reach | has_access_to |
+| 9 | cross_service_credential_chain | has_access_to, can_reach |
+| 10 | ifc_violation | has_access_to (reads INGESTS_UNTRUSTED) |
+| 11 | can_exfiltrate | can_reach |
+| 12 | can_impersonate | none |
+| 13 | confused_deputy | auth_strength, can_reach |
+| 14 | cross_protocol | has_access_to |
+| 15 | risk_score | all of 1-14 |
 
 ## Processor Interface
 
@@ -45,6 +49,19 @@ type PostProcessor interface {
 ```
 
 `ProcessingStats` returns: `ProcessorName`, `EdgesCreated`, `NodesUpdated`, `Duration`, `Error`.
+
+> The Execution Order table above is the canonical sequence. The numbered
+> section headings below predate later additions; new processors
+> (`auth_strength`, `taints`, `ifc_violation`, `confused_deputy`) and the
+> `POISONS_CONTEXT` pass are documented under their own headings.
+
+---
+
+## auth_strength (pre-pass)
+
+**Computes:** `auth_strength` numeric property on every node with an `auth_method` (`MCPServer`, `A2AAgent`).
+
+A pre-pass with no dependencies that materializes the runtime weakness score map (`riskscore.AuthStrengthScores`: none=100, apiKey=70, bearer=50, oauth=25, mtls=10) onto nodes as a Cypher `CASE`, so downstream processors (notably `confused_deputy`) can compare auth gradients directly in Cypher. It writes only node properties — no composite edges — so it needs no `source_collector` and is untouched by stale-edge cleanup.
 
 ---
 
@@ -86,6 +103,8 @@ Pattern requires `s1 <> s2` and `t1 <> t2`. The match is intentionally target-sp
 
 Confidence scales with injection patterns: 0.9 when `has_injection_patterns=true`, 0.6 otherwise. Risk weight: 0.4.
 
+**POISONS_CONTEXT (second pass):** the shadows processor runs a second Cypher pass that emits `MCPTool -[POISONS_CONTEXT]-> MCPTool` when the source has `has_injection_patterns=true` and the sink carries a high-blast capability (`shell_access`, `code_execution`, `credential_access`, `email_send`). This deliberately widens the narrow SHADOWS guard (no description-naming requirement) to model context poisoning, but caps fan-out at **20 sinks per source** to prevent a cartesian blow-up. `scripts/perf-check.sh` enforces a ≤200 poisoned-pair-per-agent ceiling (10 source tools × 20 sinks). Confidence: 0.6, risk_weight: 0.4, `source_collector='mcp'`.
+
 ## 4. poisoned_description
 
 **Computes:** `MCPTool -[POISONED_DESCRIPTION]-> MCPTool` (self-loop)
@@ -101,6 +120,12 @@ Confidence: 1.0, risk_weight: 0.8. Self-loop edge -- the finding is about the to
 Flags instruction files marked `is_suspicious=true` by the Config Collector (imperative overrides, exfiltration commands, hidden Unicode).
 
 Confidence: 1.0, risk_weight: 0.7, source_collector: `config`.
+
+## taints
+
+**Computes:** `MCPTool -[TAINTS]-> MCPTool` (cross-server)
+
+Emits a `TAINTS` edge when a tool that ingests untrusted input (it has an `INGESTS_UNTRUSTED` edge, or `source_trust='private'`) shares **≥2 input-schema keys** with a tool on another server. The schema overlap is computed in pure Cypher against the `schema_keys` node property (emitted collector-side — no APOC dependency). The ≥2 threshold avoids matching every `{type, name}` pair. No processor dependencies (reads raw `INGESTS_UNTRUSTED` edges + node properties), but registered before `can_reach` so its edges can influence the reachability walk. Confidence: 0.7, risk_weight: 0.3, `source_collector='mcp'`.
 
 ## 6. can_reach
 
@@ -136,7 +161,17 @@ LiteLLMGateway -[EXPOSES_CREDENTIAL]-> Credential(c2, type IN [apiKey, virtual_k
 
 Emits: `(AgentInstance)-[:CAN_REACH]->(c2)` with evidence including `merge_value_hash`, `via_gateway`, `upstream_provider`. Confidence: 0.95, hops: 5.
 
+The same single query also computes **credential blast radius**: `count(DISTINCT agent)` reaching the merged secret, written as `blast_radius` on both `c1` (the env-var credential) and `c1master` (its value_hash twin). The agents are collected for the count and re-UNWOUND so the CAN_REACH MERGE stays one edge per (agent, upstream-credential). `blast_radius` then amplifies the server credential-handling risk term (see risk-scoring.md).
+
 The `value_hash` is the cross-collector merge primitive -- same secret value regardless of how each collector derives its objectid.
+
+## ifc_violation
+
+**Computes:** `MCPTool -[IFC_VIOLATION]-> MCPTool`
+
+Emits an information-flow-control violation edge when an untrusted-input tool (`INGESTS_UNTRUSTED -> MCPResource`) shares a resource within **3 `HAS_ACCESS_TO` hops** with a sink tool carrying a high-impact capability (`credential_access`, `file_write`, `email_send`). The 1..3 hop cap is the false-positive / performance guard. Depends on `has_access_to`. Confidence: 0.6, risk_weight: 0.3, `source_collector='mcp'`.
+
+> **Cleanup semantics:** `IFC_VIOLATION` carries `source_collector='mcp'`, so it is only swept by stale-edge cleanup when the `mcp` collector re-runs. If an operator runs only `a2a` / `config` scans afterward, IFC edges from a prior `mcp` scan persist (the underlying tools were not re-enumerated). This is acceptable.
 
 ## 8. can_exfiltrate
 
@@ -144,9 +179,9 @@ The `value_hash` is the cross-collector merge primitive -- same secret value reg
 
 Requires both conditions:
 1. Agent CAN_REACH a resource with sensitivity `critical` or `high`
-2. Agent trusts a server with a tool having `email_send`, `network_outbound`, or `file_write` capability
+2. Agent trusts a server with a tool having an outbound capability: `email_send`, `network_outbound`, `file_write`, `auto_fetch_render`, or `allowlisted_proxy`
 
-Pattern ensures the agent has both the data access AND an outbound channel. Confidence: 0.8.
+Pattern ensures the agent has both the data access AND an outbound channel. The `auto_fetch_render` / `allowlisted_proxy` classes broaden the set of covert exfiltration channels (see detection-rules.md for the `auto_fetch_render` host-side caveat). Confidence: 0.8.
 
 ## 9. can_impersonate
 
@@ -176,6 +211,12 @@ WHERE ext.auth_method IS NULL OR ext.auth_method = 'none'
 ```
 
 Requires the external A2A agent has no authentication. The pivot point is host co-location: an A2A agent that delegates to another agent running on the same host as an MCP server. Edge properties include `cross_protocol=true`. Confidence: 0.5.
+
+## confused_deputy
+
+**Computes:** `A2AAgent -[CONFUSED_DEPUTY]-> A2AAgent`
+
+Flags a confused-deputy escalation: a weakly-authenticated agent (`auth_strength >= 80`, i.e. none/apiKey-class) that `DELEGATES_TO` a strongly-authenticated one (`auth_strength <= 30`, i.e. oauth/mtls-class). The low-trust caller effectively borrows the callee's privileges. Depends on the `auth_strength` pre-pass and `can_reach` (ordering). `source_collector='a2a'` — a real collector, so it participates in stale-edge cleanup directly. Confidence: 0.8, risk_weight: 0.3.
 
 ## 11. risk_score
 
@@ -223,3 +264,15 @@ DELETE r
 ```
 
 This prevents stale findings from accumulating while preserving composite edges from other collectors. An MCP-only re-scan deletes old MCP composite edges but leaves A2A and credential-chain edges untouched; a config or network re-scan also cleans credential-chain edges because those findings depend on the refreshed credential inputs.
+
+### INGESTS_UNTRUSTED raw-edge accumulation
+
+`INGESTS_UNTRUSTED` is a **raw** edge (`is_composite=false`), so it is *not* swept by `cleanStaleCompositeEdges` (which gates on `is_composite=true`). It is MERGE-keyed on (source, target), so re-scans rewrite `scan_id` for tools that stay around. The trade-off: a renamed or removed tool whose `INGESTS_UNTRUSTED` edge was emitted in a prior scan will linger, because the old (tool, resource) key is never re-MERGEd. Mitigation is to gate emission on stable, rule-derived `source_trust` (which does not flap for the same tool). A dedicated raw-edge sweeper is intentionally out of scope; if false-positive linger becomes load-bearing, the fix is a separate processor that DELETEs `INGESTS_UNTRUSTED` edges whose source tool no longer carries `source_trust`.
+
+---
+
+## Findings Snapshot Stage (pipeline)
+
+After post-processing completes and before the scan-completion record is written, the ingest pipeline persists a **findings snapshot** to Postgres (`appdb.FindingStore.InsertFindings`). Sequencing matters: `cleanStaleCompositeEdges` runs first, so the Neo4j graph already reflects only the current scan's composite-edge set when the snapshot is taken.
+
+This snapshot is the diffable record of "what was found when". The Neo4j graph itself is **not** diffable across scans — the stale-edge cleanup deletes prior-scan composite edges — so every triage (`/findings/triage`) and diff (`query --diff`) read comes from the Postgres snapshot, which is invariant under the next scan's cleanup. The snapshot write is non-fatal: a Postgres hiccup logs a warning but does not fail the ingest.

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -55,8 +55,10 @@ attacker-chosen ingest data. To shut that drive-by path:
   subsequent restarts (idempotent).
 - All mutating HTTP routes require
   `Authorization: Bearer <token>`. Specifically: `POST /ingest`,
-  `POST /query`, `POST /scans`, `DELETE /scans/{id}`, and the three
-  `POST /analysis/*-path` endpoints.
+  `POST /query`, `POST /scans`, `DELETE /scans/{id}`, the three
+  `POST /analysis/*-path` endpoints, and
+  `PUT /findings/triage/{fingerprint}`. The triage *read*
+  (`GET /findings/triage/{fingerprint}`) stays open like other reads.
 - Read endpoints (graph reads, findings, prebuilt queries, rules,
   health, docs) stay open. Localhost-only reads on a single-user box
   are fine; gating them would force the UI to plumb auth through
@@ -76,6 +78,17 @@ To revoke the token (e.g. you suspect another user on the box read
 the file), delete `~/.agenthound/server.token` and restart the
 server. The next startup generates a fresh token; any open UI tab
 will need a refresh to re-fetch.
+
+### Triage state retention
+
+Triage decisions written via `PUT /findings/triage/{fingerprint}` live
+in the Postgres `finding_triage` table, keyed by the finding fingerprint.
+This table has **no foreign key** to the per-scan `findings` snapshot: an
+analyst's `accepted-risk` / `false-positive` decisions deliberately
+survive scan deletion and re-detection, so deleting a scan (or re-running
+a collector) does not silently re-surface a finding that was already
+adjudicated. Operators who want a clean slate must clear `finding_triage`
+explicitly.
 
 ## Collector network behaviour
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -29,6 +29,7 @@ If you need to expose the server beyond loopback, do so at the network layer (VP
 - `POST /api/v1/analysis/shortest-path`
 - `POST /api/v1/analysis/all-paths`
 - `POST /api/v1/analysis/weighted-path`
+- `PUT /api/v1/findings/triage/{fingerprint}`
 
 A request to any of these without the header returns `401 Unauthorized`.
 
@@ -217,19 +218,39 @@ Same request format as shortest-path. Response includes `"algorithm": "dijkstra"
 
 ### `GET /api/v1/analysis/findings`
 
-List all composite edges as security findings.
+List findings from the latest persisted snapshot (one row per fingerprint), each with inline `triage` state. Reads from the Postgres snapshot, not live graph edges, so results are stable across the next scan's stale-edge cleanup.
 
 | Param | Type | Description |
 |-------|------|-------------|
 | `severity` | string | Filter: `critical`, `high`, `medium`, `low` |
+| `include_suppressed` | bool | Default `false`. When `true`, include findings triaged `accepted-risk` / `false-positive` (hidden otherwise). |
 
 ### `GET /api/v1/analysis/findings/{id}`
 
 Return evidence detail for a specific finding.
 
+### `GET /api/v1/findings/triage/{fingerprint}`
+
+Return the cross-scan triage decision for a finding fingerprint (16-char hex). Open read; a fingerprint with no recorded decision returns the implicit `new` state.
+
+```json
+{ "status": "accepted-risk", "note": "Approved by sec-review", "updated_at": "2026-06-19T12:00:00Z" }
+```
+
+### `PUT /api/v1/findings/triage/{fingerprint}` *(token required)*
+
+Record (or update) the triage decision for a finding fingerprint. Triage state has no foreign key to findings, so it survives scan deletion and re-detection.
+
+```json
+// Request
+{ "status": "accepted-risk", "note": "Approved by sec-review" }
+```
+
+`status` must be one of `new`, `triaging`, `confirmed`, `accepted-risk`, `false-positive`.
+
 ### `GET /api/v1/analysis/prebuilt`
 
-List all 18 pre-built queries with metadata.
+List all 19 pre-built queries with metadata.
 
 ### `GET /api/v1/analysis/prebuilt/{id}`
 
@@ -305,7 +326,7 @@ Delete a scan after deleting the nodes and edges that scan owned from Neo4j. If 
 
 ### `GET /api/v1/rules`
 
-List all 30 active YAML detection rules from `sdk/rules/builtin/`.
+List all 35 active YAML detection rules from `sdk/rules/builtin/`.
 
 ### `GET /api/v1/rules/{id}`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -452,7 +452,7 @@ ssh target 'agenthound scan --output -' | agenthound-server ingest -
 
 ### `agenthound-server query`
 
-Query the graph database. Four mutually exclusive modes.
+Query the graph database. Five mutually exclusive modes.
 
 ```bash
 # Raw Cypher
@@ -461,8 +461,11 @@ agenthound-server query "MATCH (n:MCPServer) RETURN n.name, n.transport"
 # Pre-built query
 agenthound-server query --prebuilt agents-shell-access
 
-# Findings (composite edges as security findings)
-agenthound-server query --findings [--severity critical]
+# Findings (from the persisted snapshot, with triage state)
+agenthound-server query --findings [--severity critical] [--all-findings]
+
+# Diff two scans' findings
+agenthound-server query --diff scan_a,scan_b
 
 # Shortest path
 agenthound-server query --shortest-path --from AgentInstance:claude --to MCPResource:postgres://prod
@@ -473,13 +476,19 @@ agenthound-server query --shortest-path --from AgentInstance:claude --to MCPReso
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--prebuilt` | | Pre-built query ID. |
-| `--findings` | `false` | List all findings. |
+| `--findings` | `false` | List findings from the latest persisted snapshot (suppressed hidden by default). |
+| `--all-findings` | `false` | Include suppressed (`accepted-risk` / `false-positive`) findings in `--findings` / `--diff` output. |
+| `--diff` | | Diff two scans' findings: `scanA,scanB`. Reports added / removed / unchanged. |
 | `--severity` | | Filter findings: `critical`, `high`, `medium`, `low`. |
 | `--shortest-path` | `false` | Find shortest path between two nodes. |
 | `--from` | | Source node (`Kind:name`). |
 | `--to` | | Target node (`Kind:name`). |
 | `--format` | `table` | `table` or `json`. |
-| `--fail-on` | | Exit 1 if findings at or above severity (CI gate). |
+| `--fail-on` | | Exit 1 if findings at or above severity (CI gate). Always ignores suppressed findings, even with `--all-findings`. |
+
+#### Suppression semantics
+
+Triage decisions (`accepted-risk`, `false-positive`) suppress a finding from the default `--findings` view and from the `added` set of `--diff`. `--all-findings` reveals them. `--fail-on` *always* evaluates against the non-suppressed set, so an accepted risk can never break CI regardless of `--all-findings`.
 
 #### Pre-Built Query IDs
 
@@ -496,6 +505,7 @@ agenthound-server query --shortest-path --from AgentInstance:claude --to MCPReso
 | `tool-shadowing` | Vulnerabilities | high |
 | `no-auth-servers` | Vulnerabilities | high |
 | `no-auth-a2a` | Vulnerabilities | high |
+| `tool-name-collision` | Vulnerabilities | high |
 | `rug-pull` | Vulnerabilities | high |
 | `instruction-poisoning` | Supply Chain | high |
 | `high-entropy-secrets` | Supply Chain | high |

--- a/docs/reference/detection-rules.md
+++ b/docs/reference/detection-rules.md
@@ -8,12 +8,12 @@ AgentHound surfaces findings through two complementary layers:
 
 | Layer | Where it runs | Count | Storage |
 |---|---|---|---|
-| **YAML rules engine** | Inside collectors at scan time. Drives capability classification, credential extraction, prompt-injection pattern matching, instruction-file poisoning, and resource-sensitivity classification. | **30 builtin rules** | `sdk/rules/builtin/*.yaml`. Inspect with `agenthound rules list`; test with `agenthound rules test`; query the running server via `GET /api/v1/rules`. |
-| **Pre-built graph queries** | Inside `agenthound-server` against the post-processed Neo4j graph. Each query expresses a high-level finding as a Cypher path or pattern. | **18 queries** | `server/internal/analysis/prebuilt/`. Surface as findings via `GET /api/v1/analysis/findings`, runnable via `GET /api/v1/analysis/prebuilt/{id}` or `agenthound-server query --prebuilt <id>`. |
+| **YAML rules engine** | Inside collectors at scan time. Drives capability classification, credential extraction, prompt-injection pattern matching, instruction-file poisoning, source-trust tagging, and resource-sensitivity classification. | **35 builtin rules** | `sdk/rules/builtin/*.yaml`. Inspect with `agenthound rules list`; test with `agenthound rules test`; query the running server via `GET /api/v1/rules`. |
+| **Pre-built graph queries** | Inside `agenthound-server` against the post-processed Neo4j graph. Each query expresses a high-level finding as a Cypher path or pattern. | **19 queries** | `server/internal/analysis/prebuilt/`. Surface as findings via `GET /api/v1/analysis/findings`, runnable via `GET /api/v1/analysis/prebuilt/{id}` or `agenthound-server query --prebuilt <id>`. |
 
-The two layers feed each other: the rules engine emits structured signals (`capability_surface`, `is_exposed`, `has_injection_patterns`, sensitivity classifications) on collected nodes; the post-processors and pre-built queries consume those signals to compute composite edges (`HAS_ACCESS_TO`, `CAN_REACH`, `POISONED_DESCRIPTION`, etc.) and enumerate attack paths.
+The two layers feed each other: the rules engine emits structured signals (`capability_surface`, `is_exposed`, `has_injection_patterns`, `source_trust`, sensitivity classifications) on collected nodes; the post-processors and pre-built queries consume those signals to compute composite edges (`HAS_ACCESS_TO`, `CAN_REACH`, `POISONED_DESCRIPTION`, `TAINTS`, `IFC_VIOLATION`, `CONFUSED_DEPUTY`, `POISONS_CONTEXT`, etc.) and enumerate attack paths.
 
-The 18 detections summarized below are the **pre-built-query** layer. The 30 underlying YAML rules are not enumerated here individually — read them directly in `sdk/rules/builtin/` for the canonical truth.
+The detections summarized below are the **pre-built-query** layer. The 35 underlying YAML rules are not enumerated here individually — read them directly in `sdk/rules/builtin/` for the canonical truth. Composite-edge detections (`TAINTS`, `IFC_VIOLATION`, `CONFUSED_DEPUTY`, `POISONS_CONTEXT`) surface through `GET /api/v1/analysis/findings` rather than a named pre-built query.
 
 ## Detection summary
 
@@ -21,6 +21,7 @@ The 18 detections summarized below are the **pre-built-query** layer. The 30 und
 |-----------|----------|-----------------|---------------|
 | Tool poisoning | high | `poisoned-tools` | MCP05, ASI03 |
 | Tool shadowing | high | `tool-shadowing` | MCP05, ASI03 |
+| Tool name collision | high | `tool-name-collision` | MCP05, ASI03 |
 | Tool description rug pull | high | `rug-pull` | MCP05, MCP09 |
 | Unauthenticated MCP servers | high | `no-auth-servers` | MCP03, ASI04 |
 | Unauthenticated A2A agents | high | `no-auth-a2a` | MCP03, ASI04 |
@@ -61,13 +62,21 @@ MCPTool:dangerous-tool has injection pattern: "ignore all previous instructions"
 
 **Risk:** An attacker controlling a low-trust server can shadow a legitimate tool. When an agent calls the shadowed tool, the malicious server handles the request instead.
 
+## Tool name collision (MCP05, ASI03)
+
+**What:** Tools on different servers share a normalized (trimmed, lower-cased) name.
+
+**How detected:** The `tool-name-collision` pre-built query matches `MCPTool` nodes across distinct servers whose names collide after normalization, with distinct `objectid`s.
+
+**Risk:** A malicious server can register a tool with the same name as a trusted one. Depending on resolution order, the agent may invoke the attacker's tool instead — a name-based variant of tool shadowing.
+
 ## Rug pull detection (MCP05, MCP09)
 
-**What:** A tool's description changes between scans, potentially indicating a supply chain attack.
+**What:** A tool's pinned surface changes between scans, potentially indicating a supply chain attack.
 
-**How detected:** Each tool gets a `description_hash` (SHA-256 of canonical description). On re-scan, the ingest pipeline compares hashes. The `rug-pull` pre-built query finds tools where `description_hash != previous_description_hash`.
+**How detected:** Each tool carries `description_hash` and `input_schema_hash`; each server carries `instructions_hash`. The node MERGE pivots `previous_*_hash` on every scan. The `rug-pull` pre-built query fires when any of the three current hashes differs from its previous value, and returns a `change_kind` discriminator (`description`, `input_schema`, `instructions`, or a comma-joined combination) identifying which surface drifted.
 
-**Risk:** An attacker who gains control of an MCP server package can change tool descriptions to include injection patterns after the initial trust decision was made.
+**Risk:** An attacker who gains control of an MCP server package can change tool descriptions, input schemas, or server instructions to include injection patterns after the initial trust decision was made. Schema and instruction pinning catch rug pulls that leave the description untouched.
 
 ## Unauthenticated servers (MCP03)
 
@@ -105,9 +114,41 @@ MCPTool:dangerous-tool has injection pattern: "ignore all previous instructions"
 
 **What:** An agent can reach sensitive data (databases, credentials, files) AND has an outbound channel (network_outbound, email_send).
 
-**How detected:** The CAN_EXFILTRATE_VIA post-processor combines CAN_REACH edges to sensitive resources with tools that have outbound capability. The pre-built query surfaces complete exfiltration paths.
+**How detected:** The CAN_EXFILTRATE_VIA post-processor combines CAN_REACH edges to sensitive resources with tools that have an outbound capability. The outbound capability set is `email_send`, `network_outbound`, `file_write`, plus two channel classes:
+
+- **`auto_fetch_render`** — tools that return content the host may auto-fetch/render (markdown images, HTML previews). *Caveat:* this detects tools that **return** renderable content, not the host's render policy — host-side rendering behavior is not observable by the collector, so treat it as a candidate channel.
+- **`allowlisted_proxy`** — tools that proxy requests through an allowlisted egress, which can slip exfiltration past naive egress controls.
 
 **Risk:** This is the complete attack chain: access sensitive data, then send it somewhere. Two capabilities that are safe independently become critical when combined.
+
+## Untrusted input sources & taint (MCP05, ASI03)
+
+**What:** Tools that ingest attacker-controllable content (open web, inbound email, external file shares) and the downstream flow of that taint into other tools and sensitive sinks.
+
+**How detected:** The `source-untrusted-web`, `source-untrusted-email`, and `source-untrusted-fileshare` rules tag matching tools with a `source_trust` property. The MCP Collector then emits an `INGESTS_UNTRUSTED` raw edge from each tagged tool to the resources on its server. Two post-processors consume that signal:
+
+- **`TAINTS`** — links an untrusted-input tool to a tool on **another** server when they share ≥2 input-schema keys, modeling data flow between tools with compatible inputs.
+- **`IFC_VIOLATION`** — links an untrusted source to a high-impact sink (`credential_access` / `file_write` / `email_send`) that shares a resource within 3 `HAS_ACCESS_TO` hops, an information-flow-control violation.
+
+Keyword sets are kept deliberately narrow — universal taint destroys signal.
+
+**Risk:** Untrusted content reaching a privileged tool is the core indirect-prompt-injection primitive: an attacker who controls a fetched web page or inbound email can drive a credential- or file-writing tool.
+
+## Confused deputy (ASI06, MCP04)
+
+**What:** A weakly-authenticated A2A agent can drive a strongly-authenticated one through delegation, borrowing its privileges.
+
+**How detected:** The `auth_strength` pre-pass materializes a numeric weakness score onto every node with an `auth_method`. The `confused_deputy` post-processor emits a `CONFUSED_DEPUTY` edge for `DELEGATES_TO` pairs where the caller's `auth_strength` ≥ 80 (none/apiKey-class) and the callee's ≤ 30 (oauth/mtls-class).
+
+**Risk:** The anonymous or low-trust caller effectively escalates to the callee's privilege level — a classic confused-deputy escalation across an agent trust boundary.
+
+## Context poisoning (MCP05, ASI03)
+
+**What:** An injection-bearing tool can poison the shared agent context that drives a high-capability tool, even without naming it.
+
+**How detected:** The shadows processor emits a `POISONS_CONTEXT` edge from any tool with `has_injection_patterns=true` to tools carrying a high-blast capability (`shell_access`, `code_execution`, `credential_access`, `email_send`). Fan-out is capped at 20 sinks per source tool to prevent a cartesian blow-up; `scripts/perf-check.sh` enforces a ≤200 poisoned-pair-per-agent ceiling.
+
+**Risk:** Unlike `SHADOWS` (which requires the poisoner to name its target), context poisoning models the broader case where injected text in one tool's description influences how the agent invokes a dangerous sibling tool.
 
 ## Cross-protocol attack paths (MCP01, ASI01)
 

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -20,15 +20,15 @@ These are the node kinds accepted in ingest input (`sdk/ingest.AllowedNodeKinds`
 
 | Label | Source | Key Properties |
 |-------|--------|----------------|
-| `MCPServer` | Config + MCP | `name`, `endpoint`, `transport` (stdio/http), `auth_method`, `protocol_version`, `instructions`, `capabilities`, `is_pinned`, `has_tasks_capability` |
-| `MCPTool` | MCP | `name`, `description`, `input_schema`, `output_schema`, `annotations`, `description_hash` (SHA-256), `capability_surface[]`, `has_injection_patterns`, `has_cross_references` |
+| `MCPServer` | Config + MCP | `name`, `endpoint`, `transport` (stdio/http), `auth_method`, `auth_strength` (numeric, post-processor), `protocol_version`, `instructions`, `instructions_hash` (SHA-256), `capabilities`, `is_pinned`, `has_tasks_capability` |
+| `MCPTool` | MCP | `name`, `description`, `input_schema`, `output_schema`, `annotations`, `description_hash` (SHA-256), `input_schema_hash` (SHA-256), `schema_keys[]`, `capability_surface[]`, `source_trust` (untrusted_web/email/fileshare), `has_injection_patterns`, `has_cross_references` |
 | `MCPResource` | MCP | `uri`, `name`, `mime_type`, `size`, `uri_scheme`, `sensitivity` (auto-classified) |
 | `MCPPrompt` | MCP | `name`, `description`, `arguments` |
-| `A2AAgent` | A2A | `name`, `description`, `url`, `provider`, `version`, `protocol_versions`, `capabilities`, `security_schemes`, `auth_method`, `is_signed`, `signature_valid`, `card_hash` |
+| `A2AAgent` | A2A | `name`, `description`, `url`, `provider`, `version`, `protocol_versions`, `capabilities`, `security_schemes`, `auth_method`, `auth_strength` (numeric, post-processor), `is_signed`, `signature_valid`, `card_hash` |
 | `A2ASkill` | A2A | `id`, `name`, `description`, `input_modes`, `output_modes`, `description_hash`, `has_injection_patterns` |
 | `AgentInstance` | Config | `name`, `framework`, `config_path` |
 | `Identity` | Config + MCP | `type` (none/apiKey/oauth/bearer/mtls), `scope`, `is_static` |
-| `Credential` | Config + LiteLLM Looter | `type` (envVar/hardcoded/vaultRef/inputPrompt/master_key/apiKey/virtual_key), `name`, `source`, `is_exposed`, `high_entropy`, `value_hash` (SHA-256) |
+| `Credential` | Config + LiteLLM Looter | `type` (envVar/hardcoded/vaultRef/inputPrompt/master_key/apiKey/virtual_key), `name`, `source`, `is_exposed`, `high_entropy`, `value_hash` (SHA-256), `blast_radius` (distinct reachable agents, post-processor) |
 | `Host` | Config + A2A | `hostname`, `ip`, `is_local`, `is_private`, `is_public` |
 | `ConfigFile` | Config | `path`, `client`, `server_count` |
 | `InstructionFile` | Config | `path`, `type` (agents.md/claude.md/cursorrules/copilot-instructions/memory.md), `hash`, `is_suspicious` |
@@ -81,7 +81,7 @@ This enables queries like `MATCH (n:AIService)` to find all AI infrastructure re
 
 ## 3. Edge Types
 
-### Raw Edges (17 collector-produced)
+### Raw Edges (18 collector-produced)
 
 | Edge | Source | Target | Collector | Meaning |
 |------|--------|--------|-----------|---------|
@@ -102,8 +102,9 @@ This enables queries like `MATCH (n:AIService)` to find all AI infrastructure re
 | `EXPOSES_CREDENTIAL` | AIService | Credential | LiteLLM Looter | Service exposes credential material (master keys, upstream provider keys, virtual keys) |
 | `PROVIDES_MODEL` | OllamaInstance | AIModel | Ollama Looter | Instance serves this model |
 | `EXTRACTED_FROM` | AIModel | ExtractedTrainingSignal | Extractors | Extracted signal was derived from this model |
+| `INGESTS_UNTRUSTED` | MCPTool | MCPResource | MCP | Tool with rule-derived `source_trust` (web/email/fileshare) ingests untrusted input that taints same-server resources. **Raw edge** — not swept by composite cleanup (see post-processors doc) |
 
-### Composite Edges (8 post-processor computed)
+### Composite Edges (12 post-processor computed)
 
 | Edge | Source | Target | Depends On | Meaning |
 |------|--------|--------|------------|---------|
@@ -112,9 +113,13 @@ This enables queries like `MATCH (n:AIService)` to find all AI infrastructure re
 | `SHADOWS` | MCPTool | MCPTool | Raw edges | Tool on another server references this tool's name/description |
 | `POISONED_DESCRIPTION` | MCPTool | MCPTool (self-edge) | Raw edges | Tool description contains injection patterns |
 | `POISONED_INSTRUCTIONS` | InstructionFile | InstructionFile (self-edge) | Raw edges | Suspicious patterns: imperative overrides, exfiltration commands, hidden Unicode |
+| `TAINTS` | MCPTool | MCPTool | INGESTS_UNTRUSTED + `schema_keys` | Untrusted-input tool shares ≥2 schema keys with a tool on another server, so attacker data can flow between them |
 | `CAN_REACH` | AgentInstance / A2AAgent | MCPResource | HAS_ACCESS_TO | Transitive access through trust chain (includes cross-protocol and credential chain variants up to 6 hops) |
-| `CAN_EXFILTRATE_VIA` | AgentInstance | MCPTool | CAN_REACH | Agent reaches sensitive data AND has outbound exfiltration channel |
+| `CAN_EXFILTRATE_VIA` | AgentInstance | MCPTool | CAN_REACH | Agent reaches sensitive data AND has outbound exfiltration channel (incl. `auto_fetch_render` / `allowlisted_proxy` channels) |
+| `IFC_VIOLATION` | MCPTool | MCPTool | INGESTS_UNTRUSTED + HAS_ACCESS_TO (≤3 hops) | Untrusted source shares a resource with a high-impact sink (credential_access/file_write/email_send) |
 | `CAN_IMPERSONATE` | A2AAgent | A2AAgent | Raw edges | TF-IDF cosine similarity > 0.8 on skill descriptions |
+| `CONFUSED_DEPUTY` | A2AAgent | A2AAgent | auth_strength + can_reach | Weakly-authed agent (`auth_strength` ≥ 80) delegates to a strongly-authed one (≤ 30) |
+| `POISONS_CONTEXT` | MCPTool | MCPTool | Raw edges | Injection-bearing tool can poison context driving a high-capability tool (fan-out capped at 20 sinks/source) |
 
 ### Edge Struct (Go SDK)
 
@@ -191,17 +196,21 @@ Processors run in strict dependency order. A processor may only read edges produ
 
 | Order | Processor | Produces | Dependencies |
 |-------|-----------|----------|--------------|
-| 1 | has_access_to | `HAS_ACCESS_TO` | Raw edges only |
-| 2 | can_execute | `CAN_EXECUTE` | Raw edges only |
-| 3 | shadows | `SHADOWS` | Raw edges only |
-| 4 | poisoned_description | `POISONED_DESCRIPTION` | Raw edges only |
-| 5 | poisoned_instructions | `POISONED_INSTRUCTIONS` | Raw edges only |
-| 6 | can_reach | `CAN_REACH` | 1 (HAS_ACCESS_TO) |
-| 7 | cross_service_credential_chain | `CAN_REACH` (credential variant) | 1, 6 (joins on `Credential.value_hash`) |
-| 8 | can_exfiltrate_via | `CAN_EXFILTRATE_VIA` | 6 (CAN_REACH) |
-| 9 | can_impersonate | `CAN_IMPERSONATE` | Raw edges only |
-| 10 | cross_protocol | `CAN_REACH` (cross-protocol) | 1 (HAS_ACCESS_TO) + DELEGATES_TO |
-| 11 | risk_score | Node property updates | 1–10 (all prior processors) |
+| 1 | auth_strength | `auth_strength` node property (pre-pass) | None |
+| 2 | has_access_to | `HAS_ACCESS_TO` | Raw edges only |
+| 3 | can_execute | `CAN_EXECUTE` | Raw edges only |
+| 4 | shadows | `SHADOWS` + `POISONS_CONTEXT` | Raw edges only |
+| 5 | poisoned_description | `POISONED_DESCRIPTION` | Raw edges only |
+| 6 | poisoned_instructions | `POISONED_INSTRUCTIONS` | Raw edges only |
+| 7 | taints | `TAINTS` | INGESTS_UNTRUSTED + `schema_keys` |
+| 8 | can_reach | `CAN_REACH` | 2 (HAS_ACCESS_TO) |
+| 9 | cross_service_credential_chain | `CAN_REACH` (credential variant) + `Credential.blast_radius` | 2, 8 (joins on `Credential.value_hash`) |
+| 10 | ifc_violation | `IFC_VIOLATION` | 2 (HAS_ACCESS_TO) + INGESTS_UNTRUSTED |
+| 11 | can_exfiltrate_via | `CAN_EXFILTRATE_VIA` | 8 (CAN_REACH) |
+| 12 | can_impersonate | `CAN_IMPERSONATE` | Raw edges only |
+| 13 | confused_deputy | `CONFUSED_DEPUTY` | 1 (auth_strength) + 8 (can_reach) |
+| 14 | cross_protocol | `CAN_REACH` (cross-protocol) | 2 (HAS_ACCESS_TO) + DELEGATES_TO |
+| 15 | risk_score | Node property updates | 1–14 (all prior processors) |
 
 ---
 
@@ -254,7 +263,7 @@ Lower weight = easier to exploit = higher risk. Used by Dijkstra weighted-path q
 Nodes merge by `objectid` using Cypher `MERGE`. When the same entity appears from multiple collectors:
 
 - Properties use **last-write-wins** semantics
-- `ON MATCH SET n.previous_description_hash = n.description_hash` preserves old hash for rug-pull detection
+- The node MERGE pivots the previous-hash trio (`previous_description_hash`, `previous_input_schema_hash`, `previous_instructions_hash`) on both `ON CREATE` (seeded from the incoming hashes) and `ON MATCH` (set to the prior values before `n += node.properties` overwrites them) for rug-pull detection
 - Edges accumulate (different collectors contribute different edge types to the same node)
 
 ### Stale Edge Cleanup

--- a/docs/reference/risk-scoring.md
+++ b/docs/reference/risk-scoring.md
@@ -74,7 +74,9 @@ score = 0.35 * auth_strength + 0.25 * tool_risk + 0.20 * exposure
 | `auth_strength` | none=100, apiKey=70, bearer=50, oauth=25, mtls=10 |
 | `tool_risk` | max `capability_risk` across all provided tools |
 | `exposure` | public host=100, private network=50, localhost=20, unknown=0 |
-| `credential_handling` | 100 if high-entropy or hardcoded creds; 50 if any env vars; 0 otherwise |
+| `credential_handling` | `max(base, blast)` where `base` = 100 if high-entropy or hardcoded creds else 50 (when any env vars), and `blast` = `min(Credential.blast_radius * 10, 100)`; 0 if no env vars |
+
+`Credential.blast_radius` (distinct agents that can reach a value_hash-merged secret) is materialized by the `cross_service_credential_chain` post-processor, so a widely-shared secret amplifies its server's credential-handling risk even when the secret itself is not high-entropy.
 
 ### MCPTool
 

--- a/modules/mcp/enumerate.go
+++ b/modules/mcp/enumerate.go
@@ -79,10 +79,12 @@ func (c *MCPCollector) enumerateServer(ctx context.Context, spec ServerSpec, sca
 
 	caps := initResult.Capabilities
 
+	var untrustedTools map[string]string
 	if caps != nil && caps.Tools != nil {
 		tools := c.enumerateTools(ctx, session, serverID, scanID)
 		result.Nodes = append(result.Nodes, tools.nodes...)
 		result.Edges = append(result.Edges, tools.edges...)
+		untrustedTools = tools.sourceTrust
 	}
 
 	if caps != nil && caps.Resources != nil {
@@ -100,6 +102,13 @@ func (c *MCPCollector) enumerateServer(ctx context.Context, spec ServerSpec, sca
 		result.Nodes = append(result.Nodes, prompts.nodes...)
 		result.Edges = append(result.Edges, prompts.edges...)
 	}
+
+	// INGESTS_UNTRUSTED join: a tool tagged with an untrusted source_trust
+	// ingests attacker-controllable content, so it taints the resources on
+	// the same server. v1 fans out to every resource on the server; a
+	// future tightening can match by URI scheme.
+	result.Edges = append(result.Edges,
+		buildIngestsUntrustedEdges(result.Nodes, untrustedTools, scanID)...)
 
 	return result
 }
@@ -138,10 +147,12 @@ func (c *MCPCollector) retryWithSSE(ctx context.Context, spec ServerSpec, scanID
 
 	caps := initResult.Capabilities
 
+	var untrustedTools map[string]string
 	if caps != nil && caps.Tools != nil {
 		tools := c.enumerateTools(ctx, session, serverID, scanID)
 		result.Nodes = append(result.Nodes, tools.nodes...)
 		result.Edges = append(result.Edges, tools.edges...)
+		untrustedTools = tools.sourceTrust
 	}
 
 	if caps != nil && caps.Resources != nil {
@@ -160,12 +171,24 @@ func (c *MCPCollector) retryWithSSE(ctx context.Context, spec ServerSpec, scanID
 		result.Edges = append(result.Edges, prompts.edges...)
 	}
 
+	// INGESTS_UNTRUSTED join: a tool tagged with an untrusted source_trust
+	// ingests attacker-controllable content, so it taints the resources on
+	// the same server. v1 fans out to every resource on the server; a
+	// future tightening can match by URI scheme.
+	result.Edges = append(result.Edges,
+		buildIngestsUntrustedEdges(result.Nodes, untrustedTools, scanID)...)
+
 	return result
 }
 
 type enumResult struct {
 	nodes []ingest.Node
 	edges []ingest.Edge
+	// sourceTrust maps an untrusted tool's node ID to its rule-derived
+	// source_trust label (untrusted_web | untrusted_email |
+	// untrusted_fileshare). Populated only by enumerateTools; consumed by
+	// the INGESTS_UNTRUSTED join after resources are enumerated.
+	sourceTrust map[string]string
 }
 
 func (c *MCPCollector) enumerateTools(ctx context.Context, session *mcpsdk.ClientSession, serverID, scanID string) enumResult {
@@ -195,18 +218,30 @@ func (c *MCPCollector) enumerateTools(ctx context.Context, session *mcpsdk.Clien
 		signals := computeToolSignals(tool, allNames, c.engine)
 		toolID := ingest.ComputeNodeID("MCPTool", serverID, tool.Name)
 
+		inputSchemaJSON := marshalJSON(tool.InputSchema)
 		props := map[string]any{
 			"name":                   tool.Name,
 			"description":            tool.Description,
-			"input_schema":           marshalJSON(tool.InputSchema),
+			"input_schema":           inputSchemaJSON,
 			"output_schema":          marshalJSON(tool.OutputSchema),
 			"description_hash":       signals.DescriptionHash,
+			"input_schema_hash":      common.HashSHA256(inputSchemaJSON),
 			"capability_surface":     signals.CapabilitySurface,
 			"has_injection_patterns": signals.HasInjection,
 			"has_cross_references":   signals.HasCrossReferences,
 		}
 		if signals.Annotations != nil {
 			props["annotations"] = signals.Annotations
+		}
+		if keys := inputSchemaKeys(tool.InputSchema); len(keys) > 0 {
+			props["schema_keys"] = keys
+		}
+		if signals.SourceTrust != "" {
+			props["source_trust"] = signals.SourceTrust
+			if result.sourceTrust == nil {
+				result.sourceTrust = make(map[string]string)
+			}
+			result.sourceTrust[toolID] = signals.SourceTrust
 		}
 
 		result.nodes = append(result.nodes, common.NewNode(toolID, []string{"MCPTool"}, props))
@@ -431,6 +466,48 @@ func buildHostNodes(serverID, serverURL, scanID string) hostResult {
 		common.DefaultEdgeProps(scanID)))
 
 	return result
+}
+
+// buildIngestsUntrustedEdges emits INGESTS_UNTRUSTED (MCPTool ->
+// MCPResource) for every untrusted tool against every resource discovered
+// on the same server. The edge is a RAW edge (is_composite=false) keyed on
+// (source, target), so re-scans rewrite scan_id idempotently. v1 is a
+// server-scoped fan-out; resource URI-scheme matching is a future
+// tightening (see docs/architecture/post-processors.md).
+func buildIngestsUntrustedEdges(nodes []ingest.Node, untrustedTools map[string]string, scanID string) []ingest.Edge {
+	if len(untrustedTools) == 0 {
+		return nil
+	}
+	var resourceIDs []string
+	for _, n := range nodes {
+		for _, k := range n.Kinds {
+			if k == "MCPResource" {
+				resourceIDs = append(resourceIDs, n.ID)
+				break
+			}
+		}
+	}
+	if len(resourceIDs) == 0 {
+		return nil
+	}
+
+	// Deterministic ordering so repeated scans emit edges in a stable
+	// order (the graph is MERGE-keyed, but stable output aids testing).
+	toolIDs := make([]string, 0, len(untrustedTools))
+	for id := range untrustedTools {
+		toolIDs = append(toolIDs, id)
+	}
+	sort.Strings(toolIDs)
+
+	var edges []ingest.Edge
+	for _, toolID := range toolIDs {
+		for _, resID := range resourceIDs {
+			props := common.NewEdgeProps(scanID, 0.6, 0.3)
+			props["source_trust"] = untrustedTools[toolID]
+			edges = append(edges, common.NewEdge(toolID, resID, "INGESTS_UNTRUSTED", "MCPTool", "MCPResource", props))
+		}
+	}
+	return edges
 }
 
 func marshalJSON(v any) string {

--- a/modules/mcp/signals.go
+++ b/modules/mcp/signals.go
@@ -17,6 +17,7 @@ type ToolSignals struct {
 	CapabilitySurface  []string
 	HasInjection       bool
 	HasCrossReferences bool
+	SourceTrust        string
 	Annotations        map[string]any
 }
 
@@ -55,6 +56,13 @@ func computeToolSignals(tool *mcpsdk.Tool, allToolNames map[string]bool, engine 
 		case "capability_classification":
 			if v, ok := m.Emit.PropertyValue.(string); ok {
 				capSet[v] = true
+			}
+		case "source_trust_classification":
+			// First non-empty untrusted-source label wins; any value
+			// marks the tool as ingesting untrusted input. Edges are
+			// MERGE-keyed so the exact label choice is stable enough.
+			if v, ok := m.Emit.PropertyValue.(string); ok && v != "" && sig.SourceTrust == "" {
+				sig.SourceTrust = v
 			}
 		}
 	}
@@ -132,6 +140,48 @@ func computeResourceSignals(uri string, engine *rules.Engine) ResourceSignals {
 	}
 
 	return sig
+}
+
+// inputSchemaKeys extracts the top-level and one-level-nested property
+// names from a tool's JSON input schema, returned sorted and de-duplicated.
+// Emitted collector-side as the schema_keys node property so the TAINTS
+// post-processor can detect schema overlap between tools in pure Cypher
+// (no APOC dependency on the server). Returns nil when there are no keys.
+func inputSchemaKeys(schema any) []string {
+	m := inputSchemaAsMap(schema)
+	if m == nil {
+		return nil
+	}
+	keySet := make(map[string]bool)
+	collectSchemaKeys(m, keySet, 0)
+	if len(keySet) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// collectSchemaKeys walks a JSON-schema "properties" map, recording each
+// property name. It descends at most one level into nested object schemas
+// (depth 0 -> top level, depth 1 -> one level of nesting) to keep the key
+// set bounded and the overlap signal meaningful.
+func collectSchemaKeys(m map[string]any, out map[string]bool, depth int) {
+	props, ok := m["properties"].(map[string]any)
+	if !ok {
+		return
+	}
+	for key, val := range props {
+		out[key] = true
+		if depth < 1 {
+			if sub, ok := val.(map[string]any); ok {
+				collectSchemaKeys(sub, out, depth+1)
+			}
+		}
+	}
 }
 
 func inputSchemaAsMap(schema any) map[string]any {

--- a/scripts/perf-check.sh
+++ b/scripts/perf-check.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# perf-check.sh — POISONS_CONTEXT pair-count invariant.
+#
+# B8 (POISONS_CONTEXT) widens the narrow SHADOWS guard: an injection-bearing
+# tool can poison the shared agent context that drives a high-capability tool.
+# To stop that breadth from exploding into a cartesian product, the shadows
+# processor caps fan-out at 20 sinks per source tool. This script verifies the
+# resulting per-agent ceiling holds against a live graph after a scan.
+#
+# The math: per-source cap = 20. An agent with N source tools (injection-
+# bearing tools it can reach) tops out at N * 20 poisoned pairs. The ceiling
+# below is 200, i.e. 10 source tools at the cap. An 11th source tool at the
+# cap (220) breaches it — meaning either the per-source cap is too loose or
+# the fixture is pathological. Tune MAX_PAIRS deliberately if the fleet shape
+# legitimately changes.
+#
+# Requires a running graph (Neo4j + Postgres) reachable by agenthound-server.
+# When no server binary or database is available the check SKIPS (exit 0) so
+# it is safe to invoke in environments without a live stack.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MAX_PAIRS="${PERF_CHECK_MAX_PAIRS:-200}"
+
+# Resolve the server binary: explicit override, built artifact, or PATH.
+BIN="${AGENTHOUND_SERVER_BIN:-}"
+if [ -z "$BIN" ]; then
+  if [ -x "./bin/agenthound-server" ]; then
+    BIN="./bin/agenthound-server"
+  elif command -v agenthound-server >/dev/null 2>&1; then
+    BIN="agenthound-server"
+  fi
+fi
+
+if [ -z "$BIN" ]; then
+  echo "perf-check: agenthound-server binary not found (set AGENTHOUND_SERVER_BIN or run 'make build-server'); SKIPPING."
+  exit 0
+fi
+
+QUERY='MATCH (a:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)-[:PROVIDES_TOOL]->(t1)-[:POISONS_CONTEXT]->(t2)
+RETURN a.name AS agent, count(DISTINCT [t1.objectid, t2.objectid]) AS poisoned_pairs
+ORDER BY poisoned_pairs DESC LIMIT 1'
+
+OUT=$(mktemp)
+trap 'rm -f "$OUT"' EXIT
+
+if ! "$BIN" query "$QUERY" --format json >"$OUT" 2>/dev/null; then
+  echo "perf-check: could not query the graph (no database reachable?); SKIPPING."
+  exit 0
+fi
+
+# No POISONS_CONTEXT edges -> printRows emits "(no results)"; nothing to gate.
+if grep -q "(no results)" "$OUT"; then
+  echo "perf-check: no POISONS_CONTEXT edges present; OK."
+  exit 0
+fi
+
+# Extract the largest poisoned_pairs value from the JSON output.
+MAX_OBSERVED=$(grep -oE '"poisoned_pairs"[[:space:]]*:[[:space:]]*[0-9]+' "$OUT" \
+  | grep -oE '[0-9]+$' | sort -nr | head -1)
+MAX_OBSERVED="${MAX_OBSERVED:-0}"
+
+echo "perf-check: max poisoned_pairs per agent = $MAX_OBSERVED (ceiling $MAX_PAIRS)"
+
+if [ "$MAX_OBSERVED" -gt "$MAX_PAIRS" ]; then
+  echo "FAIL: an agent exceeds $MAX_PAIRS POISONS_CONTEXT pairs."
+  echo "      Either the per-source fan-out cap (20) is too loose or the fixture is pathological."
+  exit 1
+fi
+
+echo "perf-check: OK."

--- a/sdk/ingest/kinds.go
+++ b/sdk/ingest/kinds.go
@@ -56,11 +56,12 @@ var UmbrellaLabels = map[string]bool{
 	"AIService": true,
 }
 
-// RawEdgeKinds are the 17 collector-produced edge kinds accepted in ingest
+// RawEdgeKinds are the 18 collector-produced edge kinds accepted in ingest
 // input. EXPOSES is reserved in v0.2 for v0.3 fingerprinters; EXPOSES_CREDENTIAL
 // is emitted by the v0.2 LiteLLM Looter; PROVIDES_MODEL is emitted by the v0.3
 // Ollama Looter; EXTRACTED_FROM is emitted by the v0.5 embedding-inversion
-// Extractor (AIModel → ExtractedTrainingSignal).
+// Extractor (AIModel → ExtractedTrainingSignal); INGESTS_UNTRUSTED is emitted by
+// the MCP Collector for tools whose rule-derived source_trust is untrusted.
 var RawEdgeKinds = map[string]bool{
 	"TRUSTS_SERVER":      true,
 	"PROVIDES_TOOL":      true,
@@ -79,9 +80,10 @@ var RawEdgeKinds = map[string]bool{
 	"EXPOSES_CREDENTIAL": true,
 	"PROVIDES_MODEL":     true,
 	"EXTRACTED_FROM":     true,
+	"INGESTS_UNTRUSTED":  true,
 }
 
-// AllowedEdgeKinds includes all 25 edge kinds (17 raw + 8 composite) for Neo4j writer dispatch.
+// AllowedEdgeKinds includes all 30 edge kinds (18 raw + 12 composite) for Neo4j writer dispatch.
 var AllowedEdgeKinds = map[string]bool{
 	// Raw (collector-produced)
 	"TRUSTS_SERVER":      true,
@@ -101,6 +103,7 @@ var AllowedEdgeKinds = map[string]bool{
 	"EXPOSES_CREDENTIAL": true,
 	"PROVIDES_MODEL":     true,
 	"EXTRACTED_FROM":     true,
+	"INGESTS_UNTRUSTED":  true,
 	// Composite (post-processor produced)
 	"HAS_ACCESS_TO":         true,
 	"CAN_EXECUTE":           true,
@@ -110,6 +113,10 @@ var AllowedEdgeKinds = map[string]bool{
 	"POISONED_DESCRIPTION":  true,
 	"CAN_IMPERSONATE":       true,
 	"POISONED_INSTRUCTIONS": true,
+	"CONFUSED_DEPUTY":       true,
+	"TAINTS":                true,
+	"IFC_VIOLATION":         true,
+	"POISONS_CONTEXT":       true,
 }
 
 // AllowedCollectors are the valid collector identifiers in ingest meta.
@@ -153,6 +160,11 @@ var EdgeKindEndpoints = map[string]EdgeEndpoints{
 	"EXPOSES_CREDENTIAL":    {SourceKinds: []string{"AIService"}, TargetKinds: []string{"Credential"}},
 	"PROVIDES_MODEL":        {SourceKinds: []string{"OllamaInstance"}, TargetKinds: []string{"AIModel"}},
 	"EXTRACTED_FROM":        {SourceKinds: []string{"AIModel"}, TargetKinds: []string{"ExtractedTrainingSignal"}},
+	"INGESTS_UNTRUSTED":     {SourceKinds: []string{"MCPTool"}, TargetKinds: []string{"MCPResource"}},
+	"CONFUSED_DEPUTY":       {SourceKinds: []string{"A2AAgent"}, TargetKinds: []string{"A2AAgent"}},
+	"TAINTS":                {SourceKinds: []string{"MCPTool"}, TargetKinds: []string{"MCPTool"}},
+	"IFC_VIOLATION":         {SourceKinds: []string{"MCPTool"}, TargetKinds: []string{"MCPTool"}},
+	"POISONS_CONTEXT":       {SourceKinds: []string{"MCPTool"}, TargetKinds: []string{"MCPTool"}},
 }
 
 // ResolveEdgeEndpoints returns the source and target node kinds for an edge,

--- a/sdk/ingest/model_test.go
+++ b/sdk/ingest/model_test.go
@@ -109,8 +109,8 @@ func TestAllNodeLabelsComplete(t *testing.T) {
 }
 
 func TestAllowedEdgeKindsComplete(t *testing.T) {
-	if len(AllowedEdgeKinds) != 25 {
-		t.Errorf("AllowedEdgeKinds: got %d entries, want 25", len(AllowedEdgeKinds))
+	if len(AllowedEdgeKinds) != 30 {
+		t.Errorf("AllowedEdgeKinds: got %d entries, want 30", len(AllowedEdgeKinds))
 	}
 }
 

--- a/sdk/rules/builtin/capability-allowlisted-proxy.yaml
+++ b/sdk/rules/builtin/capability-allowlisted-proxy.yaml
@@ -1,0 +1,24 @@
+id: capability-allowlisted-proxy
+name: Allowlisted Proxy Capability
+description: >
+  Classifies tools that proxy requests through an allowlisted egress
+  (corporate proxy, URL allowlist, fetch-through gateway). These can serve as
+  a covert outbound exfiltration channel that slips past naive egress
+  controls because the destination looks allowlisted.
+version: 1
+enabled: true
+scope:
+  collector: mcp
+  targets: [tool.combined]
+severity: medium
+owasp: [MCP04, ASI10]
+tags: [capability, allowlisted-proxy, exfiltration]
+matcher:
+  type: keyword
+  keywords: [proxy_request, allowlisted_proxy, "proxy fetch", egress_proxy, "forward request", proxy_url, "allowlist proxy"]
+  case_insensitive: true
+  match_mode: any
+emit:
+  finding_type: capability_classification
+  property_key: capability_surface
+  property_value: allowlisted_proxy

--- a/sdk/rules/builtin/capability-auto-fetch-render.yaml
+++ b/sdk/rules/builtin/capability-auto-fetch-render.yaml
@@ -1,0 +1,26 @@
+id: capability-auto-fetch-render
+name: Auto Fetch/Render Capability
+description: >
+  Classifies tools that return content the host may auto-fetch or render
+  (markdown images, HTML previews, embedded links). Such tools can be abused
+  as an out-of-band exfiltration channel when an attacker controls the
+  rendered content. Caveat: this detects tools that RETURN renderable
+  content, not the host's render policy — host-side render behavior is not
+  observable by the collector.
+version: 1
+enabled: true
+scope:
+  collector: mcp
+  targets: [tool.combined]
+severity: medium
+owasp: [MCP04, ASI10]
+tags: [capability, auto-fetch-render, exfiltration]
+matcher:
+  type: keyword
+  keywords: [render_markdown, render_html, "markdown image", "embed image", auto_render, render_preview, "image markdown"]
+  case_insensitive: true
+  match_mode: any
+emit:
+  finding_type: capability_classification
+  property_key: capability_surface
+  property_value: auto_fetch_render

--- a/sdk/rules/builtin/source-untrusted-email.yaml
+++ b/sdk/rules/builtin/source-untrusted-email.yaml
@@ -1,0 +1,24 @@
+id: source-untrusted-email
+name: Untrusted Email Source
+description: >
+  Flags tools that read inbound email/message content. Inbound mail is a
+  classic prompt-injection delivery channel and is treated as an untrusted
+  input source for taint / information-flow analysis (INGESTS_UNTRUSTED).
+  Keywords are kept narrow on purpose — universal taint kills signal.
+version: 1
+enabled: true
+scope:
+  collector: mcp
+  targets: [tool.combined]
+severity: medium
+owasp: [MCP05, ASI03]
+tags: [source-trust, untrusted-email]
+matcher:
+  type: keyword
+  keywords: [read_email, "read email", fetch_email, get_email, "read inbox", read_inbox, list_emails, fetch_inbox, imap_read]
+  case_insensitive: true
+  match_mode: any
+emit:
+  finding_type: source_trust_classification
+  property_key: source_trust
+  property_value: untrusted_email

--- a/sdk/rules/builtin/source-untrusted-fileshare.yaml
+++ b/sdk/rules/builtin/source-untrusted-fileshare.yaml
@@ -1,0 +1,26 @@
+id: source-untrusted-fileshare
+name: Untrusted File-Share Source
+description: >
+  Flags tools that read from shared / external file stores (SMB, NFS, object
+  storage, uploaded attachments). Content placed there by other parties is
+  attacker-controllable and is treated as an untrusted input source for taint
+  / information-flow analysis (INGESTS_UNTRUSTED). Keywords are kept narrow on
+  purpose — universal taint kills signal, so plain local "read_file" is
+  intentionally excluded.
+version: 1
+enabled: true
+scope:
+  collector: mcp
+  targets: [tool.combined]
+severity: medium
+owasp: [MCP05, ASI03]
+tags: [source-trust, untrusted-fileshare]
+matcher:
+  type: keyword
+  keywords: ["file share", "shared drive", "network share", smb_read, nfs_read, "s3 get", s3_download, read_share, "download attachment"]
+  case_insensitive: true
+  match_mode: any
+emit:
+  finding_type: source_trust_classification
+  property_key: source_trust
+  property_value: untrusted_fileshare

--- a/sdk/rules/builtin/source-untrusted-web.yaml
+++ b/sdk/rules/builtin/source-untrusted-web.yaml
@@ -1,0 +1,25 @@
+id: source-untrusted-web
+name: Untrusted Web Source
+description: >
+  Flags tools that ingest content fetched from the open web (URL fetch, web
+  scraping, page crawling, web search). Such content is attacker-controllable
+  and is treated as an untrusted input source for taint / information-flow
+  analysis (INGESTS_UNTRUSTED). Keywords are kept narrow on purpose —
+  universal taint kills signal.
+version: 1
+enabled: true
+scope:
+  collector: mcp
+  targets: [tool.combined]
+severity: medium
+owasp: [MCP05, ASI03]
+tags: [source-trust, untrusted-web]
+matcher:
+  type: keyword
+  keywords: [fetch_url, web_fetch, "fetch web page", scrape_url, web_scrape, crawl_url, "scrape website", browse_url, web_search]
+  case_insensitive: true
+  match_mode: any
+emit:
+  finding_type: source_trust_classification
+  property_key: source_trust
+  property_value: untrusted_web

--- a/sdk/rules/builtin_tests/capability-allowlisted-proxy.yaml
+++ b/sdk/rules/builtin_tests/capability-allowlisted-proxy.yaml
@@ -1,0 +1,10 @@
+tests:
+  - input: "proxy_request Forwards an HTTP request through the egress proxy"
+    should_match: true
+    description: "matches proxy_request keyword"
+  - input: "egress_proxy fetch of an external resource"
+    should_match: true
+    description: "matches egress_proxy keyword"
+  - input: "format_date renders a timestamp as a string"
+    should_match: false
+    description: "no allowlisted-proxy keywords present"

--- a/sdk/rules/builtin_tests/capability-auto-fetch-render.yaml
+++ b/sdk/rules/builtin_tests/capability-auto-fetch-render.yaml
@@ -1,0 +1,10 @@
+tests:
+  - input: "render_markdown Renders the supplied markdown, including images"
+    should_match: true
+    description: "matches render_markdown keyword"
+  - input: "embed image into the chat response"
+    should_match: true
+    description: "matches embed image keyword"
+  - input: "sum_values adds a list of numbers"
+    should_match: false
+    description: "no auto-fetch-render keywords present"

--- a/sdk/rules/builtin_tests/source-untrusted-email.yaml
+++ b/sdk/rules/builtin_tests/source-untrusted-email.yaml
@@ -1,0 +1,13 @@
+tests:
+  - input: "read_email Reads the body of a message from the user's inbox"
+    should_match: true
+    description: "matches read_email keyword"
+  - input: "list_emails returns recent messages"
+    should_match: true
+    description: "matches list_emails keyword"
+  - input: "send_email delivers a drafted message"
+    should_match: false
+    description: "sending email is an outbound action, not an untrusted source"
+  - input: "compute_sum totals a list of numbers"
+    should_match: false
+    description: "no untrusted-email keywords present"

--- a/sdk/rules/builtin_tests/source-untrusted-fileshare.yaml
+++ b/sdk/rules/builtin_tests/source-untrusted-fileshare.yaml
@@ -1,0 +1,13 @@
+tests:
+  - input: "read_share Reads a file from the corporate network share"
+    should_match: true
+    description: "matches read_share keyword"
+  - input: "s3_download fetches an object from the upload bucket"
+    should_match: true
+    description: "matches s3_download keyword"
+  - input: "read_file opens a local config file bundled with the server"
+    should_match: false
+    description: "plain local read_file is intentionally not treated as untrusted-fileshare"
+  - input: "rotate_logs compresses old log files"
+    should_match: false
+    description: "no untrusted-fileshare keywords present"

--- a/sdk/rules/builtin_tests/source-untrusted-web.yaml
+++ b/sdk/rules/builtin_tests/source-untrusted-web.yaml
@@ -1,0 +1,13 @@
+tests:
+  - input: "web_fetch Fetches the contents of an arbitrary URL"
+    should_match: true
+    description: "matches web_fetch keyword"
+  - input: "scrape_url and return the rendered page text"
+    should_match: true
+    description: "matches scrape_url keyword"
+  - input: "add_numbers adds two integers together"
+    should_match: false
+    description: "no untrusted-web keywords present"
+  - input: "read_record looks up a row in the internal database"
+    should_match: false
+    description: "internal data access is not untrusted-web"

--- a/server/cli/bootstrap.go
+++ b/server/cli/bootstrap.go
@@ -13,13 +13,14 @@ import (
 )
 
 type Infrastructure struct {
-	Neo4jDriver neo4j.DriverWithContext
-	PGPool      *pgxpool.Pool
-	Writer      *graph.Writer
-	Reader      *graph.Reader
-	GraphDB     graph.GraphDB
-	ScanStore   *appdb.ScanStore
-	Pipeline    *ingest.Pipeline
+	Neo4jDriver  neo4j.DriverWithContext
+	PGPool       *pgxpool.Pool
+	Writer       *graph.Writer
+	Reader       *graph.Reader
+	GraphDB      graph.GraphDB
+	ScanStore    *appdb.ScanStore
+	FindingStore *appdb.FindingStore
+	Pipeline     *ingest.Pipeline
 }
 
 func Bootstrap(ctx context.Context) (*Infrastructure, func(), error) {
@@ -58,7 +59,8 @@ func Bootstrap(ctx context.Context) (*Infrastructure, func(), error) {
 	reader := graph.NewReader(neo4jDriver)
 	graphDB := graph.NewDB(reader, writer)
 	scanStore := appdb.NewScanStore(pgPool)
-	pipeline := ingest.NewPipeline(writer, graphDB, scanStore)
+	findingStore := appdb.NewFindingStore(pgPool)
+	pipeline := ingest.NewPipeline(writer, graphDB, scanStore, findingStore)
 
 	cleanup := func() {
 		pgPool.Close()
@@ -66,12 +68,13 @@ func Bootstrap(ctx context.Context) (*Infrastructure, func(), error) {
 	}
 
 	return &Infrastructure{
-		Neo4jDriver: neo4jDriver,
-		PGPool:      pgPool,
-		Writer:      writer,
-		Reader:      reader,
-		GraphDB:     graphDB,
-		ScanStore:   scanStore,
-		Pipeline:    pipeline,
+		Neo4jDriver:  neo4jDriver,
+		PGPool:       pgPool,
+		Writer:       writer,
+		Reader:       reader,
+		GraphDB:      graphDB,
+		ScanStore:    scanStore,
+		FindingStore: findingStore,
+		Pipeline:     pipeline,
 	}, cleanup, nil
 }

--- a/server/cli/query.go
+++ b/server/cli/query.go
@@ -36,6 +36,8 @@ func init() {
 	queryCmd.Flags().String("to", "", "Target node in Kind:name format (e.g. MCPResource:postgres://prod)")
 	queryCmd.Flags().String("format", "table", "Output format: table or json")
 	queryCmd.Flags().String("fail-on", "", "Exit 1 if findings at or above severity: critical, high, medium, low")
+	queryCmd.Flags().Bool("all-findings", false, "Include suppressed findings (accepted-risk, false-positive); --fail-on always ignores suppressed")
+	queryCmd.Flags().String("diff", "", "Diff two scans' findings: scanA,scanB")
 	rootCmd.AddCommand(queryCmd)
 }
 
@@ -49,6 +51,8 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("format")
 
 	failOn, _ := cmd.Flags().GetString("fail-on")
+	includeSuppressed, _ := cmd.Flags().GetBool("all-findings")
+	diffArg, _ := cmd.Flags().GetString("diff")
 
 	if format != "table" && format != "json" {
 		return fmt.Errorf("invalid format %q: must be table or json", format)
@@ -67,8 +71,11 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if shortestPath {
 		modes++
 	}
+	if diffArg != "" {
+		modes++
+	}
 	if modes == 0 {
-		return fmt.Errorf("specify a query mode: raw Cypher argument, --prebuilt, --findings, or --shortest-path")
+		return fmt.Errorf("specify a query mode: raw Cypher argument, --prebuilt, --findings, --diff, or --shortest-path")
 	}
 	if modes > 1 {
 		return fmt.Errorf("specify only one query mode at a time")
@@ -78,7 +85,9 @@ func runQuery(cmd *cobra.Command, args []string) error {
 
 	switch {
 	case findings:
-		return runFindings(ctx, severity, format, failOn)
+		return runFindings(ctx, severity, format, failOn, includeSuppressed)
+	case diffArg != "":
+		return runDiff(ctx, diffArg, format, includeSuppressed)
 	case prebuiltID != "":
 		return runPrebuilt(ctx, prebuiltID, format)
 	case shortestPath:
@@ -128,7 +137,7 @@ func runPrebuilt(ctx context.Context, id, format string) error {
 	return printRows(rows, format)
 }
 
-func runFindings(ctx context.Context, severity, format, failOn string) error {
+func runFindings(ctx context.Context, severity, format, failOn string, includeSuppressed bool) error {
 	if severity != "" {
 		switch severity {
 		case "critical", "high", "medium", "low":
@@ -143,44 +152,55 @@ func runFindings(ctx context.Context, severity, format, failOn string) error {
 	}
 	defer cleanup()
 
-	findings, err := analysis.QueryFindings(ctx, infra.GraphDB, severity)
+	// Reads come from the persisted Postgres snapshot, not live graph
+	// edges: the snapshot is invariant under the next scan's stale-edge
+	// cleanup, and it carries triage state for suppression.
+	findings, err := infra.FindingStore.ListLatestPerFingerprint(ctx, severity, includeSuppressed)
 	if err != nil {
 		return fmt.Errorf("query findings: %w", err)
 	}
 
 	if len(findings) == 0 {
 		fmt.Println("No findings found.")
-		return nil
-	}
-
-	if format == "json" {
-		return printJSON(findings)
-	}
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ID\tSEVERITY\tCATEGORY\tTITLE\tSOURCE\tTARGET")
-	for _, f := range findings {
-		srcLabel := f.SourceName
-		if srcLabel == "" {
-			srcLabel = f.SourceID
+	} else if format == "json" {
+		if err := printJSON(findings); err != nil {
+			return err
 		}
-		tgtLabel := f.TargetName
-		if tgtLabel == "" {
-			tgtLabel = f.TargetID
+	} else {
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "ID\tSEVERITY\tTRIAGE\tCATEGORY\tTITLE\tSOURCE\tTARGET")
+		for _, f := range findings {
+			srcLabel := f.SourceName
+			if srcLabel == "" {
+				srcLabel = f.SourceID
+			}
+			tgtLabel := f.TargetName
+			if tgtLabel == "" {
+				tgtLabel = f.TargetID
+			}
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				f.ID, f.Severity, triageStatus(f), f.Category, f.Title, srcLabel, tgtLabel)
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			f.ID, f.Severity, f.Category, f.Title, srcLabel, tgtLabel)
+		_ = w.Flush()
+		_, _ = fmt.Fprintf(os.Stderr, "\n%d finding(s)\n", len(findings))
 	}
-	_ = w.Flush()
-
-	_, _ = fmt.Fprintf(os.Stderr, "\n%d finding(s)\n", len(findings))
 
 	if failOn != "" {
 		threshold, ok := severityRank[failOn]
 		if !ok {
 			return fmt.Errorf("invalid --fail-on value %q: must be critical, high, medium, or low", failOn)
 		}
-		count := countAtOrAbove(findings, threshold)
+		// --fail-on ALWAYS evaluates against the non-suppressed set so an
+		// accepted-risk / false-positive never breaks CI, regardless of
+		// whether --all-findings was passed to widen the display.
+		gate := findings
+		if includeSuppressed {
+			gate, err = infra.FindingStore.ListLatestPerFingerprint(ctx, severity, false)
+			if err != nil {
+				return fmt.Errorf("query findings for fail-on: %w", err)
+			}
+		}
+		count := countAtOrAbove(gate, threshold)
 		if count > 0 {
 			_, _ = fmt.Fprintf(os.Stderr, "Failed: %d finding(s) at severity %q or above\n", count, failOn)
 			os.Exit(1)
@@ -350,4 +370,67 @@ func countAtOrAbove(findings []analysis.Finding, threshold int) int {
 		}
 	}
 	return count
+}
+
+func triageStatus(f analysis.Finding) string {
+	if f.Triage != nil && f.Triage.Status != "" {
+		return f.Triage.Status
+	}
+	return "new"
+}
+
+// runDiff compares two scans' persisted findings snapshots. By default
+// suppressed findings are dropped from the added set so CI-style diffs
+// don't re-alert on an accepted risk reappearing; --all-findings includes
+// them.
+func runDiff(ctx context.Context, diffArg, format string, includeSuppressed bool) error {
+	parts := strings.SplitN(diffArg, ",", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("--diff requires two scan IDs separated by a comma: scanA,scanB")
+	}
+	scanA, scanB := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+
+	infra, cleanup, err := Bootstrap(ctx)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	diff, err := infra.FindingStore.Diff(ctx, scanA, scanB, includeSuppressed)
+	if err != nil {
+		return fmt.Errorf("diff findings: %w", err)
+	}
+
+	if format == "json" {
+		return printJSON(diff)
+	}
+
+	printDiffSection("+ ADDED", diff.Added)
+	printDiffSection("- REMOVED", diff.Removed)
+	printDiffSection("= UNCHANGED", diff.Unchanged)
+	_, _ = fmt.Fprintf(os.Stderr, "\n+%d  -%d  =%d   (%s -> %s)\n",
+		len(diff.Added), len(diff.Removed), len(diff.Unchanged), scanA, scanB)
+	return nil
+}
+
+func printDiffSection(label string, findings []analysis.Finding) {
+	if len(findings) == 0 {
+		return
+	}
+	fmt.Printf("\n%s (%d)\n", label, len(findings))
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tSEVERITY\tCATEGORY\tTITLE\tSOURCE\tTARGET")
+	for _, f := range findings {
+		srcLabel := f.SourceName
+		if srcLabel == "" {
+			srcLabel = f.SourceID
+		}
+		tgtLabel := f.TargetName
+		if tgtLabel == "" {
+			tgtLabel = f.TargetID
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			f.ID, f.Severity, f.Category, f.Title, srcLabel, tgtLabel)
+	}
+	_ = w.Flush()
 }

--- a/server/cli/query_helpers_test.go
+++ b/server/cli/query_helpers_test.go
@@ -282,6 +282,8 @@ func newQueryCmd() *cobra.Command {
 	cmd.Flags().String("to", "", "")
 	cmd.Flags().String("format", "table", "")
 	cmd.Flags().String("fail-on", "", "")
+	cmd.Flags().Bool("all-findings", false, "")
+	cmd.Flags().String("diff", "", "")
 	return cmd
 }
 
@@ -322,7 +324,7 @@ func TestRunQuery_MultipleModes(t *testing.T) {
 }
 
 func TestRunFindings_InvalidSeverity(t *testing.T) {
-	err := runFindings(context.Background(), "bogus", "table", "")
+	err := runFindings(context.Background(), "bogus", "table", "", false)
 	if err == nil {
 		t.Fatal("expected error for invalid severity")
 	}

--- a/server/cli/serve.go
+++ b/server/cli/serve.go
@@ -42,14 +42,15 @@ var serveCmd = &cobra.Command{
 		}
 
 		server := api.NewServer(api.ServerDeps{
-			GraphDB:     infra.GraphDB,
-			Reader:      infra.Reader,
-			PGPool:      infra.PGPool,
-			Pipeline:    infra.Pipeline,
-			ScanStore:   infra.ScanStore,
-			RulesEngine: rulesEngine,
-			CORSOrigins: cfg.CORSOrigins,
-			LocalToken:  localToken,
+			GraphDB:      infra.GraphDB,
+			Reader:       infra.Reader,
+			PGPool:       infra.PGPool,
+			Pipeline:     infra.Pipeline,
+			ScanStore:    infra.ScanStore,
+			FindingStore: infra.FindingStore,
+			RulesEngine:  rulesEngine,
+			CORSOrigins:  cfg.CORSOrigins,
+			LocalToken:   localToken,
 		})
 
 		errCh := make(chan error, 1)

--- a/server/internal/analysis/findings.go
+++ b/server/internal/analysis/findings.go
@@ -75,6 +75,30 @@ var findingsMeta = map[string]struct {
 		desc:     "Tool %s has inferred access to a resource",
 		owasp:    []string{"MCP04", "ASI08"},
 	},
+	"CONFUSED_DEPUTY": {
+		category: "Authorization Confusion",
+		title:    "Confused deputy delegation",
+		desc:     "Low-auth agent delegates to higher-privileged agent %s",
+		owasp:    []string{"ASI06", "MCP04"},
+	},
+	"TAINTS": {
+		category: "Cross-Tool Taint",
+		title:    "Tool taints another tool",
+		desc:     "Untrusted-input tool shares schema with %s, tainting its inputs",
+		owasp:    []string{"MCP05", "ASI03"},
+	},
+	"IFC_VIOLATION": {
+		category: "Information Flow Violation",
+		title:    "Information-flow violation",
+		desc:     "Untrusted source reaches sensitive sink %s",
+		owasp:    []string{"MCP05", "ASI08"},
+	},
+	"POISONS_CONTEXT": {
+		category: "Context Poisoning",
+		title:    "Tool poisons agent context",
+		desc:     "Injection-bearing tool can poison high-capability tool %s",
+		owasp:    []string{"MCP05", "ASI03"},
+	},
 }
 
 const findingsQuery = `
@@ -172,9 +196,10 @@ func classifySeverity(edgeKind string, crossProtocol bool, confidence float64, t
 			return "high"
 		}
 		return "medium"
-	case "POISONED_DESCRIPTION", "SHADOWS", "POISONED_INSTRUCTIONS":
+	case "POISONED_DESCRIPTION", "SHADOWS", "POISONED_INSTRUCTIONS",
+		"CONFUSED_DEPUTY", "IFC_VIOLATION", "POISONS_CONTEXT":
 		return "high"
-	case "CAN_IMPERSONATE", "CAN_EXECUTE", "HAS_ACCESS_TO":
+	case "CAN_IMPERSONATE", "CAN_EXECUTE", "HAS_ACCESS_TO", "TAINTS":
 		return "medium"
 	default:
 		return "low"

--- a/server/internal/analysis/prebuilt/cypher.go
+++ b/server/internal/analysis/prebuilt/cypher.go
@@ -149,12 +149,18 @@ ORDER BY skill_count DESC`
 
 const CypherRugPull = `
 MATCH (s:MCPServer)-[:PROVIDES_TOOL]->(t:MCPTool)
-WHERE t.previous_description_hash IS NOT NULL
-  AND t.previous_description_hash <> t.description_hash
+WITH s, t,
+  [x IN [
+    CASE WHEN t.previous_description_hash IS NOT NULL AND t.previous_description_hash <> t.description_hash THEN 'description' END,
+    CASE WHEN t.previous_input_schema_hash IS NOT NULL AND t.previous_input_schema_hash <> t.input_schema_hash THEN 'input_schema' END,
+    CASE WHEN s.previous_instructions_hash IS NOT NULL AND s.previous_instructions_hash <> s.instructions_hash THEN 'instructions' END
+  ] WHERE x IS NOT NULL] AS changes
+WHERE size(changes) > 0
 RETURN t.name AS tool_name,
        s.name AS server_name,
        t.description_hash AS current_hash,
        t.previous_description_hash AS previous_hash,
+       reduce(acc = '', c IN changes | CASE WHEN acc = '' THEN c ELSE acc + ',' + c END) AS change_kind,
        t.objectid AS tool_id,
        s.objectid AS server_id
 ORDER BY s.name, t.name`
@@ -246,3 +252,26 @@ RETURN s.name AS server_name,
        s.objectid AS server_id,
        t.objectid AS tool_id
 ORDER BY s.name, t.name`
+
+// CypherToolNameCollision finds tools on different servers that share a
+// normalized (trimmed, lower-cased) name. A collision lets a malicious
+// server shadow a trusted tool by registering the same name — the agent may
+// invoke the wrong one. Distinct objectids ensure we compare genuinely
+// different tools; s1.objectid < s2.objectid deduplicates the (a,b)/(b,a)
+// pairing and excludes same-server matches.
+const CypherToolNameCollision = `
+MATCH (s1:MCPServer)-[:PROVIDES_TOOL]->(t1:MCPTool)
+MATCH (s2:MCPServer)-[:PROVIDES_TOOL]->(t2:MCPTool)
+WHERE s1.objectid < s2.objectid
+  AND t1.name IS NOT NULL
+  AND t2.name IS NOT NULL
+  AND toLower(trim(t1.name)) = toLower(trim(t2.name))
+  AND t1.objectid <> t2.objectid
+RETURN t1.name AS tool_name,
+       s1.name AS server_a,
+       s2.name AS server_b,
+       t1.objectid AS tool_a_id,
+       t2.objectid AS tool_b_id,
+       s1.objectid AS server_a_id,
+       s2.objectid AS server_b_id
+ORDER BY tool_name`

--- a/server/internal/analysis/prebuilt/prebuilt_test.go
+++ b/server/internal/analysis/prebuilt/prebuilt_test.go
@@ -24,9 +24,9 @@ func TestGet_InvalidID(t *testing.T) {
 
 func TestList_Count(t *testing.T) {
 	queries := List()
-	// 17 v0.1 + 1 v0.2 (litellm-credential-leak) = 18.
-	if len(queries) != 18 {
-		t.Fatalf("expected 18 pre-built queries, got %d", len(queries))
+	// 17 v0.1 + 1 v0.2 (litellm-credential-leak) + 1 (tool-name-collision) = 19.
+	if len(queries) != 19 {
+		t.Fatalf("expected 19 pre-built queries, got %d", len(queries))
 	}
 }
 

--- a/server/internal/analysis/prebuilt/queries.go
+++ b/server/internal/analysis/prebuilt/queries.go
@@ -189,6 +189,15 @@ func init() {
 			Cypher:      CypherUnpinnedShell,
 			OWASPMap:    []string{"MCP01", "MCP09", "ASI06", "ASI09"},
 		},
+		"tool-name-collision": {
+			ID:          "tool-name-collision",
+			Name:        "Cross-Server Tool Name Collisions",
+			Description: "Finds tools on different servers that share a normalized name -- a malicious server can shadow a trusted tool by reusing its name.",
+			Category:    "Vulnerabilities",
+			Severity:    "high",
+			Cypher:      CypherToolNameCollision,
+			OWASPMap:    []string{"MCP05", "ASI03"},
+		},
 	}
 }
 

--- a/server/internal/analysis/processors/auth_strength.go
+++ b/server/internal/analysis/processors/auth_strength.go
@@ -1,0 +1,64 @@
+package processors
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/server/internal/analysis/riskscore"
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+// AuthStrength materializes a numeric auth_strength property on every node
+// that carries a categorical auth_method (MCPServer, A2AAgent). Downstream
+// processors (notably confused_deputy) can then compare auth gradients
+// directly in Cypher instead of re-deriving the score map.
+//
+// Pre-pass: no dependencies, and it only updates node properties — it
+// writes no composite edges, so it needs no source_collector and is not
+// touched by the stale-edge cleanup.
+type AuthStrength struct{}
+
+func (p *AuthStrength) Name() string           { return "auth_strength" }
+func (p *AuthStrength) Dependencies() []string { return nil }
+
+func (p *AuthStrength) Process(ctx context.Context, db graph.GraphDB, _ string) (graph.ProcessingStats, error) {
+	start := time.Now()
+
+	cypher := fmt.Sprintf(`MATCH (n) WHERE n.auth_method IS NOT NULL
+SET n.auth_strength = %s
+RETURN count(n) AS updated`, authStrengthCase("n.auth_method"))
+
+	updated, err := db.ExecuteWrite(ctx, cypher, map[string]any{})
+	if err != nil {
+		return graph.ProcessingStats{ProcessorName: p.Name(), Duration: time.Since(start)}, err
+	}
+	return graph.ProcessingStats{
+		ProcessorName: p.Name(),
+		NodesUpdated:  updated,
+		Duration:      time.Since(start),
+	}, nil
+}
+
+// authStrengthCase renders a Cypher CASE expression that maps the given
+// auth_method property to its numeric strength, sourced from
+// riskscore.AuthStrengthScores so the runtime risk model and the
+// materialized node property never drift. Unknown / absent methods default
+// to 100 (treated as weakest, matching serverAuthStrength's fallback).
+func authStrengthCase(prop string) string {
+	keys := make([]string, 0, len(riskscore.AuthStrengthScores))
+	for k := range riskscore.AuthStrengthScores {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	sb.WriteString("CASE " + prop)
+	for _, k := range keys {
+		fmt.Fprintf(&sb, " WHEN '%s' THEN %g", k, riskscore.AuthStrengthScores[k])
+	}
+	sb.WriteString(" ELSE 100 END")
+	return sb.String()
+}

--- a/server/internal/analysis/processors/can_exfiltrate.go
+++ b/server/internal/analysis/processors/can_exfiltrate.go
@@ -19,7 +19,7 @@ func (p *CanExfiltrate) Process(ctx context.Context, db graph.GraphDB, scanID st
 MATCH (a:AgentInstance)-[:CAN_REACH]->(r:MCPResource)
 WHERE r.sensitivity IN ['critical', 'high']
 MATCH (a)-[:TRUSTS_SERVER]->(s:MCPServer)-[:PROVIDES_TOOL]->(outbound:MCPTool)
-WHERE ANY(cap IN outbound.capability_surface WHERE cap IN ['email_send', 'network_outbound', 'file_write'])
+WHERE ANY(cap IN outbound.capability_surface WHERE cap IN ['email_send', 'network_outbound', 'file_write', 'auto_fetch_render', 'allowlisted_proxy'])
       AND NOT EXISTS((a)-[:CAN_EXFILTRATE_VIA]->(outbound))
 MERGE (a)-[e:CAN_EXFILTRATE_VIA]->(outbound)
 SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true, e.source_collector = 'mcp',

--- a/server/internal/analysis/processors/confused_deputy.go
+++ b/server/internal/analysis/processors/confused_deputy.go
@@ -1,0 +1,58 @@
+package processors
+
+import (
+	"context"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+// ConfusedDeputy flags A2A delegation where a weakly-authenticated agent
+// can drive a strongly-authenticated one — a classic confused-deputy
+// escalation: the anonymous/low-trust caller borrows the high-trust agent's
+// privileges through the DELEGATES_TO edge.
+//
+// auth_strength is the numeric weakness score materialized by the
+// auth_strength pre-pass (higher = weaker). low.auth_strength >= 80 picks
+// out none/apiKey-class callers; high.auth_strength <= 30 picks out
+// oauth/mtls-class callees.
+type ConfusedDeputy struct{}
+
+func (p *ConfusedDeputy) Name() string { return "confused_deputy" }
+
+// Depends on auth_strength (provides the numeric scores this query
+// compares) and can_reach (so it runs in the late reachability phase
+// alongside the other escalation detectors).
+func (p *ConfusedDeputy) Dependencies() []string {
+	return []string{"auth_strength", "can_reach"}
+}
+
+func (p *ConfusedDeputy) Process(ctx context.Context, db graph.GraphDB, scanID string) (graph.ProcessingStats, error) {
+	start := time.Now()
+
+	// source_collector='a2a': a real collector in AllowedCollectors, so the
+	// edge participates in stale-edge cleanup directly (no expand mapping).
+	cypher := `
+MATCH (low:A2AAgent)-[:DELEGATES_TO]->(high:A2AAgent)
+WHERE low.auth_strength >= 80 AND high.auth_strength <= 30
+MERGE (low)-[e:CONFUSED_DEPUTY]->(high)
+SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
+    e.source_collector = 'a2a',
+    e.low_auth_method = low.auth_method,
+    e.high_auth_method = high.auth_method,
+    e.confidence = 0.8, e.risk_weight = 0.3
+RETURN count(*) AS written`
+
+	n, err := db.ExecuteWrite(ctx, cypher, map[string]any{"scan_id": scanID})
+	if err != nil {
+		return graph.ProcessingStats{
+			ProcessorName: p.Name(),
+			Duration:      time.Since(start),
+		}, err
+	}
+	return graph.ProcessingStats{
+		ProcessorName: p.Name(),
+		EdgesCreated:  n,
+		Duration:      time.Since(start),
+	}, nil
+}

--- a/server/internal/analysis/processors/cross_service_credential_chain.go
+++ b/server/internal/analysis/processors/cross_service_credential_chain.go
@@ -52,6 +52,13 @@ func (p *CrossServiceCredentialChain) Process(ctx context.Context, db graph.Grap
 	// hand-loaded test fixtures where both nodes happen to share an
 	// objectid; in real graphs they always have different objectids
 	// because the Config Collector and Looter compute IDs differently).
+	// Single query (one ExecuteWrite): the same agent→server→credential
+	// join also yields the credential blast radius (count of distinct
+	// agents that can reach the merged secret), which we materialize on
+	// both the env-var credential (c1) and its value_hash-merged master
+	// (c1master). Folding it here avoids re-MATCHing the join path. The
+	// agents are collected for the count, then re-UNWOUND so the CAN_REACH
+	// MERGE stays one edge per (agent, upstream-credential) as before.
 	cypher := `
 MATCH (a:AgentInstance)-[:TRUSTS_SERVER]->(s:MCPServer)
       -[:HAS_ENV_VAR]->(c1:Credential)
@@ -60,6 +67,11 @@ MATCH (gw:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(c1master:Credential)
 WHERE c1master.value_hash = c1.value_hash AND c1master.objectid <> c1.objectid
 MATCH (gw)-[:EXPOSES_CREDENTIAL]->(c2:Credential)
 WHERE c2.type IN ['apiKey', 'virtual_key'] AND c2.objectid <> c1master.objectid
+WITH s, c1, c1master, c2, gw, collect(DISTINCT a) AS agents
+WITH s, c1, c1master, c2, gw, agents, size(agents) AS reachable_agents
+SET c1.blast_radius = reachable_agents, c1master.blast_radius = reachable_agents
+WITH s, c1, c1master, c2, gw, agents
+UNWIND agents AS a
 MERGE (a)-[e:CAN_REACH]->(c2)
 SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
     e.source_collector = 'cross_service_credential_chain',

--- a/server/internal/analysis/processors/ifc_violation.go
+++ b/server/internal/analysis/processors/ifc_violation.go
@@ -1,0 +1,53 @@
+package processors
+
+import (
+	"context"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+// IfcViolation flags an information-flow-control violation: a tool that
+// ingests untrusted input shares a resource (within 3 HAS_ACCESS_TO hops)
+// with a tool wielding a high-impact capability (credential access, file
+// write, email send). Untrusted data can thus flow into a sensitive sink.
+//
+// The 1..3 hop cap is the false-positive / performance guard — without it
+// the resource-sharing join explodes on dense graphs.
+type IfcViolation struct{}
+
+func (p *IfcViolation) Name() string { return "ifc_violation" }
+
+// Depends on has_access_to (the tool→resource accessibility edges this
+// query traverses). INGESTS_UNTRUSTED is a raw collector edge, present
+// from ingest, so it needs no processor dependency.
+func (p *IfcViolation) Dependencies() []string { return []string{"has_access_to"} }
+
+func (p *IfcViolation) Process(ctx context.Context, db graph.GraphDB, scanID string) (graph.ProcessingStats, error) {
+	start := time.Now()
+
+	// source_collector='mcp' (a real collector): the edge participates in
+	// stale-edge cleanup whenever the mcp collector re-runs. See
+	// docs/architecture/post-processors.md for the cleanup-only-on-mcp note.
+	cypher := `
+MATCH (untrusted:MCPTool)-[:INGESTS_UNTRUSTED]->(:MCPResource)<-[:HAS_ACCESS_TO*1..3]-(sensitive:MCPTool)
+WHERE untrusted <> sensitive
+  AND any(cap IN sensitive.capability_surface WHERE cap IN ['credential_access', 'file_write', 'email_send'])
+MERGE (untrusted)-[e:IFC_VIOLATION]->(sensitive)
+SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
+    e.source_collector = 'mcp', e.confidence = 0.6, e.risk_weight = 0.3
+RETURN count(*) AS written`
+
+	n, err := db.ExecuteWrite(ctx, cypher, map[string]any{"scan_id": scanID})
+	if err != nil {
+		return graph.ProcessingStats{
+			ProcessorName: p.Name(),
+			Duration:      time.Since(start),
+		}, err
+	}
+	return graph.ProcessingStats{
+		ProcessorName: p.Name(),
+		EdgesCreated:  n,
+		Duration:      time.Since(start),
+	}, nil
+}

--- a/server/internal/analysis/processors/shadows.go
+++ b/server/internal/analysis/processors/shadows.go
@@ -25,7 +25,7 @@ func (p *Shadows) Process(ctx context.Context, db graph.GraphDB, scanID string) 
 	// has_cross_references still feeds tool risk scoring as a node
 	// property (server/internal/analysis/riskscore/tool.go); it just no
 	// longer manufactures SHADOWS edges.
-	cypher := `
+	shadowsCypher := `
 MATCH (s1:MCPServer)-[:PROVIDES_TOOL]->(t1:MCPTool),
       (s2:MCPServer)-[:PROVIDES_TOOL]->(t2:MCPTool)
 WHERE s1 <> s2
@@ -44,7 +44,7 @@ ON MATCH SET  e.scan_id = $scan_id,
               e.last_seen = datetime()
 RETURN count(*) AS written`
 
-	n, err := db.ExecuteWrite(ctx, cypher, map[string]any{"scan_id": scanID})
+	shadowsN, err := db.ExecuteWrite(ctx, shadowsCypher, map[string]any{"scan_id": scanID})
 	if err != nil {
 		return graph.ProcessingStats{
 			ProcessorName: p.Name(),
@@ -52,9 +52,39 @@ RETURN count(*) AS written`
 		}, err
 	}
 
+	// POISONS_CONTEXT is the deliberate widening of the narrow SHADOWS
+	// guard above: an injection-bearing tool can poison the shared agent
+	// context that drives a high-capability tool, even without naming it.
+	// To keep that breadth from exploding into a cartesian product, the
+	// fan-out is capped at 20 sinks per source tool. With the perf-check
+	// ceiling of 200 poisoned pairs per agent, an agent maxes out at 10
+	// source tools * 20 sinks = 200 (see scripts/perf-check.sh).
+	poisonsCypher := `
+MATCH (src:MCPTool)
+WHERE src.has_injection_patterns = true
+MATCH (snk:MCPTool)
+WHERE src <> snk
+  AND any(cap IN snk.capability_surface WHERE cap IN ['shell_access', 'code_execution', 'credential_access', 'email_send'])
+WITH src, collect(DISTINCT snk) AS sinks
+WHERE size(sinks) <= 20
+UNWIND sinks AS snk
+MERGE (src)-[e:POISONS_CONTEXT]->(snk)
+SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
+    e.source_collector = 'mcp', e.confidence = 0.6, e.risk_weight = 0.4
+RETURN count(*) AS written`
+
+	poisonsN, err := db.ExecuteWrite(ctx, poisonsCypher, map[string]any{"scan_id": scanID})
+	if err != nil {
+		return graph.ProcessingStats{
+			ProcessorName: p.Name(),
+			EdgesCreated:  shadowsN,
+			Duration:      time.Since(start),
+		}, err
+	}
+
 	return graph.ProcessingStats{
 		ProcessorName: p.Name(),
-		EdgesCreated:  n,
+		EdgesCreated:  shadowsN + poisonsN,
 		Duration:      time.Since(start),
 	}, nil
 }

--- a/server/internal/analysis/processors/shadows_test.go
+++ b/server/internal/analysis/processors/shadows_test.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/adithyan-ak/agenthound/server/internal/graph"
@@ -33,19 +34,32 @@ func TestShadows_ProcessSuccess(t *testing.T) {
 	if stats.ProcessorName != "shadows" {
 		t.Errorf("ProcessorName = %q", stats.ProcessorName)
 	}
-	if stats.EdgesCreated != 2 {
-		t.Errorf("EdgesCreated = %d, want 2", stats.EdgesCreated)
+	// Two ExecuteWrite passes now run: SHADOWS, then POISONS_CONTEXT. The
+	// mock returns 2 for each, so EdgesCreated sums to 4.
+	if stats.EdgesCreated != 4 {
+		t.Errorf("EdgesCreated = %d, want 4 (SHADOWS + POISONS_CONTEXT)", stats.EdgesCreated)
 	}
 
 	calls := mock.CallsTo("ExecuteWrite")
-	if len(calls) != 1 {
-		t.Fatalf("ExecuteWrite called %d times, want 1", len(calls))
+	if len(calls) != 2 {
+		t.Fatalf("ExecuteWrite called %d times, want 2 (SHADOWS + POISONS_CONTEXT)", len(calls))
 	}
 	params, _ := calls[0].Args[1].(map[string]any)
 	if params["scan_id"] != "scan-1" {
 		t.Errorf("scan_id = %v, want scan-1", params["scan_id"])
 	}
+
+	shadowsCypher, _ := calls[0].Args[0].(string)
+	if !contains(shadowsCypher, "SHADOWS") {
+		t.Errorf("first pass should emit SHADOWS, got:\n%s", shadowsCypher)
+	}
+	poisonsCypher, _ := calls[1].Args[0].(string)
+	if !contains(poisonsCypher, "POISONS_CONTEXT") {
+		t.Errorf("second pass should emit POISONS_CONTEXT, got:\n%s", poisonsCypher)
+	}
 }
+
+func contains(s, sub string) bool { return strings.Contains(s, sub) }
 
 func TestShadows_ProcessError(t *testing.T) {
 	mock := &graph.MockGraphDB{ExecuteWriteError: errors.New("db error")}

--- a/server/internal/analysis/processors/taints.go
+++ b/server/internal/analysis/processors/taints.go
@@ -1,0 +1,56 @@
+package processors
+
+import (
+	"context"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+// Taints emits a TAINTS edge (MCPTool -> MCPTool) when a tool that ingests
+// untrusted input shares enough of its input schema with a tool on another
+// server that attacker-controlled data could flow from the first into the
+// second. The schema_keys node property (emitted collector-side) lets the
+// overlap be computed in pure Cypher with no APOC dependency.
+//
+// The >= 2 shared-key threshold avoids matching every {type, name} pair —
+// a single common key like "id" is not signal.
+type Taints struct{}
+
+func (p *Taints) Name() string { return "taints" }
+
+// No processor dependencies: it reads only raw INGESTS_UNTRUSTED edges and
+// the schema_keys / source_trust node properties, all present from ingest.
+func (p *Taints) Dependencies() []string { return nil }
+
+func (p *Taints) Process(ctx context.Context, db graph.GraphDB, scanID string) (graph.ProcessingStats, error) {
+	start := time.Now()
+
+	cypher := `
+MATCH (s1:MCPServer)-[:PROVIDES_TOOL]->(src:MCPTool)
+MATCH (s2:MCPServer)-[:PROVIDES_TOOL]->(snk:MCPTool)
+WHERE s1 <> s2
+  AND src <> snk
+  AND src.schema_keys IS NOT NULL
+  AND snk.schema_keys IS NOT NULL
+  AND size([k IN src.schema_keys WHERE k IN snk.schema_keys]) >= 2
+  AND ((src)-[:INGESTS_UNTRUSTED]->(:MCPResource)
+       OR src.source_trust = 'private')
+MERGE (src)-[e:TAINTS]->(snk)
+SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
+    e.source_collector = 'mcp', e.confidence = 0.7, e.risk_weight = 0.3
+RETURN count(*) AS written`
+
+	n, err := db.ExecuteWrite(ctx, cypher, map[string]any{"scan_id": scanID})
+	if err != nil {
+		return graph.ProcessingStats{
+			ProcessorName: p.Name(),
+			Duration:      time.Since(start),
+		}, err
+	}
+	return graph.ProcessingStats{
+		ProcessorName: p.Name(),
+		EdgesCreated:  n,
+		Duration:      time.Since(start),
+	}, nil
+}

--- a/server/internal/analysis/registry.go
+++ b/server/internal/analysis/registry.go
@@ -4,11 +4,18 @@ import "github.com/adithyan-ak/agenthound/server/internal/analysis/processors"
 
 func allProcessors() []PostProcessor {
 	return []PostProcessor{
+		// auth_strength is a pre-pass: it materializes a numeric
+		// auth_strength node property that confused_deputy compares in
+		// Cypher. No deps; must run before any processor that reads it.
+		&processors.AuthStrength{},
 		&processors.HasAccessTo{},
 		&processors.CanExecute{},
 		&processors.Shadows{},
 		&processors.PoisonedDescription{},
 		&processors.PoisonedInstructions{},
+		// taints runs before can_reach so its cross-tool taint edges can
+		// influence the transitive reachability walk.
+		&processors.Taints{},
 		&processors.CanReach{},
 		// CrossServiceCredentialChain depends on can_reach and emits
 		// CAN_REACH edges that span Config Collector + LiteLLM Looter
@@ -17,8 +24,13 @@ func allProcessors() []PostProcessor {
 		// description; design rationale in
 		// docs/plans/sprint3-offensive-primitives.md 3.7 + 4.5.
 		&processors.CrossServiceCredentialChain{},
+		// ifc_violation reads HAS_ACCESS_TO paths populated earlier and the
+		// raw INGESTS_UNTRUSTED edges; runs after the credential chain,
+		// before the exfiltration detector.
+		&processors.IfcViolation{},
 		&processors.CanExfiltrate{},
 		&processors.CanImpersonate{},
+		&processors.ConfusedDeputy{},
 		&processors.CrossProtocol{},
 		&processors.RiskScore{},
 	}

--- a/server/internal/analysis/riskscore/a2a_agent.go
+++ b/server/internal/analysis/riskscore/a2a_agent.go
@@ -39,7 +39,7 @@ func a2aAuthStrength(ctx context.Context, db graph.GraphDB, objectID string) (fl
 		return 100, nil
 	}
 	am, _ := rows[0]["am"].(string)
-	if s, ok := authStrengthScores[am]; ok {
+	if s, ok := AuthStrengthScores[am]; ok {
 		return s, nil
 	}
 	return 100, nil

--- a/server/internal/analysis/riskscore/server.go
+++ b/server/internal/analysis/riskscore/server.go
@@ -7,7 +7,11 @@ import (
 	"github.com/adithyan-ak/agenthound/server/internal/graph"
 )
 
-var authStrengthScores = map[string]float64{
+// AuthStrengthScores maps a categorical auth_method to a numeric weakness
+// score (higher = weaker). Exported so the auth_strength post-processor can
+// materialize the same scores onto :MCPServer / :A2AAgent nodes as a Cypher
+// CASE without the two definitions drifting.
+var AuthStrengthScores = map[string]float64{
 	"none":   100,
 	"apiKey": 70,
 	"bearer": 50,
@@ -47,7 +51,7 @@ func serverAuthStrength(ctx context.Context, db graph.GraphDB, objectID string) 
 		return 100, nil
 	}
 	am, _ := rows[0]["am"].(string)
-	if s, ok := authStrengthScores[am]; ok {
+	if s, ok := AuthStrengthScores[am]; ok {
 		return s, nil
 	}
 	return 100, nil
@@ -110,7 +114,7 @@ RETURN h.is_public AS pub, h.is_private AS priv, h.is_local AS loc`
 func serverCredentialHandling(ctx context.Context, db graph.GraphDB, objectID string) (float64, error) {
 	cypher := `
 MATCH (s {objectid: $id})-[:HAS_ENV_VAR]->(c:Credential)
-RETURN c.high_entropy AS high_entropy, c.type AS cred_type`
+RETURN c.high_entropy AS high_entropy, c.type AS cred_type, c.blast_radius AS blast_radius`
 
 	rows, err := db.Query(ctx, cypher, map[string]any{"id": objectID})
 	if err != nil {
@@ -120,13 +124,24 @@ RETURN c.high_entropy AS high_entropy, c.type AS cred_type`
 		return 0, nil
 	}
 
+	// base captures intrinsic handling risk (high-entropy / hardcoded
+	// secrets max it out). blast amplifies it by how many distinct agents
+	// can reach the secret (materialized as Credential.blast_radius by the
+	// cross_service_credential_chain processor), mirroring a2aBlastRadius.
+	base := 50.0
+	var blast float64
 	for _, row := range rows {
 		if he, ok := row["high_entropy"].(bool); ok && he {
-			return 100, nil
+			base = 100
 		}
 		if ct, ok := row["cred_type"].(string); ok && ct == "hardcoded" {
-			return 100, nil
+			base = 100
+		}
+		if br := toInt64(row["blast_radius"]); br > 0 {
+			if b := math.Min(float64(br)*10, 100); b > blast {
+				blast = b
+			}
 		}
 	}
-	return 50, nil
+	return math.Max(base, blast), nil
 }

--- a/server/internal/api/handlers/analysis.go
+++ b/server/internal/api/handlers/analysis.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -10,16 +11,33 @@ import (
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 	"github.com/adithyan-ak/agenthound/server/internal/analysis"
 	"github.com/adithyan-ak/agenthound/server/internal/analysis/prebuilt"
+	"github.com/adithyan-ak/agenthound/server/internal/appdb"
 	"github.com/adithyan-ak/agenthound/server/internal/graph"
+	"github.com/adithyan-ak/agenthound/server/model"
 	"github.com/go-chi/chi/v5"
 )
 
-type AnalysisHandler struct {
-	graphDB graph.GraphDB
+// findingLister is the subset of *appdb.FindingStore that the findings
+// endpoint reads from. When nil (e.g. in unit tests without Postgres),
+// HandleFindings falls back to live composite edges in the graph.
+type findingLister interface {
+	ListLatestPerFingerprint(ctx context.Context, severity string, includeSuppressed bool) ([]model.Finding, error)
 }
 
-func NewAnalysisHandler(db graph.GraphDB) *AnalysisHandler {
-	return &AnalysisHandler{graphDB: db}
+type AnalysisHandler struct {
+	graphDB      graph.GraphDB
+	findingStore findingLister
+}
+
+func NewAnalysisHandler(db graph.GraphDB, findingStore *appdb.FindingStore) *AnalysisHandler {
+	h := &AnalysisHandler{graphDB: db}
+	// Avoid the typed-nil-into-interface trap: only populate the
+	// interface field when the concrete pointer is non-nil so the
+	// `h.findingStore != nil` fallback check stays correct.
+	if findingStore != nil {
+		h.findingStore = findingStore
+	}
+	return h
 }
 
 var allowedNodeLabels = func() map[string]bool {
@@ -303,14 +321,26 @@ func (h *AnalysisHandler) HandleWeightedPath(w http.ResponseWriter, r *http.Requ
 
 func (h *AnalysisHandler) HandleFindings(w http.ResponseWriter, r *http.Request) {
 	severity := r.URL.Query().Get("severity")
+	includeSuppressed := r.URL.Query().Get("include_suppressed") == "true"
 
-	findings, err := analysis.QueryFindings(r.Context(), h.graphDB, severity)
+	var findings []model.Finding
+	var err error
+	if h.findingStore != nil {
+		// Default data source: the persisted per-scan snapshot, with
+		// triage state joined in and suppressed findings hidden unless
+		// include_suppressed=true.
+		findings, err = h.findingStore.ListLatestPerFingerprint(r.Context(), severity, includeSuppressed)
+	} else {
+		// Fallback for setups without a Postgres snapshot (unit tests):
+		// read live composite edges directly from the graph.
+		findings, err = analysis.QueryFindings(r.Context(), h.graphDB, severity)
+	}
 	if err != nil {
 		WriteInternalError(w, r, fmt.Errorf("findings query: %w", err))
 		return
 	}
 	if findings == nil {
-		findings = []analysis.Finding{}
+		findings = []model.Finding{}
 	}
 	WriteJSON(w, http.StatusOK, findings)
 }

--- a/server/internal/api/handlers/analysis_security_test.go
+++ b/server/internal/api/handlers/analysis_security_test.go
@@ -22,7 +22,7 @@ func TestCypherInjectionViaNodeKind(t *testing.T) {
 	}
 
 	mock := &graph.MockGraphDB{}
-	h := NewAnalysisHandler(mock)
+	h := NewAnalysisHandler(mock, nil)
 
 	for _, kind := range injections {
 		t.Run(kind, func(t *testing.T) {
@@ -79,7 +79,7 @@ func TestValidNodeKindAcceptsAllLabels(t *testing.T) {
 
 func TestCypherInjectionViaTargetKind(t *testing.T) {
 	mock := &graph.MockGraphDB{}
-	h := NewAnalysisHandler(mock)
+	h := NewAnalysisHandler(mock, nil)
 
 	body := `{"source":"test","source_kind":"MCPServer","target":"x","target_kind":"MCPTool' OR 1=1--"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/analysis/shortest-path", strings.NewReader(body))

--- a/server/internal/api/handlers/analysis_test.go
+++ b/server/internal/api/handlers/analysis_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHandleShortestPath_MissingSource(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodPost, "/api/v1/analysis/shortest-path", []byte(`{}`))
 	h.HandleShortestPath(w, r)
@@ -33,7 +33,7 @@ func TestHandleShortestPath_MissingSource(t *testing.T) {
 }
 
 func TestHandleShortestPath_InvalidKind(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodPost, "/api/v1/analysis/shortest-path",
 		[]byte(`{"source":"x","source_kind":"INVALID"}`))
@@ -45,7 +45,7 @@ func TestHandleShortestPath_InvalidKind(t *testing.T) {
 }
 
 func TestHandleFindings_Empty(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{queryResult: nil})
+	h := NewAnalysisHandler(&mockGraphDB{queryResult: nil}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings", nil)
 	h.HandleFindings(w, r)
@@ -63,7 +63,7 @@ func TestHandleFindings_Empty(t *testing.T) {
 }
 
 func TestHandleListPreBuilt(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodGet, "/api/v1/analysis/prebuilt", nil)
 	h.HandleListPreBuilt(w, r)
@@ -75,13 +75,13 @@ func TestHandleListPreBuilt(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&queries); err != nil {
 		t.Fatal(err)
 	}
-	if len(queries) != 18 {
-		t.Fatalf("expected 18 pre-built queries, got %d", len(queries))
+	if len(queries) != 19 {
+		t.Fatalf("expected 19 pre-built queries, got %d", len(queries))
 	}
 }
 
 func TestHandlePreBuilt_NotFound(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	router := chi.NewRouter()
 	router.Get("/api/v1/analysis/prebuilt/{id}", h.HandlePreBuilt)
 
@@ -191,7 +191,7 @@ func TestClamp(t *testing.T) {
 }
 
 func TestHandleAllPaths_MissingSource(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodPost, "/api/v1/analysis/all-paths", []byte(`{}`))
 	h.HandleAllPaths(w, r)
@@ -209,7 +209,7 @@ func TestHandleAllPaths_MissingSource(t *testing.T) {
 }
 
 func TestHandleWeightedPath_MissingFields(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodPost, "/api/v1/analysis/weighted-path", []byte(`{}`))
 	h.HandleWeightedPath(w, r)
@@ -276,7 +276,7 @@ func TestHandleFindingDetail_Success(t *testing.T) {
 			return []map[string]any{pathRow()}, nil
 		},
 	}
-	h := NewAnalysisHandler(mock)
+	h := NewAnalysisHandler(mock, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings/"+testFindingID, nil)
 	r = withChiURLParam(r, "id", testFindingID)
@@ -307,7 +307,7 @@ func TestHandleFindingDetail_Success(t *testing.T) {
 }
 
 func TestHandleFindingDetail_InvalidID_TooShort(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings/abc123", nil)
 	r = withChiURLParam(r, "id", "abc123")
@@ -326,7 +326,7 @@ func TestHandleFindingDetail_InvalidID_TooShort(t *testing.T) {
 }
 
 func TestHandleFindingDetail_InvalidID_NonHex(t *testing.T) {
-	h := NewAnalysisHandler(&mockGraphDB{})
+	h := NewAnalysisHandler(&mockGraphDB{}, nil)
 	w := httptest.NewRecorder()
 	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings/zzzzzzzzzzzzzzzz", nil)
 	r = withChiURLParam(r, "id", "zzzzzzzzzzzzzzzz")
@@ -350,7 +350,7 @@ func TestHandleFindingDetail_NotFound(t *testing.T) {
 			return nil, nil
 		},
 	}
-	h := NewAnalysisHandler(mock)
+	h := NewAnalysisHandler(mock, nil)
 	w := httptest.NewRecorder()
 	validHexID := "aabbccdd11223344"
 	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings/"+validHexID, nil)
@@ -375,7 +375,7 @@ func TestHandleFindingDetail_QueryError(t *testing.T) {
 			return nil, errors.New("neo4j connection refused")
 		},
 	}
-	h := NewAnalysisHandler(mock)
+	h := NewAnalysisHandler(mock, nil)
 	w := httptest.NewRecorder()
 	validHexID := "aabbccdd11223344"
 	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings/"+validHexID, nil)

--- a/server/internal/api/handlers/analysis_test.go
+++ b/server/internal/api/handlers/analysis_test.go
@@ -11,8 +11,66 @@ import (
 
 	"github.com/adithyan-ak/agenthound/server/internal/analysis"
 	"github.com/adithyan-ak/agenthound/server/internal/graph"
+	"github.com/adithyan-ak/agenthound/server/model"
 	"github.com/go-chi/chi/v5"
 )
+
+// recordingFindingLister captures the args HandleFindings forwards to the
+// snapshot store so the ?include_suppressed / ?severity plumbing can be
+// asserted at the handler layer without a database.
+type recordingFindingLister struct {
+	gotSeverity   string
+	gotSuppressed bool
+	findings      []model.Finding
+}
+
+func (m *recordingFindingLister) ListLatestPerFingerprint(_ context.Context, severity string, includeSuppressed bool) ([]model.Finding, error) {
+	m.gotSeverity = severity
+	m.gotSuppressed = includeSuppressed
+	return m.findings, nil
+}
+
+func TestHandleFindings_SuppressedHiddenByDefault(t *testing.T) {
+	mock := &recordingFindingLister{findings: []model.Finding{{ID: "aaaaaaaaaaaaaaaa", Severity: "high"}}}
+	h := &AnalysisHandler{findingStore: mock}
+	w := httptest.NewRecorder()
+	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings", nil)
+	h.HandleFindings(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if mock.gotSuppressed {
+		t.Error("default findings request must pass includeSuppressed=false")
+	}
+}
+
+func TestHandleFindings_IncludeSuppressedTrue(t *testing.T) {
+	mock := &recordingFindingLister{}
+	h := &AnalysisHandler{findingStore: mock}
+	w := httptest.NewRecorder()
+	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings?include_suppressed=true", nil)
+	h.HandleFindings(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !mock.gotSuppressed {
+		t.Error("?include_suppressed=true must pass includeSuppressed=true to the store")
+	}
+}
+
+func TestHandleFindings_SeverityForwarded(t *testing.T) {
+	mock := &recordingFindingLister{}
+	h := &AnalysisHandler{findingStore: mock}
+	w := httptest.NewRecorder()
+	r := newTestRequest(http.MethodGet, "/api/v1/analysis/findings?severity=critical", nil)
+	h.HandleFindings(w, r)
+
+	if mock.gotSeverity != "critical" {
+		t.Errorf("severity filter not forwarded: got %q", mock.gotSeverity)
+	}
+}
 
 func TestHandleShortestPath_MissingSource(t *testing.T) {
 	h := NewAnalysisHandler(&mockGraphDB{}, nil)

--- a/server/internal/api/handlers/openapi.yaml
+++ b/server/internal/api/handlers/openapi.yaml
@@ -296,6 +296,36 @@ components:
           type: array
           items:
             type: string
+        triage:
+          allOf:
+            - $ref: "#/components/schemas/TriageState"
+          nullable: true
+          description: >-
+            Inline triage state for this finding (omitted when no decision
+            has been recorded). Lets the register render the triage control
+            without a per-row round-trip.
+
+    TriageState:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [new, triaging, confirmed, accepted-risk, false-positive]
+        note:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+
+    TriageUpdateRequest:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [new, triaging, confirmed, accepted-risk, false-positive]
+        note:
+          type: string
 
     FindingDetail:
       type: object
@@ -842,7 +872,11 @@ paths:
   /analysis/findings:
     get:
       summary: Security findings
-      description: List all composite edges as security findings.
+      description: >-
+        List findings from the latest persisted snapshot (one row per
+        fingerprint), each with inline triage state. Findings triaged as
+        `accepted-risk` or `false-positive` are hidden unless
+        `include_suppressed=true`.
       operationId: getFindings
       tags: [Analysis]
       parameters:
@@ -851,6 +885,12 @@ paths:
           schema:
             type: string
             enum: [critical, high, medium, low]
+        - name: include_suppressed
+          in: query
+          description: When true, include accepted-risk / false-positive findings.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: Findings list
@@ -860,6 +900,66 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Finding"
+
+  /findings/triage/{fingerprint}:
+    get:
+      summary: Get finding triage state
+      description: >-
+        Returns the cross-scan triage decision for a finding fingerprint.
+        Open read. A fingerprint with no recorded decision returns the
+        implicit `new` state.
+      operationId: getTriage
+      tags: [Analysis]
+      parameters:
+        - name: fingerprint
+          in: path
+          required: true
+          schema:
+            type: string
+          description: 16-character hex finding fingerprint
+      responses:
+        "200":
+          description: Triage state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TriageState"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+    put:
+      summary: Set finding triage state
+      description: >-
+        Records (or updates) the triage decision for a finding fingerprint.
+        Triage state has no foreign key to findings, so it survives scan
+        deletion and re-detection.
+      operationId: setTriage
+      tags: [Analysis]
+      security:
+        - LocalhostToken: []
+      parameters:
+        - name: fingerprint
+          in: path
+          required: true
+          schema:
+            type: string
+          description: 16-character hex finding fingerprint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TriageUpdateRequest"
+      responses:
+        "200":
+          description: Updated triage state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TriageState"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
   /analysis/findings/{id}:
     get:
@@ -886,7 +986,7 @@ paths:
   /analysis/prebuilt:
     get:
       summary: List pre-built queries
-      description: Returns metadata for all 18 pre-built security queries.
+      description: Returns metadata for all 19 pre-built security queries.
       operationId: listPreBuilt
       tags: [Analysis]
       responses:

--- a/server/internal/api/handlers/triage.go
+++ b/server/internal/api/handlers/triage.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/adithyan-ak/agenthound/server/internal/appdb"
+	"github.com/adithyan-ak/agenthound/server/model"
+	"github.com/go-chi/chi/v5"
+)
+
+// triageStore is the subset of *appdb.FindingStore the triage handler
+// needs. Defined as an interface so the handler can be unit-tested with a
+// recorder and so a nil store degrades to a clean 503.
+type triageStore interface {
+	GetTriage(ctx context.Context, fingerprint string) (*model.TriageState, error)
+	UpsertTriage(ctx context.Context, fingerprint, status, note string) (*model.TriageState, error)
+}
+
+type TriageHandler struct {
+	store triageStore
+}
+
+func NewTriageHandler(store *appdb.FindingStore) *TriageHandler {
+	h := &TriageHandler{}
+	// Avoid the typed-nil-into-interface trap so the `h.store == nil`
+	// guards in the handlers behave correctly when no store is wired.
+	if store != nil {
+		h.store = store
+	}
+	return h
+}
+
+// validTriageStatuses mirrors the SQL CHECK on finding_triage.status and
+// the UI TriageStatus enum (server/ui/src/shared/model/triage.ts).
+var validTriageStatuses = map[string]bool{
+	"new":            true,
+	"triaging":       true,
+	"confirmed":      true,
+	"accepted-risk":  true,
+	"false-positive": true,
+}
+
+// HandleGet returns the triage state for a finding fingerprint. Open read.
+// A fingerprint with no recorded decision returns the implicit "new" state.
+func (h *TriageHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
+	fp := chi.URLParam(r, "fingerprint")
+	if !validFingerprint(fp) {
+		WriteValidationError(w, "fingerprint must be a 16-character hex string")
+		return
+	}
+	if h.store == nil {
+		WriteServiceError(w, "triage store")
+		return
+	}
+
+	ts, err := h.store.GetTriage(r.Context(), fp)
+	if err != nil {
+		WriteInternalError(w, r, fmt.Errorf("get triage: %w", err))
+		return
+	}
+	if ts == nil {
+		ts = &model.TriageState{Status: "new"}
+	}
+	WriteJSON(w, http.StatusOK, ts)
+}
+
+type triageUpdateRequest struct {
+	Status string `json:"status"`
+	Note   string `json:"note"`
+}
+
+// HandleSet records (or updates) the triage decision for a fingerprint.
+// Gated by the LocalToken middleware (mutating endpoint).
+func (h *TriageHandler) HandleSet(w http.ResponseWriter, r *http.Request) {
+	fp := chi.URLParam(r, "fingerprint")
+	if !validFingerprint(fp) {
+		WriteValidationError(w, "fingerprint must be a 16-character hex string")
+		return
+	}
+
+	var req triageUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteValidationError(w, "invalid JSON: "+err.Error())
+		return
+	}
+	if !validTriageStatuses[req.Status] {
+		WriteValidationError(w, "invalid status; must be one of: new, triaging, confirmed, accepted-risk, false-positive")
+		return
+	}
+	if h.store == nil {
+		WriteServiceError(w, "triage store")
+		return
+	}
+
+	ts, err := h.store.UpsertTriage(r.Context(), fp, req.Status, req.Note)
+	if err != nil {
+		WriteInternalError(w, r, fmt.Errorf("upsert triage: %w", err))
+		return
+	}
+	WriteJSON(w, http.StatusOK, ts)
+}
+
+// validFingerprint reports whether s is a 16-character lowercase-hex
+// finding fingerprint (the form produced by analysis.findingFingerprint).
+func validFingerprint(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/api/handlers/triage.go
+++ b/server/internal/api/handlers/triage.go
@@ -72,6 +72,14 @@ type triageUpdateRequest struct {
 	Note   string `json:"note"`
 }
 
+// maxTriageBodySize bounds the PUT body (a tiny {status, note} JSON);
+// mirrors the ingest handler's MaxBytesReader guard. maxTriageNoteLen caps
+// the note so a single field cannot bloat the finding_triage table.
+const (
+	maxTriageBodySize = 64 << 10 // 64 KB
+	maxTriageNoteLen  = 4096
+)
+
 // HandleSet records (or updates) the triage decision for a fingerprint.
 // Gated by the LocalToken middleware (mutating endpoint).
 func (h *TriageHandler) HandleSet(w http.ResponseWriter, r *http.Request) {
@@ -81,6 +89,7 @@ func (h *TriageHandler) HandleSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxTriageBodySize)
 	var req triageUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		WriteValidationError(w, "invalid JSON: "+err.Error())
@@ -88,6 +97,10 @@ func (h *TriageHandler) HandleSet(w http.ResponseWriter, r *http.Request) {
 	}
 	if !validTriageStatuses[req.Status] {
 		WriteValidationError(w, "invalid status; must be one of: new, triaging, confirmed, accepted-risk, false-positive")
+		return
+	}
+	if len(req.Note) > maxTriageNoteLen {
+		WriteValidationError(w, "note exceeds 4096 characters")
 		return
 	}
 	if h.store == nil {

--- a/server/internal/api/handlers/triage_test.go
+++ b/server/internal/api/handlers/triage_test.go
@@ -1,0 +1,178 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/server/model"
+)
+
+type mockTriageStore struct {
+	getResult *model.TriageState
+	getErr    error
+	upsertErr error
+
+	gotGetFP    string
+	gotUpsertFP string
+	gotStatus   string
+	gotNote     string
+}
+
+func (m *mockTriageStore) GetTriage(_ context.Context, fp string) (*model.TriageState, error) {
+	m.gotGetFP = fp
+	return m.getResult, m.getErr
+}
+
+func (m *mockTriageStore) UpsertTriage(_ context.Context, fp, status, note string) (*model.TriageState, error) {
+	m.gotUpsertFP, m.gotStatus, m.gotNote = fp, status, note
+	if m.upsertErr != nil {
+		return nil, m.upsertErr
+	}
+	return &model.TriageState{Status: status, Note: note}, nil
+}
+
+const validFP = "aaaaaaaaaaaaaaaa"
+
+func TestTriageHandler_Get_InvalidFingerprint(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodGet, "/x", nil), "fingerprint", "not-hex")
+	h.HandleGet(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Get_NilStore(t *testing.T) {
+	h := &TriageHandler{} // store nil
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodGet, "/x", nil), "fingerprint", validFP)
+	h.HandleGet(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Get_DefaultsToNewWhenAbsent(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{getResult: nil}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodGet, "/x", nil), "fingerprint", validFP)
+	h.HandleGet(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var ts model.TriageState
+	if err := json.NewDecoder(w.Body).Decode(&ts); err != nil {
+		t.Fatal(err)
+	}
+	if ts.Status != "new" {
+		t.Errorf("absent triage should default to 'new', got %q", ts.Status)
+	}
+}
+
+func TestTriageHandler_Get_Success(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{getResult: &model.TriageState{Status: "confirmed", Note: "verified"}}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodGet, "/x", nil), "fingerprint", validFP)
+	h.HandleGet(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var ts model.TriageState
+	if err := json.NewDecoder(w.Body).Decode(&ts); err != nil {
+		t.Fatal(err)
+	}
+	if ts.Status != "confirmed" || ts.Note != "verified" {
+		t.Errorf("got %+v", ts)
+	}
+}
+
+func TestTriageHandler_Get_StoreError(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{getErr: errors.New("pg down")}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodGet, "/x", nil), "fingerprint", validFP)
+	h.HandleGet(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Set_InvalidFingerprint(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodPut, "/x", []byte(`{"status":"confirmed"}`)), "fingerprint", "zzz")
+	h.HandleSet(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Set_DecodeError(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodPut, "/x", []byte(`{not json`)), "fingerprint", validFP)
+	h.HandleSet(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Set_InvalidStatus(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodPut, "/x", []byte(`{"status":"bogus"}`)), "fingerprint", validFP)
+	h.HandleSet(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Set_NoteTooLong(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{}}
+	body, _ := json.Marshal(triageUpdateRequest{Status: "confirmed", Note: strings.Repeat("x", maxTriageNoteLen+1)})
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodPut, "/x", body), "fingerprint", validFP)
+	h.HandleSet(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized note, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Set_NilStore(t *testing.T) {
+	h := &TriageHandler{} // store nil
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodPut, "/x", []byte(`{"status":"confirmed"}`)), "fingerprint", validFP)
+	h.HandleSet(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestTriageHandler_Set_Success(t *testing.T) {
+	store := &mockTriageStore{}
+	h := &TriageHandler{store: store}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodPut, "/x", []byte(`{"status":"accepted-risk","note":"ok"}`)), "fingerprint", validFP)
+	h.HandleSet(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if store.gotUpsertFP != validFP || store.gotStatus != "accepted-risk" || store.gotNote != "ok" {
+		t.Errorf("upsert got fp=%q status=%q note=%q", store.gotUpsertFP, store.gotStatus, store.gotNote)
+	}
+}
+
+func TestTriageHandler_Set_StoreError(t *testing.T) {
+	h := &TriageHandler{store: &mockTriageStore{upsertErr: errors.New("pg down")}}
+	w := httptest.NewRecorder()
+	r := withChiURLParam(newTestRequest(http.MethodPut, "/x", []byte(`{"status":"confirmed"}`)), "fingerprint", validFP)
+	h.HandleSet(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}

--- a/server/internal/api/server.go
+++ b/server/internal/api/server.go
@@ -37,13 +37,14 @@ type Server struct {
 }
 
 type ServerDeps struct {
-	GraphDB     graph.GraphDB
-	Reader      *graph.Reader
-	PGPool      *pgxpool.Pool
-	Pipeline    *ingest.Pipeline
-	ScanStore   *appdb.ScanStore
-	RulesEngine *rules.Engine
-	CORSOrigins []string
+	GraphDB      graph.GraphDB
+	Reader       *graph.Reader
+	PGPool       *pgxpool.Pool
+	Pipeline     *ingest.Pipeline
+	ScanStore    *appdb.ScanStore
+	FindingStore *appdb.FindingStore
+	RulesEngine  *rules.Engine
+	CORSOrigins  []string
 	// LocalToken gates all mutating endpoints with a Bearer token. The
 	// embedded UI fetches the token from /api/v1/auth/local-token on
 	// load. Required; callers should construct via apimw.NewLocalToken.
@@ -66,9 +67,10 @@ func NewServer(deps ServerDeps) *Server {
 	graphH := handlers.NewGraphHandler(deps.Reader)
 	ingestH := handlers.NewIngestHandler(deps.Pipeline)
 	queryH := handlers.NewQueryHandler(deps.Reader)
-	analysisH := handlers.NewAnalysisHandler(deps.GraphDB)
+	analysisH := handlers.NewAnalysisHandler(deps.GraphDB, deps.FindingStore)
 	scanH := handlers.NewScanHandler(deps.ScanStore, deps.GraphDB)
 	rulesH := handlers.NewRulesHandler(deps.RulesEngine)
+	triageH := handlers.NewTriageHandler(deps.FindingStore)
 
 	r.Route("/api/v1", func(r chi.Router) {
 		// Open read endpoints. Single-user posture means localhost
@@ -98,6 +100,10 @@ func NewServer(deps ServerDeps) *Server {
 		r.Get("/analysis/prebuilt", analysisH.HandleListPreBuilt)
 		r.Get("/analysis/prebuilt/{id}", analysisH.HandlePreBuilt)
 
+		// Triage read is open (same posture as findings reads); the
+		// mutating PUT is gated below.
+		r.Get("/findings/triage/{fingerprint}", triageH.HandleGet)
+
 		r.Get("/scans", scanH.HandleList)
 		r.Get("/scans/{id}", scanH.HandleGet)
 
@@ -122,6 +128,7 @@ func NewServer(deps ServerDeps) *Server {
 			r.Post("/analysis/shortest-path", analysisH.HandleShortestPath)
 			r.Post("/analysis/all-paths", analysisH.HandleAllPaths)
 			r.Post("/analysis/weighted-path", analysisH.HandleWeightedPath)
+			r.Put("/findings/triage/{fingerprint}", triageH.HandleSet)
 		})
 	})
 

--- a/server/internal/appdb/findings_store.go
+++ b/server/internal/appdb/findings_store.go
@@ -1,0 +1,266 @@
+package appdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/server/model"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// suppressedStatuses are triage decisions that hide a finding from the
+// default findings view and from CI-style diffs/fail-on gates.
+var suppressedStatuses = []string{"accepted-risk", "false-positive"}
+
+// FindingStore persists per-scan finding snapshots and cross-scan triage
+// state. The graph's stale-edge cleanup rewrites composite edges every
+// scan, so the Postgres snapshot is the only diffable record of "what was
+// found when".
+type FindingStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewFindingStore(pool *pgxpool.Pool) *FindingStore {
+	return &FindingStore{pool: pool}
+}
+
+// FindingsDiff is the result of comparing two scans' finding snapshots,
+// keyed by fingerprint.
+type FindingsDiff struct {
+	ScanA     string          `json:"scan_a"`
+	ScanB     string          `json:"scan_b"`
+	Added     []model.Finding `json:"added"`
+	Removed   []model.Finding `json:"removed"`
+	Unchanged []model.Finding `json:"unchanged"`
+}
+
+// InsertFindings persists a scan's findings snapshot. Idempotent: a re-run
+// of the same scan_id overwrites the prior rows for that scan.
+func (s *FindingStore) InsertFindings(ctx context.Context, scanID string, findings []model.Finding) error {
+	if scanID == "" {
+		return errors.New("insert findings: empty scan_id")
+	}
+	if len(findings) == 0 {
+		return nil
+	}
+
+	batch := &pgx.Batch{}
+	for _, f := range findings {
+		owasp := f.OWASPMap
+		if owasp == nil {
+			owasp = []string{}
+		}
+		batch.Queue(
+			`INSERT INTO findings
+			   (scan_id, fingerprint, severity, category, title, description, edge_kind,
+			    source_id, source_name, source_kind, target_id, target_name, target_kind,
+			    confidence, owasp_map, cross_protocol)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+			 ON CONFLICT (scan_id, fingerprint) DO UPDATE SET
+			    severity = EXCLUDED.severity,
+			    category = EXCLUDED.category,
+			    title = EXCLUDED.title,
+			    description = EXCLUDED.description,
+			    edge_kind = EXCLUDED.edge_kind,
+			    source_id = EXCLUDED.source_id,
+			    source_name = EXCLUDED.source_name,
+			    source_kind = EXCLUDED.source_kind,
+			    target_id = EXCLUDED.target_id,
+			    target_name = EXCLUDED.target_name,
+			    target_kind = EXCLUDED.target_kind,
+			    confidence = EXCLUDED.confidence,
+			    owasp_map = EXCLUDED.owasp_map,
+			    cross_protocol = EXCLUDED.cross_protocol`,
+			scanID, f.ID, f.Severity, f.Category, f.Title, f.Description, f.EdgeKind,
+			f.SourceID, f.SourceName, f.SourceKind, f.TargetID, f.TargetName, f.TargetKind,
+			f.Confidence, owasp, isCrossProtocol(f.SourceKind, f.TargetKind),
+		)
+	}
+
+	br := s.pool.SendBatch(ctx, batch)
+	defer br.Close()
+	for range findings {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("insert findings batch: %w", err)
+		}
+	}
+	return nil
+}
+
+const findingSelectColumns = `f.fingerprint, f.severity, f.category, f.title, f.description, f.edge_kind,
+	f.source_id, f.source_name, f.source_kind, f.target_id, f.target_name, f.target_kind,
+	f.confidence, f.owasp_map, t.status, t.note, t.updated_at`
+
+// ListLatestPerFingerprint returns the most recent finding row per
+// fingerprint (across all scans), with triage state attached. severity
+// filters by exact level when non-empty. When includeSuppressed is false,
+// findings triaged as accepted-risk / false-positive are dropped.
+func (s *FindingStore) ListLatestPerFingerprint(ctx context.Context, severity string, includeSuppressed bool) ([]model.Finding, error) {
+	query := `
+SELECT ` + strings.ReplaceAll(findingSelectColumns, "f.", "latest.") + `
+FROM (
+    SELECT DISTINCT ON (f.fingerprint) ` + findingSelectColumns + `
+    FROM findings f
+    LEFT JOIN finding_triage t ON t.fingerprint = f.fingerprint
+    ORDER BY f.fingerprint, f.captured_at DESC
+) latest
+WHERE ($1 = '' OR latest.severity = $1)
+  AND ($2 OR latest.status IS NULL OR latest.status NOT IN ('accepted-risk','false-positive'))
+ORDER BY latest.confidence DESC`
+
+	rows, err := s.pool.Query(ctx, query, severity, includeSuppressed)
+	if err != nil {
+		return nil, fmt.Errorf("list findings: %w", err)
+	}
+	defer rows.Close()
+	return scanFindings(rows)
+}
+
+// findingsForScan returns every finding persisted for a single scan, with
+// triage state attached.
+func (s *FindingStore) findingsForScan(ctx context.Context, scanID string) ([]model.Finding, error) {
+	query := `
+SELECT ` + findingSelectColumns + `
+FROM findings f
+LEFT JOIN finding_triage t ON t.fingerprint = f.fingerprint
+WHERE f.scan_id = $1
+ORDER BY f.confidence DESC`
+
+	rows, err := s.pool.Query(ctx, query, scanID)
+	if err != nil {
+		return nil, fmt.Errorf("findings for scan %s: %w", scanID, err)
+	}
+	defer rows.Close()
+	return scanFindings(rows)
+}
+
+// Diff compares two scans' snapshots. added = present in scanB but not
+// scanA; removed = present in scanA but not scanB; unchanged = present in
+// both. When includeSuppressed is false, suppressed findings are dropped
+// from the added set so CI-style diffs don't re-alert on accepted risks.
+func (s *FindingStore) Diff(ctx context.Context, scanA, scanB string, includeSuppressed bool) (*FindingsDiff, error) {
+	a, err := s.findingsForScan(ctx, scanA)
+	if err != nil {
+		return nil, err
+	}
+	b, err := s.findingsForScan(ctx, scanB)
+	if err != nil {
+		return nil, err
+	}
+
+	aByFP := make(map[string]model.Finding, len(a))
+	for _, f := range a {
+		aByFP[f.ID] = f
+	}
+	bByFP := make(map[string]model.Finding, len(b))
+	for _, f := range b {
+		bByFP[f.ID] = f
+	}
+
+	diff := &FindingsDiff{ScanA: scanA, ScanB: scanB}
+	for _, f := range b {
+		if _, ok := aByFP[f.ID]; ok {
+			diff.Unchanged = append(diff.Unchanged, f)
+			continue
+		}
+		if !includeSuppressed && isSuppressed(f.Triage) {
+			continue
+		}
+		diff.Added = append(diff.Added, f)
+	}
+	for _, f := range a {
+		if _, ok := bByFP[f.ID]; !ok {
+			diff.Removed = append(diff.Removed, f)
+		}
+	}
+	return diff, nil
+}
+
+// GetTriage returns the triage state for a fingerprint, or nil if none has
+// been recorded (callers treat nil as the implicit "new" status).
+func (s *FindingStore) GetTriage(ctx context.Context, fingerprint string) (*model.TriageState, error) {
+	var ts model.TriageState
+	err := s.pool.QueryRow(ctx,
+		`SELECT status, note, updated_at FROM finding_triage WHERE fingerprint = $1`,
+		fingerprint).Scan(&ts.Status, &ts.Note, &ts.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get triage: %w", err)
+	}
+	return &ts, nil
+}
+
+// UpsertTriage records (or updates) the triage decision for a fingerprint.
+func (s *FindingStore) UpsertTriage(ctx context.Context, fingerprint, status, note string) (*model.TriageState, error) {
+	var ts model.TriageState
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO finding_triage (fingerprint, status, note, updated_at)
+		 VALUES ($1, $2, $3, NOW())
+		 ON CONFLICT (fingerprint) DO UPDATE SET
+		    status = EXCLUDED.status,
+		    note = EXCLUDED.note,
+		    updated_at = NOW()
+		 RETURNING status, note, updated_at`,
+		fingerprint, status, note).Scan(&ts.Status, &ts.Note, &ts.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("upsert triage: %w", err)
+	}
+	return &ts, nil
+}
+
+// scanFindings maps result rows (with the LEFT JOIN triage columns) into
+// model.Finding values. A NULL triage status yields a nil Triage pointer.
+func scanFindings(rows pgx.Rows) ([]model.Finding, error) {
+	var out []model.Finding
+	for rows.Next() {
+		var f model.Finding
+		var status, note *string
+		var updatedAt *time.Time
+		if err := rows.Scan(
+			&f.ID, &f.Severity, &f.Category, &f.Title, &f.Description, &f.EdgeKind,
+			&f.SourceID, &f.SourceName, &f.SourceKind, &f.TargetID, &f.TargetName, &f.TargetKind,
+			&f.Confidence, &f.OWASPMap, &status, &note, &updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan finding row: %w", err)
+		}
+		f.ID = strings.TrimSpace(f.ID)
+		if status != nil {
+			ts := &model.TriageState{Status: *status}
+			if note != nil {
+				ts.Note = *note
+			}
+			if updatedAt != nil {
+				ts.UpdatedAt = *updatedAt
+			}
+			f.Triage = ts
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+func isSuppressed(ts *model.TriageState) bool {
+	if ts == nil {
+		return false
+	}
+	for _, s := range suppressedStatuses {
+		if ts.Status == s {
+			return true
+		}
+	}
+	return false
+}
+
+// isCrossProtocol mirrors the UI's cross-protocol predicate: a finding
+// whose endpoints straddle the A2A and MCP protocol families.
+func isCrossProtocol(sourceKind, targetKind string) bool {
+	a2a := func(k string) bool { return strings.HasPrefix(k, "A2A") }
+	mcp := func(k string) bool { return strings.HasPrefix(k, "MCP") }
+	return (a2a(sourceKind) && mcp(targetKind)) || (mcp(sourceKind) && a2a(targetKind))
+}

--- a/server/internal/appdb/findings_store.go
+++ b/server/internal/appdb/findings_store.go
@@ -100,8 +100,17 @@ const findingSelectColumns = `f.fingerprint, f.severity, f.category, f.title, f.
 // filters by exact level when non-empty. When includeSuppressed is false,
 // findings triaged as accepted-risk / false-positive are dropped.
 func (s *FindingStore) ListLatestPerFingerprint(ctx context.Context, severity string, includeSuppressed bool) ([]model.Finding, error) {
+	// The inner subquery joins findings + finding_triage (aliases f, t) and
+	// keeps the latest row per fingerprint. The outer query must read every
+	// column back from the `latest` subquery — including the triage columns
+	// (status/note/updated_at), which at the outer level live on `latest`,
+	// NOT on `t` (that alias is only in scope inside the subquery). Listing
+	// the outer columns explicitly keeps the projection order aligned with
+	// scanFindings' positional scan.
 	query := `
-SELECT ` + strings.ReplaceAll(findingSelectColumns, "f.", "latest.") + `
+SELECT latest.fingerprint, latest.severity, latest.category, latest.title, latest.description, latest.edge_kind,
+       latest.source_id, latest.source_name, latest.source_kind, latest.target_id, latest.target_name, latest.target_kind,
+       latest.confidence, latest.owasp_map, latest.status, latest.note, latest.updated_at
 FROM (
     SELECT DISTINCT ON (f.fingerprint) ` + findingSelectColumns + `
     FROM findings f

--- a/server/internal/appdb/findings_store_test.go
+++ b/server/internal/appdb/findings_store_test.go
@@ -1,0 +1,156 @@
+package appdb
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/server/model"
+)
+
+// TestIntegrationFindingStore exercises the FindingStore against a real
+// Postgres (skipped without AGENTHOUND_PG_URI; CI's test-integration job
+// wires it). It is the regression guard for the ListLatestPerFingerprint
+// outer-SELECT alias bug, where the triage columns referenced the inner
+// subquery alias `t` from the outer query and produced
+// "missing FROM-clause entry for table t" on every findings read.
+func TestIntegrationFindingStore(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := context.Background()
+
+	pool, err := NewPool(os.Getenv("AGENTHOUND_PG_URI"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	if err := RunMigrations(ctx, pool); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	scanStore := NewScanStore(pool)
+	fs := NewFindingStore(pool)
+
+	fpA := "aaaaaaaaaaaaaaaa"
+	fpB := "bbbbbbbbbbbbbbbb"
+	fpD := "dddddddddddddddd"
+
+	// Make the test hermetic regardless of leftover state: clear any prior
+	// fs-test scans (cascade-deletes their findings) and the fixed triage
+	// fingerprints up front. finding_triage has no FK, so it survives scan
+	// deletion and must be cleared explicitly.
+	cleanup := func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM scans WHERE id LIKE 'fs-test-%'")
+		_, _ = pool.Exec(ctx, "DELETE FROM finding_triage WHERE fingerprint = ANY($1)", []string{fpA, fpB, fpD})
+	}
+	cleanup()
+	// Use defer (not t.Cleanup) so this runs BEFORE the deferred pool.Close()
+	// above (defers are LIFO) — the t.Cleanup variant would run after the
+	// pool is already closed and silently no-op.
+	defer cleanup()
+
+	scanID := "fs-test-" + time.Now().Format("20060102150405.000000")
+	scanID2 := scanID + "-2"
+	mustScan := func(id string) {
+		if err := scanStore.CreateScan(ctx, &model.Scan{
+			ID: id, Collector: "mcp", Status: model.ScanStatusRunning, StartedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("create scan %s: %v", id, err)
+		}
+	}
+	mustScan(scanID)
+	mustScan(scanID2)
+
+	findings := []model.Finding{
+		{ID: fpA, Severity: "critical", Category: "Data Exfiltration", Title: "exfil", EdgeKind: "CAN_EXFILTRATE_VIA",
+			SourceID: "s1", SourceName: "agent", SourceKind: "AgentInstance", TargetID: "t1", TargetName: "tool", TargetKind: "MCPTool",
+			Confidence: 0.9, OWASPMap: []string{"MCP04", "ASI08"}},
+		{ID: fpB, Severity: "high", Category: "Tool Shadowing", Title: "shadow", EdgeKind: "SHADOWS",
+			SourceKind: "MCPTool", TargetKind: "MCPTool", Confidence: 0.6},
+	}
+	if err := fs.InsertFindings(ctx, scanID, findings); err != nil {
+		t.Fatalf("insert findings: %v", err)
+	}
+
+	// The load-bearing assertion: this read regressed to a 500 before the
+	// alias fix.
+	all, err := fs.ListLatestPerFingerprint(ctx, "", false)
+	if err != nil {
+		t.Fatalf("ListLatestPerFingerprint: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(all))
+	}
+
+	crit, err := fs.ListLatestPerFingerprint(ctx, "critical", false)
+	if err != nil {
+		t.Fatalf("list critical: %v", err)
+	}
+	if len(crit) != 1 || crit[0].Severity != "critical" {
+		t.Fatalf("severity filter: got %+v", crit)
+	}
+
+	// Suppression: a false-positive is hidden by default, shown with the flag.
+	if _, err := fs.UpsertTriage(ctx, fpA, "false-positive", "benign"); err != nil {
+		t.Fatalf("upsert triage: %v", err)
+	}
+	visible, err := fs.ListLatestPerFingerprint(ctx, "", false)
+	if err != nil {
+		t.Fatalf("list after suppress: %v", err)
+	}
+	if len(visible) != 1 {
+		t.Fatalf("suppressed finding should be hidden by default; got %d visible", len(visible))
+	}
+	withSupp, err := fs.ListLatestPerFingerprint(ctx, "", true)
+	if err != nil {
+		t.Fatalf("list include-suppressed: %v", err)
+	}
+	if len(withSupp) != 2 {
+		t.Fatalf("include_suppressed should show all; got %d", len(withSupp))
+	}
+	var sawInlineTriage bool
+	for _, f := range withSupp {
+		if f.ID == fpA {
+			if f.Triage == nil || f.Triage.Status != "false-positive" || f.Triage.Note != "benign" {
+				t.Fatalf("expected inline triage {false-positive, benign}, got %+v", f.Triage)
+			}
+			sawInlineTriage = true
+		}
+	}
+	if !sawInlineTriage {
+		t.Fatal("suppressed finding not returned with include_suppressed")
+	}
+
+	// GetTriage: present and absent.
+	ts, err := fs.GetTriage(ctx, fpA)
+	if err != nil || ts == nil || ts.Status != "false-positive" {
+		t.Fatalf("GetTriage(fpA): ts=%+v err=%v", ts, err)
+	}
+	if none, err := fs.GetTriage(ctx, "cccccccccccccccc"); err != nil || none != nil {
+		t.Fatalf("GetTriage(unknown): want (nil,nil), got (%+v,%v)", none, err)
+	}
+
+	// Diff: scan2 keeps fpA, drops fpB, adds fpD.
+	findings2 := []model.Finding{
+		findings[0],
+		{ID: fpD, Severity: "high", Category: "Cross-Tool Taint", Title: "taint", EdgeKind: "TAINTS",
+			SourceKind: "MCPTool", TargetKind: "MCPTool", Confidence: 0.7},
+	}
+	if err := fs.InsertFindings(ctx, scanID2, findings2); err != nil {
+		t.Fatalf("insert findings2: %v", err)
+	}
+	diff, err := fs.Diff(ctx, scanID, scanID2, false)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(diff.Added) != 1 || diff.Added[0].ID != fpD {
+		t.Fatalf("diff.Added = %+v, want [%s]", diff.Added, fpD)
+	}
+	if len(diff.Removed) != 1 || diff.Removed[0].ID != fpB {
+		t.Fatalf("diff.Removed = %+v, want [%s]", diff.Removed, fpB)
+	}
+	if len(diff.Unchanged) != 1 || diff.Unchanged[0].ID != fpA {
+		t.Fatalf("diff.Unchanged = %+v, want [%s]", diff.Unchanged, fpA)
+	}
+}

--- a/server/internal/appdb/migrations/003_findings_triage.sql
+++ b/server/internal/appdb/migrations/003_findings_triage.sql
@@ -1,0 +1,47 @@
+-- 003_findings_triage.sql
+--
+-- Tier-0 productization: persist a per-scan snapshot of findings so the
+-- graph (which the post-processor's stale-edge cleanup rewrites every scan)
+-- stays diffable, and track cross-scan triage state keyed by the stable
+-- 16-char finding fingerprint.
+--
+-- Two tables, deliberately separate:
+--   * findings        — immutable per-scan record (FK to scans, ON DELETE
+--                       CASCADE so deleting a scan reaps its snapshot).
+--   * finding_triage  — cross-scan analyst state. NO FK to findings: triage
+--                       decisions (accepted-risk / false-positive) must
+--                       survive scan deletion and re-detection.
+
+CREATE TABLE IF NOT EXISTS findings (
+    scan_id        TEXT NOT NULL REFERENCES scans(id) ON DELETE CASCADE,
+    fingerprint    CHAR(16) NOT NULL,
+    severity       TEXT NOT NULL DEFAULT '',
+    category       TEXT NOT NULL DEFAULT '',
+    title          TEXT NOT NULL DEFAULT '',
+    description    TEXT NOT NULL DEFAULT '',
+    edge_kind      TEXT NOT NULL DEFAULT '',
+    source_id      TEXT NOT NULL DEFAULT '',
+    source_name    TEXT NOT NULL DEFAULT '',
+    source_kind    TEXT NOT NULL DEFAULT '',
+    target_id      TEXT NOT NULL DEFAULT '',
+    target_name    TEXT NOT NULL DEFAULT '',
+    target_kind    TEXT NOT NULL DEFAULT '',
+    confidence     DOUBLE PRECISION NOT NULL DEFAULT 0,
+    owasp_map      JSONB NOT NULL DEFAULT '[]',
+    cross_protocol BOOLEAN NOT NULL DEFAULT FALSE,
+    captured_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (scan_id, fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_findings_fingerprint ON findings(fingerprint);
+CREATE INDEX IF NOT EXISTS idx_findings_scan_id ON findings(scan_id);
+CREATE INDEX IF NOT EXISTS idx_findings_severity ON findings(severity);
+CREATE INDEX IF NOT EXISTS idx_findings_edge_kind ON findings(edge_kind);
+
+CREATE TABLE IF NOT EXISTS finding_triage (
+    fingerprint CHAR(16) PRIMARY KEY,
+    status      TEXT NOT NULL DEFAULT 'new'
+                CHECK (status IN ('new','triaging','confirmed','accepted-risk','false-positive')),
+    note        TEXT NOT NULL DEFAULT '',
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/server/internal/graph/writer.go
+++ b/server/internal/graph/writer.go
@@ -114,8 +114,15 @@ func nodeCypherForKindTuple(primaryKind string, extraLabels []string) string {
 	var sb strings.Builder
 	sb.WriteString("UNWIND $nodes AS node\n")
 	fmt.Fprintf(&sb, "MERGE (n:%s {objectid: node.id})\n", primaryKind)
-	sb.WriteString("ON CREATE SET n = node.properties, n.objectid = node.id, n.scan_id = $scan_id, n.first_seen = datetime(), n.last_seen = datetime()\n")
-	sb.WriteString("ON MATCH SET n.previous_description_hash = n.description_hash, n += node.properties, n.scan_id = $scan_id, n.last_seen = datetime()")
+	// ON CREATE: seed the previous-hash trio from the incoming hashes so the
+	// rug-pull predicates (which gate on previous_*_hash IS NOT NULL) do not
+	// fire spuriously on a tool's/server's first scan. Reading from
+	// node.properties.* is unambiguous regardless of SET-item ordering.
+	sb.WriteString("ON CREATE SET n = node.properties, n.objectid = node.id, n.scan_id = $scan_id, n.first_seen = datetime(), n.last_seen = datetime(), n.previous_description_hash = node.properties.description_hash, n.previous_input_schema_hash = node.properties.input_schema_hash, n.previous_instructions_hash = node.properties.instructions_hash\n")
+	// ON MATCH: pivot previous_*_hash = current hash BEFORE n += node.properties
+	// overwrites the current values. SET items apply left-to-right, so the
+	// three pivots capture the prior scan's hashes (rug-pull change detection).
+	sb.WriteString("ON MATCH SET n.previous_description_hash = n.description_hash, n.previous_input_schema_hash = n.input_schema_hash, n.previous_instructions_hash = n.instructions_hash, n += node.properties, n.scan_id = $scan_id, n.last_seen = datetime()")
 	for _, lbl := range extraLabels {
 		fmt.Fprintf(&sb, "\nSET n:%s", lbl)
 	}

--- a/server/internal/ingest/pipeline.go
+++ b/server/internal/ingest/pipeline.go
@@ -34,6 +34,14 @@ type scanRecorder interface {
 // without exercising every concrete processor.
 type postProcessFunc func(ctx context.Context, db graph.GraphDB, scanID string, collectors []string) ([]graph.ProcessingStats, error)
 
+// findingSnapshotter persists the per-scan findings snapshot to Postgres.
+// *appdb.FindingStore satisfies it implicitly; defined as an interface so
+// tests can substitute a recorder and so a nil store cleanly disables the
+// snapshot stage.
+type findingSnapshotter interface {
+	InsertFindings(ctx context.Context, scanID string, findings []model.Finding) error
+}
+
 // Pipeline serializes ingests through a single mutex.
 //
 // The post-processing stage's stale-edge cleanup deletes composite
@@ -45,16 +53,17 @@ type postProcessFunc func(ctx context.Context, db graph.GraphDB, scanID string, 
 // for the duration of a single scan, and concurrent UI uploads are not
 // a target scenario.
 type Pipeline struct {
-	mu         sync.Mutex
-	validator  *Validator
-	normalizer *Normalizer
-	writer     nodeEdgeWriter
-	graphDB    graph.GraphDB
-	scanStore  scanRecorder
-	runPP      postProcessFunc
+	mu           sync.Mutex
+	validator    *Validator
+	normalizer   *Normalizer
+	writer       nodeEdgeWriter
+	graphDB      graph.GraphDB
+	scanStore    scanRecorder
+	findingStore findingSnapshotter
+	runPP        postProcessFunc
 }
 
-func NewPipeline(writer *graph.Writer, graphDB graph.GraphDB, scanStore *appdb.ScanStore) *Pipeline {
+func NewPipeline(writer *graph.Writer, graphDB graph.GraphDB, scanStore *appdb.ScanStore, findingStore *appdb.FindingStore) *Pipeline {
 	p := &Pipeline{
 		validator:  NewValidator(),
 		normalizer: NewNormalizer(),
@@ -69,6 +78,9 @@ func NewPipeline(writer *graph.Writer, graphDB graph.GraphDB, scanStore *appdb.S
 	}
 	if scanStore != nil {
 		p.scanStore = scanStore
+	}
+	if findingStore != nil {
+		p.findingStore = findingStore
 	}
 	return p
 }
@@ -143,6 +155,22 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 				Duration:      s.Duration,
 				Error:         s.Error,
 			})
+		}
+	}
+
+	// Stage 6.5: Persist findings snapshot (non-fatal). Post-processing
+	// above already ran cleanStaleCompositeEdges, so the graph now holds
+	// only this scan's composite edges — snapshotting here captures
+	// exactly this scan's findings. All triage/diff reads come from this
+	// Postgres snapshot, which is invariant under the next scan's cleanup.
+	if p.findingStore != nil && p.graphDB != nil {
+		snapshot, qErr := analysis.QueryFindings(ctx, p.graphDB, "")
+		if qErr != nil {
+			slog.Warn("findings snapshot query failed", "error", qErr)
+		} else if iErr := p.findingStore.InsertFindings(ctx, data.Meta.ScanID, snapshot); iErr != nil {
+			slog.Warn("findings snapshot insert failed", "error", iErr)
+		} else {
+			slog.Info("findings snapshot persisted", "scan_id", data.Meta.ScanID, "count", len(snapshot))
 		}
 	}
 

--- a/server/internal/ingest/pipeline_test.go
+++ b/server/internal/ingest/pipeline_test.go
@@ -818,7 +818,7 @@ func TestPipeline_NormalizerWarningsPropagated(t *testing.T) {
 // runner. We pass nil for the unit-testable types we don't have here
 // (Writer, GraphDB, ScanStore) — the constructor is purely structural.
 func TestNewPipeline_ConstructsWithDefaults(t *testing.T) {
-	p := NewPipeline(nil, nil, nil)
+	p := NewPipeline(nil, nil, nil, nil)
 	if p.validator == nil {
 		t.Error("validator should be initialized")
 	}
@@ -848,7 +848,7 @@ func TestNewPipeline_PassesConcreteThrough(t *testing.T) {
 	// only validate the Writer path here. The ScanStore path is
 	// exercised in production by bootstrap.go and indirectly covered
 	// by integration tests.
-	p := NewPipeline(w, nil, nil)
+	p := NewPipeline(w, nil, nil, nil)
 	if p.writer == nil {
 		t.Error("non-nil *graph.Writer should be stored as interface")
 	}

--- a/server/model/finding.go
+++ b/server/model/finding.go
@@ -1,19 +1,32 @@
 package model
 
+import "time"
+
 // Finding represents a security finding derived from a composite edge.
 type Finding struct {
-	ID          string   `json:"id"`
-	Severity    string   `json:"severity"`
-	Category    string   `json:"category"`
-	Title       string   `json:"title"`
-	Description string   `json:"description"`
-	EdgeKind    string   `json:"edge_kind"`
-	SourceID    string   `json:"source_id"`
-	SourceName  string   `json:"source_name"`
-	SourceKind  string   `json:"source_kind"`
-	TargetID    string   `json:"target_id"`
-	TargetName  string   `json:"target_name"`
-	TargetKind  string   `json:"target_kind"`
-	Confidence  float64  `json:"confidence"`
-	OWASPMap    []string `json:"owasp_map,omitempty"`
+	ID          string       `json:"id"`
+	Severity    string       `json:"severity"`
+	Category    string       `json:"category"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	EdgeKind    string       `json:"edge_kind"`
+	SourceID    string       `json:"source_id"`
+	SourceName  string       `json:"source_name"`
+	SourceKind  string       `json:"source_kind"`
+	TargetID    string       `json:"target_id"`
+	TargetName  string       `json:"target_name"`
+	TargetKind  string       `json:"target_kind"`
+	Confidence  float64      `json:"confidence"`
+	OWASPMap    []string     `json:"owasp_map,omitempty"`
+	Triage      *TriageState `json:"triage,omitempty"`
+}
+
+// TriageState is the cross-scan analyst decision attached to a finding,
+// keyed by the finding's 16-char fingerprint. Persisted in the
+// finding_triage table; co-located here so all finding-shaped types stay
+// together.
+type TriageState struct {
+	Status    string    `json:"status"`
+	Note      string    `json:"note"`
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/server/ui/src/entities/finding/api.ts
+++ b/server/ui/src/entities/finding/api.ts
@@ -1,9 +1,13 @@
 import { api } from "@shared/api/client";
-import type { Finding, FindingDetail } from "./model";
+import type { Finding, FindingDetail, TriageState } from "./model";
 
-export async function fetchFindings(severity?: string): Promise<Finding[]> {
+export async function fetchFindings(
+  severity?: string,
+  includeSuppressed?: boolean,
+): Promise<Finding[]> {
   const params: Record<string, string> = {};
   if (severity) params["severity"] = severity;
+  if (includeSuppressed) params["include_suppressed"] = "true";
   return api
     .get("analysis/findings", { searchParams: params })
     .json<Finding[]>();
@@ -11,6 +15,20 @@ export async function fetchFindings(severity?: string): Promise<Finding[]> {
 
 export async function fetchFindingDetail(id: string): Promise<FindingDetail> {
   return api.get(`analysis/findings/${id}`).json<FindingDetail>();
+}
+
+export async function getTriage(fingerprint: string): Promise<TriageState> {
+  return api.get(`findings/triage/${fingerprint}`).json<TriageState>();
+}
+
+export async function setTriage(
+  fingerprint: string,
+  status: string,
+  note: string,
+): Promise<TriageState> {
+  return api
+    .put(`findings/triage/${fingerprint}`, { json: { status, note } })
+    .json<TriageState>();
 }
 
 /**

--- a/server/ui/src/entities/finding/model.ts
+++ b/server/ui/src/entities/finding/model.ts
@@ -1,5 +1,15 @@
 // Finding domain types + severity view-model helpers.
 
+// TriageState is the cross-scan analyst decision attached to a finding by
+// fingerprint. Returned inline on list findings (so the register renders the
+// dropdown without a per-row round-trip) and standalone from the triage
+// endpoints.
+export interface TriageState {
+  status: string;
+  note: string;
+  updated_at: string;
+}
+
 export interface Finding {
   id: string;
   severity: string;
@@ -15,6 +25,7 @@ export interface Finding {
   target_kind: string;
   confidence: number;
   owasp_map: string[];
+  triage?: TriageState | null;
 }
 
 export interface AttackPathNode {

--- a/server/ui/src/entities/finding/queries.ts
+++ b/server/ui/src/entities/finding/queries.ts
@@ -1,13 +1,21 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { qk } from "@shared/api/query-keys";
-import { fetchFindingDetail, fetchFindings } from "./api";
+import {
+  fetchFindingDetail,
+  fetchFindings,
+  getTriage,
+  setTriage,
+} from "./api";
+import type { TriageStatus } from "@shared/model/triage";
 
 // One findings cache for every surface that needs the full set (dashboard,
-// findings list, node findings, references, navigation).
-export function useFindings() {
+// findings list, node findings, references, navigation). includeSuppressed
+// addresses a distinct cache entry so the register's "show suppressed"
+// toggle does not disturb the default (hidden-suppressed) view.
+export function useFindings(includeSuppressed = false) {
   return useQuery({
-    queryKey: qk.findings(),
-    queryFn: () => fetchFindings(),
+    queryKey: qk.findings(includeSuppressed),
+    queryFn: () => fetchFindings(undefined, includeSuppressed),
   });
 }
 
@@ -16,5 +24,34 @@ export function useFindingDetail(findingId: string | undefined) {
     queryKey: qk.findingDetail(findingId ?? ""),
     queryFn: () => fetchFindingDetail(findingId!),
     enabled: !!findingId,
+  });
+}
+
+// useTriage fetches a single finding's triage state standalone. Used by
+// the dossier header (the list carries triage inline, so rows do not call
+// this — avoiding an N+1 of per-row requests).
+export function useTriage(fingerprint: string | undefined) {
+  return useQuery({
+    queryKey: qk.triage(fingerprint ?? ""),
+    queryFn: () => getTriage(fingerprint!),
+    enabled: !!fingerprint,
+  });
+}
+
+// useSetTriage writes a triage decision. On success it invalidates the
+// whole findings namespace (so inline triage in every list variant
+// refreshes) plus the edited fingerprint's standalone triage query.
+export function useSetTriage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: {
+      fingerprint: string;
+      status: TriageStatus;
+      note?: string;
+    }) => setTriage(vars.fingerprint, vars.status, vars.note ?? ""),
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: qk.findings() });
+      void qc.invalidateQueries({ queryKey: qk.triage(vars.fingerprint) });
+    },
   });
 }

--- a/server/ui/src/features/findings/ui/FindingHeader.tsx
+++ b/server/ui/src/features/findings/ui/FindingHeader.tsx
@@ -5,7 +5,9 @@ import { MiniHexIcon } from "./MiniHexIcon";
 import { TriageControl } from "./TriageControl";
 import { cn } from "@shared/lib/utils";
 import { SEVERITY, SEVERITY_BY_KEY } from "@shared/theme/tokens";
+import { useTriage } from "@entities/finding";
 import type { FindingDetail } from "@entities/finding/model";
+import type { TriageStatus } from "@shared/model/triage";
 
 interface FindingHeaderProps {
   detail: FindingDetail;
@@ -36,6 +38,11 @@ export function FindingHeader({ detail, prevId, nextId, onCopyReport }: FindingH
   const sev = SEVERITY_BY_KEY[f.severity] ?? SEVERITY.low;
   const color = sev.solid;
   const [copied, setCopied] = useState(false);
+
+  // The detail's finding comes from the graph (no inline triage), so the
+  // dossier control fetches the standalone triage state for this row.
+  const { data: triage } = useTriage(f.id);
+  const triageStatus = (triage?.status as TriageStatus) ?? "new";
 
   const hops = detail.composite_props?.hops;
 
@@ -148,7 +155,7 @@ export function FindingHeader({ detail, prevId, nextId, onCopyReport }: FindingH
 
           {/* Actions */}
           <div className="flex shrink-0 flex-col items-end gap-2">
-            <TriageControl findingId={f.id} />
+            <TriageControl findingId={f.id} status={triageStatus} />
             <button
               className={consoleBtn}
               onClick={() => navigate(`/explorer?finding=${f.id}`)}

--- a/server/ui/src/features/findings/ui/FindingsListPage.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.tsx
@@ -13,11 +13,10 @@ import {
   ShieldAlert,
   X,
 } from "lucide-react";
-import { useFindings, SEVERITY_RANK } from "@entities/finding";
+import { useFindings, useSetTriage, SEVERITY_RANK } from "@entities/finding";
 import type { Finding } from "@entities/finding/model";
 import { edgeLabel } from "@entities/edge";
 import {
-  useTriageStore,
   TRIAGE_ORDER,
   TRIAGE_META,
   type TriageStatus,
@@ -90,9 +89,20 @@ export function FindingsListPage() {
   const navigate = useNavigate();
   const [params, setParams] = useSearchParams();
 
-  const { data: findings, isLoading } = useFindings();
-  const triageMap = useTriageStore((s) => s.status);
-  const setStatus = useTriageStore((s) => s.setStatus);
+  const showSuppressed = params.get("suppressed") === "1";
+  const { data: findings, isLoading } = useFindings(showSuppressed);
+  const setTriage = useSetTriage();
+
+  // Triage status now arrives inline on each finding (server-backed). Derive
+  // the id→status lookup the filter/sort/group paths use from that, so they
+  // stay in sync without a separate store.
+  const triageMap = useMemo(() => {
+    const m: Record<string, TriageStatus> = {};
+    for (const f of findings ?? []) {
+      if (f.triage?.status) m[f.id] = f.triage.status as TriageStatus;
+    }
+    return m;
+  }, [findings]);
 
   const searchRef = useRef<HTMLInputElement | null>(null);
   const rowRefs = useRef<Array<HTMLTableRowElement | null>>([]);
@@ -321,7 +331,7 @@ export function FindingsListPage() {
   }
 
   function bulkSetStatus(status: TriageStatus) {
-    for (const id of selected) setStatus(id, status);
+    for (const id of selected) setTriage.mutate({ fingerprint: id, status });
   }
 
   function setSortKey(key: SortKey) {
@@ -513,6 +523,19 @@ export function FindingsListPage() {
               </option>
             ))}
           </select>
+          <span className="mx-1 h-5 w-px bg-border/70" />
+          <button
+            onClick={() => patch({ suppressed: showSuppressed ? null : "1" })}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-[3px] border px-2.5 py-1 font-mono text-[11px] font-medium uppercase tracking-[0.08em] transition-colors",
+              showSuppressed
+                ? "border-primary/60 bg-primary/15 text-primary"
+                : "border-border bg-black/30 text-muted-foreground hover:border-mauve-7 hover:text-foreground",
+            )}
+            title="Include accepted-risk / false-positive findings"
+          >
+            Show suppressed
+          </button>
         </div>
 
         {/* ---------- Selection / bulk action bar ---------- */}
@@ -879,7 +902,11 @@ function FindingRow({
         </span>
       </td>
       <td className="px-3 py-3 align-middle">
-        <TriageControl findingId={f.id} compact />
+        <TriageControl
+          findingId={f.id}
+          status={(f.triage?.status as TriageStatus) ?? "new"}
+          compact
+        />
       </td>
       <td className="max-w-sm px-3 py-3 align-middle">
         <p className="truncate text-[13px] font-medium text-foreground">{f.title}</p>

--- a/server/ui/src/features/findings/ui/TriageControl.tsx
+++ b/server/ui/src/features/findings/ui/TriageControl.tsx
@@ -1,29 +1,32 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronDown } from "lucide-react";
 import {
-  useTriageStore,
   TRIAGE_ORDER,
   TRIAGE_META,
   type TriageStatus,
 } from "@shared/model/triage";
+import { useSetTriage } from "@entities/finding";
 import { cn } from "@shared/lib/utils";
 
 interface TriageControlProps {
   findingId: string;
+  /** Current triage status (controlled). List rows pass the inline
+   * f.triage status; the dossier header passes the fetched status. */
+  status: TriageStatus;
   /** Compact = inline register cell; full = dossier header. */
   compact?: boolean;
 }
 
 /**
  * Status dropdown shared by the findings register (inline, compact) and the
- * dossier header (full). Reads/writes the persisted triage store. Stops click
- * propagation so it can live inside a clickable table row without triggering
- * row navigation.
+ * dossier header (full). Controlled: the current status is supplied by the
+ * caller and writes go through the server-backed useSetTriage mutation. Stops
+ * click propagation so it can live inside a clickable table row without
+ * triggering row navigation.
  */
-export function TriageControl({ findingId, compact = false }: TriageControlProps) {
-  const status = useTriageStore((s) => s.status[findingId] ?? "new");
-  const setStatus = useTriageStore((s) => s.setStatus);
-  const meta = TRIAGE_META[status as TriageStatus];
+export function TriageControl({ findingId, status, compact = false }: TriageControlProps) {
+  const setTriage = useSetTriage();
+  const meta = TRIAGE_META[status] ?? TRIAGE_META.new;
 
   return (
     <DropdownMenu.Root>
@@ -65,7 +68,7 @@ export function TriageControl({ findingId, compact = false }: TriageControlProps
             return (
               <DropdownMenu.Item
                 key={s}
-                onSelect={() => setStatus(findingId, s)}
+                onSelect={() => setTriage.mutate({ fingerprint: findingId, status: s })}
                 className={cn(
                   "flex cursor-pointer items-center gap-2 rounded-[3px] px-2 py-1.5 text-xs outline-none",
                   "focus:bg-white/[0.05] data-[highlighted]:bg-white/[0.05]",

--- a/server/ui/src/shared/api/query-keys.ts
+++ b/server/ui/src/shared/api/query-keys.ts
@@ -19,9 +19,20 @@ export const qk = {
   edges: () => ["edges", "all"] as const,
 
   // One findings cache — unifies the dashboard, findings list, node findings,
-  // references, and navigation surfaces (all fetched the full set).
-  findings: () => ["findings"] as const,
+  // references, and navigation surfaces (all fetched the full set). The
+  // optional includeSuppressed segment lets the findings register show
+  // accepted-risk / false-positive rows under a distinct cache entry; call
+  // with no argument to address the whole findings namespace for
+  // invalidation.
+  findings: (includeSuppressed?: boolean) =>
+    includeSuppressed === undefined
+      ? (["findings"] as const)
+      : (["findings", includeSuppressed] as const),
   findingDetail: (id: string) => ["finding-detail", id] as const,
+  // Per-fingerprint triage state — one key per finding so a triage edit
+  // invalidates just that row's standalone query (the list query carries
+  // triage inline and is invalidated by prefix).
+  triage: (fingerprint: string) => ["triage", fingerprint] as const,
 
   // One scans hook, parameterized by page size: the scan manager (50) and the
   // dashboard (20) keep distinct cache entries so a write to one does not

--- a/server/ui/src/shared/model/triage.ts
+++ b/server/ui/src/shared/model/triage.ts
@@ -1,17 +1,15 @@
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import { SEVERITY, ACCENT, SIGNAL_OK, TRIAGE_NEUTRAL } from "@shared/theme/tokens";
 
 /**
- * Finding triage workflow state (shared kernel).
+ * Finding triage workflow types + view-model constants (shared kernel).
  *
- * A red-team engagement works a register of findings over time; this slice
- * tracks per-finding triage status + a freeform note so progress survives
- * reloads. Lives in shared (not the findings feature) so the explorer can also
- * read it later without a cross-feature import. Persisted under its own key.
+ * Triage state is now server-backed (Postgres finding_triage table, keyed by
+ * the finding fingerprint) and read/written via TanStack Query — see
+ * `@entities/finding` useTriage / useSetTriage. This module keeps only the
+ * status enum and its display metadata so consumers (the register, the
+ * dossier header) stay decoupled from the transport.
  *
- * "new" is the implicit default (absence of an entry), so a fresh scan's
- * findings all read as New without seeding the map.
+ * "new" is the implicit default for a finding with no recorded decision.
  */
 export type TriageStatus =
   | "new"
@@ -41,50 +39,3 @@ export const TRIAGE_META: Record<TriageStatus, TriageMeta> = {
   "accepted-risk": { label: "Accepted risk", short: "ACCEPTED", color: SEVERITY.info.solid },
   "false-positive": { label: "False positive", short: "FALSE+", color: SIGNAL_OK },
 };
-
-interface TriageState {
-  status: Record<string, TriageStatus>;
-  notes: Record<string, string>;
-}
-
-interface TriageActions {
-  setStatus: (id: string, status: TriageStatus) => void;
-  setNote: (id: string, note: string) => void;
-  getStatus: (id: string) => TriageStatus;
-  getNote: (id: string) => string;
-  reset: () => void;
-}
-
-export const useTriageStore = create<TriageState & TriageActions>()(
-  persist(
-    (set, get) => ({
-      status: {},
-      notes: {},
-
-      setStatus: (id, status) =>
-        set((state) => {
-          const next = { ...state.status };
-          if (status === "new") delete next[id];
-          else next[id] = status;
-          return { status: next };
-        }),
-
-      setNote: (id, note) =>
-        set((state) => {
-          const next = { ...state.notes };
-          if (note.trim() === "") delete next[id];
-          else next[id] = note;
-          return { notes: next };
-        }),
-
-      getStatus: (id) => get().status[id] ?? "new",
-      getNote: (id) => get().notes[id] ?? "",
-
-      reset: () => set({ status: {}, notes: {} }),
-    }),
-    {
-      name: "agenthound-triage",
-      partialize: (state) => ({ status: state.status, notes: state.notes }),
-    },
-  ),
-);


### PR DESCRIPTION
## Summary

Implements the T0 (triage + scan-diffing) productization seam and the T1 graph "moat" detectors from the architect plan.

**Tier 0 — persisted findings, triage, diff**
- New Postgres migration `003_findings_triage.sql` (two tables: immutable per-scan `findings` snapshot with FK→`scans` ON DELETE CASCADE; cross-scan `finding_triage` with no FK so decisions survive scan deletion).
- `appdb.FindingStore` (`InsertFindings`, `ListLatestPerFingerprint`, `Diff`, `GetTriage`, `UpsertTriage`); ingest pipeline snapshots findings after post-processing (between stages 6 and 7) so reads are invariant under the next scan's stale-edge cleanup.
- Triage endpoints: open `GET /api/v1/findings/triage/{fp}`, gated `PUT /api/v1/findings/triage/{fp}`. Findings endpoint + `query --findings` now read the snapshot, hide suppressed (accepted-risk/false-positive) by default, and add `?include_suppressed` / `--all-findings`. `--fail-on` **always** ignores suppressed so CI never breaks on an accepted risk.
- `query --diff scanA,scanB` reports added/removed/unchanged.
- UI: triage store replaced with server-backed TanStack Query hooks; register reads inline `f.triage`, "Show suppressed" toggle, dossier control fetches per-fingerprint.

**Tier 1 — moat detectors** (additive on `sdk/ingest/kinds.go` + `processors/`)
- `INGESTS_UNTRUSTED` raw edge + `source-untrusted-{web,email,fileshare}` rules.
- `auth_strength` pre-pass (materializes numeric score from `riskscore.AuthStrengthScores`).
- `CONFUSED_DEPUTY` (weak→strong A2A delegation).
- Credential `blast_radius` folded into the credential-chain query + a server risk term.
- Rug-pull pinning extended to `input_schema_hash` + `instructions_hash`, with a `change_kind` discriminator.
- `TAINTS` (schema overlap), `IFC_VIOLATION` (≤3 hops), `POISONS_CONTEXT` (fan-out capped at 20, `scripts/perf-check.sh` enforces ≤200 pairs/agent).
- `auto_fetch_render` / `allowlisted_proxy` exfil capability classes; `tool-name-collision` prebuilt query.
- `AllowedEdgeKinds` 25→30 (18 raw + 12 composite). Note: the plan said 31/13-composite, but there are exactly 5 new edge kinds (1 raw + 4 composite), so the arithmetically-correct count is 30.

Docs updated: graph-model, detection-rules, api (+ `openapi.yaml`), cli, risk-scoring, post-processors, security.

## Test plan
- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -race` — all pass (count assertions updated: edge kinds 25→30, prebuilt 18→19)
- [x] `scripts/deps-check.sh` — collector deps unchanged (no new go.mod deps)
- [x] `scripts/size-check.sh` — 9.96 MiB, within baseline+10%
- [x] `scripts/perf-check.sh` — skips cleanly without a DB; gates ≤200 pairs/agent when live
- [x] `npm run build` (UI) — builds; `tsc -b` clean
- [ ] End-to-end with live Neo4j/Postgres (scan → ingest → findings/diff/triage round-trip) — needs a running stack
- Note: `scripts/slop-check.sh` reports pre-existing `grid-cols` violations in dashboard files untouched by this PR.

Made with [Cursor](https://cursor.com)