### PR TITLE
fix: repoint dead doc links and add next-step guidance

### DIFF
--- a/collector/cli/collect_helpers.go
+++ b/collector/cli/collect_helpers.go
@@ -29,6 +29,7 @@ func writeCollectorOutput(data *ingest.IngestData, outputPath string) error {
 		return fmt.Errorf("write file: %w", err)
 	}
 	slog.Info("output written", "path", outputPath, "nodes", len(data.Graph.Nodes), "edges", len(data.Graph.Edges))
+	_, _ = fmt.Fprintf(os.Stderr, "Next: agenthound-server ingest %s\n", outputPath)
 	return nil
 }
 

--- a/collector/cli/discover.go
+++ b/collector/cli/discover.go
@@ -43,7 +43,7 @@ Example:
     agenthound discover 10.0.0.0/24 --output -
 
 Public-IP targets require --allow-public-targets and an interactive
-AUTHORIZED prompt — same gates as 'scan'. See docs/discover.md.`,
+AUTHORIZED prompt — same gates as 'scan'. See https://docs.agenthound.io/operator/discover/.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDiscover,
 }

--- a/collector/cli/implant.go
+++ b/collector/cli/implant.go
@@ -49,7 +49,7 @@ file. Every Implanter embeds Reverter; receipts are persisted to
 By default --commit is OFF. Without --commit the Implanter runs end-
 to-end with no mutating writes; the receipt records dry_run=true.
 
-See docs/poison.md for the shared safety-gate rationale.`,
+See https://docs.agenthound.io/operator/offensive-actions/ for the shared safety-gate rationale.`,
 	Args:          cobra.ExactArgs(1),
 	RunE:          runImplant,
 	SilenceUsage:  true,

--- a/collector/cli/loot.go
+++ b/collector/cli/loot.go
@@ -224,7 +224,7 @@ func requireLootAcknowledged(stderr io.Writer, stdin io.Reader) error {
 	_, _ = fmt.Fprintln(stderr, "[loot] Looters extract credentials from running services. They are read-only —")
 	_, _ = fmt.Fprintln(stderr, "[loot] no state-mutating HTTP methods — but every probe shows up in the target's audit")
 	_, _ = fmt.Fprintln(stderr, "[loot] log. Coordinate with the target's IR/security team out-of-band BEFORE")
-	_, _ = fmt.Fprintln(stderr, "[loot] running this against any production system. See docs/loot-litellm.md.")
+	_, _ = fmt.Fprintln(stderr, "[loot] running this against any production system. See https://docs.agenthound.io/operator/loot/litellm/.")
 	_, _ = fmt.Fprint(stderr, "[loot] If you have authorization for this engagement, type AUTHORIZED to proceed: ")
 	r := bufio.NewReader(stdin)
 	line, err := r.ReadString('\n')

--- a/collector/cli/poison.go
+++ b/collector/cli/poison.go
@@ -74,7 +74,7 @@ Example (the v0.3-v0.4 demo arc):
       --mode replace --commit \
       --engagement-id DC35-DEMO
 
-See docs/poison.md for the full operator guide.`,
+See https://docs.agenthound.io/operator/offensive-actions/ for the full operator guide.`,
 	Args:          cobra.ExactArgs(1),
 	RunE:          runPoison,
 	SilenceUsage:  true,

--- a/collector/cli/root.go
+++ b/collector/cli/root.go
@@ -66,7 +66,7 @@ func init() {
 	rootCmd.PersistentFlags().Int("concurrency", 0, "Max parallel collector workers (env: AGENTHOUND_CONCURRENCY)")
 	rootCmd.PersistentFlags().Bool("quiet", false, "Suppress non-error log output (env: AGENTHOUND_QUIET=1)")
 	rootCmd.PersistentFlags().Bool("log-json", false, "Emit logs as JSON instead of text (env: AGENTHOUND_LOG_JSON=1)")
-	rootCmd.PersistentFlags().String("rules-bundle", "", "Path to a fingerprint rules bundle (directory or .tar.gz). Same-id rules from the bundle override the embedded set. Verify cosign signature manually before pointing AgentHound at it; see docs/rules-bundle.md. (env: AGENTHOUND_RULES_BUNDLE)")
+	rootCmd.PersistentFlags().String("rules-bundle", "", "Path to a fingerprint rules bundle (directory or .tar.gz). Same-id rules from the bundle override the embedded set. Verify cosign signature manually before pointing AgentHound at it; see https://docs.agenthound.io/reference/rule-syntax/. (env: AGENTHOUND_RULES_BUNDLE)")
 }
 
 func setupLogger(level string, quiet, jsonLog bool) {

--- a/collector/cli/unknown.go
+++ b/collector/cli/unknown.go
@@ -30,7 +30,7 @@ func HandleUnknownCommand() bool {
 		return false
 	}
 	fmt.Fprintf(os.Stderr,
-		"%q moved to the 'agenthound-server' binary — see https://github.com/adithyan-ak/agenthound#two-binary-split\n",
+		"%q moved to the 'agenthound-server' binary — see https://docs.agenthound.io/adr/0001-two-binary-split/\n",
 		verb)
 	os.Exit(1)
 	return true

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Attack-path discovery for AI agent infrastructure. [BloodHound](https://github.c
 - **[API Reference](reference/api.md)** — REST endpoints, auth, request/response schemas
 - **[Graph Model](reference/graph-model.md)** — 25 node types, 25 edge types, ID strategy, merge semantics
   - [CAN_REACH](reference/edges/can-reach.md) — The marquee composite edge (transitive agent→resource access)
-- **[Detection Rules](reference/detection-rules.md)** — 18 pre-built queries + OWASP mapping
+- **[Detection Rules](reference/detection-rules.md)** — 19 pre-built queries + OWASP mapping
 - **[Rule Syntax](reference/rule-syntax.md)** — YAML schema for detection + fingerprint rules
 - **[Configuration](reference/configuration.md)** — Env vars, state directories, defaults
 - **[Risk Scoring](reference/risk-scoring.md)** — Edge weights, node scores, sensitivity classification

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -58,7 +58,7 @@ scan --config         scan --mcp --url <url>           scan --a2a --target <url>
                         v
               Query / Pathfinding
               (Cypher, APOC Dijkstra,
-               18 pre-built queries)
+               19 pre-built queries)
 ```
 
 ## Graph Data Model

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -148,7 +148,7 @@ agenthound-server ingest loot-ollama.json
 - **Dashboard** -- node/edge counts, risk distribution, top findings
 - **Graph Explorer** -- interactive visualization (React Flow + ELK layout)
 - **Findings** -- per-finding detail with embedded attack-path diagrams
-- **Query Library** -- 18 pre-built security queries mapped to OWASP MCP/Agentic Top 10
+- **Query Library** -- 19 pre-built security queries mapped to OWASP MCP/Agentic Top 10
 - **Scan Manager** -- history, drag-drop import
 
 **CLI queries:**

--- a/server/cli/unknown.go
+++ b/server/cli/unknown.go
@@ -36,7 +36,7 @@ func HandleUnknownCommand() bool {
 		return false
 	}
 	fmt.Fprintf(os.Stderr,
-		"%q lives in the 'agenthound' collector binary — see https://github.com/adithyan-ak/agenthound#two-binary-split\n",
+		"%q lives in the 'agenthound' collector binary — see https://docs.agenthound.io/adr/0001-two-binary-split/\n",
 		verb)
 	os.Exit(1)
 	return true

--- a/server/internal/api/ui/fallback/index.html
+++ b/server/internal/api/ui/fallback/index.html
@@ -53,7 +53,7 @@
       </p>
       <p class="hint">
         See
-        <a href="https://github.com/adithyan-ak/agenthound#build-from-source">README → Build from source</a>
+        <a href="https://docs.agenthound.io/getting-started/install/">Installation guide</a>
         for full instructions.
       </p>
     </main>

--- a/server/ui/src/__tests__/ScanManager.test.tsx
+++ b/server/ui/src/__tests__/ScanManager.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
 import { ScanManager } from "@features/scans";
 import type { Scan } from "@entities/scan";
 
@@ -50,7 +51,9 @@ function createWrapper() {
   });
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
     );
   };
 }

--- a/server/ui/src/features/scans/ui/ScanImport.test.tsx
+++ b/server/ui/src/features/scans/ui/ScanImport.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
 import { ScanImport, validateScanFile } from "./ScanImport";
 
 vi.mock("@entities/scan/api", () => ({
@@ -19,7 +20,9 @@ function createWrapper() {
   });
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
     );
   };
 }

--- a/server/ui/src/features/scans/ui/ScanImport.tsx
+++ b/server/ui/src/features/scans/ui/ScanImport.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Upload, FileJson, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 import {
   Dialog,
@@ -62,6 +63,7 @@ export function ScanImport({ open, onClose, onSuccess }: ScanImportProps) {
   const [dragActive, setDragActive] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const { mutateAsync: uploadScan } = useUploadScan();
+  const navigate = useNavigate();
 
   const reset = useCallback(() => {
     setStatus({ kind: "idle" });
@@ -72,6 +74,14 @@ export function ScanImport({ open, onClose, onSuccess }: ScanImportProps) {
     reset();
     onClose();
   }, [onClose, reset]);
+
+  const goTo = useCallback(
+    (path: string) => {
+      handleClose();
+      navigate(path);
+    },
+    [handleClose, navigate],
+  );
 
   const processFile = useCallback(
     async (file: File) => {
@@ -230,12 +240,15 @@ export function ScanImport({ open, onClose, onSuccess }: ScanImportProps) {
                 </p>
               </div>
             </div>
-            <div className="flex justify-end gap-2">
+            <div className="flex flex-wrap justify-end gap-2">
               <button className={ghostBtn} onClick={reset}>
                 Import another
               </button>
-              <button className={primaryBtn} onClick={handleClose}>
-                Close
+              <button className={ghostBtn} onClick={() => goTo("/findings")}>
+                View findings
+              </button>
+              <button className={primaryBtn} onClick={() => goTo("/explorer")}>
+                Open graph
               </button>
             </div>
           </div>


### PR DESCRIPTION
Issue 4: replace dead docs/*.md references in collector help/prompts (poison, implant, loot, discover, --rules-bundle) and the UI fallback page with published docs.agenthound.io URLs that actually resolve.

Issue 5: print "Next: agenthound-server ingest <path>" after a successful collector file write, and add View findings / Open graph navigation CTAs to the Scan Import success dialog.