### PR TITLE
refactor(looters): centralize getJSON/redact/credential-edge into sdk

### DIFF
--- a/modules/jupyterloot/looter.go
+++ b/modules/jupyterloot/looter.go
@@ -29,12 +29,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
@@ -60,12 +60,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		maxItems = DefaultMaxItems
 	}
 
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := common.NoRedirectClient(timeout)
 
 	res := &action.LootResult{IngestData: &ingest.IngestData{}}
 
@@ -159,7 +154,7 @@ type session struct {
 }
 
 func fetchSessions(ctx context.Context, client *http.Client, baseURL string) ([]session, error) {
-	body, err := getJSON(ctx, client, baseURL+"/api/sessions")
+	body, err := common.GetJSON(ctx, client, baseURL+"/api/sessions", "", 4<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +174,7 @@ type contentsEntry struct {
 
 func fetchContents(ctx context.Context, client *http.Client, baseURL, path string, maxItems int) ([]contentsEntry, error) {
 	u := baseURL + "/api/contents/" + path
-	body, err := getJSON(ctx, client, u)
+	body, err := common.GetJSON(ctx, client, u, "", 4<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -199,27 +194,6 @@ func fetchContents(ctx context.Context, client *http.Client, baseURL, path strin
 		}
 	}
 	return out, nil
-}
-
-func getJSON(ctx context.Context, client *http.Client, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return body, nil
 }
 
 var _ action.Looter = (*Looter)(nil)

--- a/modules/litellmloot/looter.go
+++ b/modules/litellmloot/looter.go
@@ -28,7 +28,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -74,12 +73,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		maxItems = DefaultMaxItems
 	}
 
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := common.NoRedirectClient(timeout)
 
 	res := &action.LootResult{
 		IngestData: &ingest.IngestData{},
@@ -112,7 +106,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		Properties: masterProps,
 	})
 	res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges,
-		exposesCredentialEdge(gatewayObjectID, masterID, opts.EngagementID, "master_key", baseURL))
+		ingest.ExposesCredentialEdge(gatewayObjectID, masterID, opts.EngagementID, "master_key", baseURL))
 
 	res.Summary.EndpointsProbed++
 	res.Summary.CredentialsFound++
@@ -124,7 +118,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 	if modelInfoErr != nil {
 		slog.Warn("litellm loot: /model/info failed",
 			"endpoint", modelInfoURL,
-			"key_prefix", redact(masterKey),
+			"key_prefix", common.Redact(masterKey),
 			"engagement_id", opts.EngagementID,
 			"error", modelInfoErr)
 		res.PartialErrors = append(res.PartialErrors, fmt.Sprintf("model/info: %v", modelInfoErr))
@@ -150,7 +144,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 			ID: credID, Kinds: []string{"Credential"}, Properties: props,
 		})
 		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges,
-			exposesCredentialEdge(gatewayObjectID, credID, opts.EngagementID, "model_info", uc.Endpoint))
+			ingest.ExposesCredentialEdge(gatewayObjectID, credID, opts.EngagementID, "model_info", uc.Endpoint))
 		res.Summary.CredentialsFound++
 	}
 
@@ -162,7 +156,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 	if keyListErr != nil {
 		slog.Warn("litellm loot: /key/list failed",
 			"endpoint", keyListURL,
-			"key_prefix", redact(masterKey),
+			"key_prefix", common.Redact(masterKey),
 			"engagement_id", opts.EngagementID,
 			"error", keyListErr)
 		res.PartialErrors = append(res.PartialErrors, fmt.Sprintf("key/list: %v", keyListErr))
@@ -189,13 +183,13 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 			ID: credID, Kinds: []string{"Credential"}, Properties: props,
 		})
 		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges,
-			exposesCredentialEdge(gatewayObjectID, credID, opts.EngagementID, "key_list", baseURL))
+			ingest.ExposesCredentialEdge(gatewayObjectID, credID, opts.EngagementID, "key_list", baseURL))
 		res.Summary.CredentialsFound++
 	}
 
 	slog.Info("litellm loot complete",
 		"endpoint", baseURL,
-		"key_prefix", redact(masterKey),
+		"key_prefix", common.Redact(masterKey),
 		"engagement_id", opts.EngagementID,
 		"credentials_found", res.Summary.CredentialsFound,
 		"partial_failures", res.Summary.PartialFailures)
@@ -230,7 +224,7 @@ type virtualKey struct {
 // varies. Unknown fields are skipped; missing fields produce no
 // upstreamCred for that entry rather than an error.
 func fetchModelInfo(ctx context.Context, client *http.Client, url, masterKey string, maxItems int) ([]upstreamCred, error) {
-	body, err := getJSON(ctx, client, url, masterKey)
+	body, err := common.GetJSON(ctx, client, url, masterKey, 16<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +273,7 @@ func fetchModelInfo(ctx context.Context, client *http.Client, url, masterKey str
 
 // fetchKeyList issues GET /key/list with the master key.
 func fetchKeyList(ctx context.Context, client *http.Client, url, masterKey string, maxItems int) ([]virtualKey, error) {
-	body, err := getJSON(ctx, client, url, masterKey)
+	body, err := common.GetJSON(ctx, client, url, masterKey, 16<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -333,56 +327,6 @@ func fetchKeyList(ctx context.Context, client *http.Client, url, masterKey strin
 	return out, nil
 }
 
-// getJSON does the GET-and-read dance with master-key auth. Reads up
-// to 16 MiB, then errors. Returns the raw body for the caller to
-// json.Unmarshal — the looter parses leniently and we don't want
-// double-decoding overhead.
-func getJSON(ctx context.Context, client *http.Client, url, masterKey string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+masterKey)
-	req.Header.Set("Accept", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return body, nil
-}
-
-// exposesCredentialEdge builds an EXPOSES_CREDENTIAL edge from the
-// LiteLLM gateway to a Credential. EngagementID and the source
-// endpoint are recorded in evidence so the post-processor can include
-// them in the credential-chain finding output.
-func exposesCredentialEdge(gatewayID, credID, engagementID, source, endpoint string) ingest.Edge {
-	props := map[string]any{
-		"confidence":  1.0,
-		"risk_weight": 0.1,
-		"evidence": map[string]any{
-			"endpoint":      endpoint,
-			"source":        source,
-			"engagement_id": engagementID,
-		},
-	}
-	return ingest.Edge{
-		Source:     gatewayID,
-		Target:     credID,
-		Kind:       "EXPOSES_CREDENTIAL",
-		SourceKind: "AIService",
-		TargetKind: "Credential",
-		Properties: props,
-	}
-}
-
 // sanitizeName turns a model_name into a property-safe slug.
 func sanitizeName(s string) string {
 	return strings.ToLower(strings.NewReplacer(" ", "-", "/", "-").Replace(s))
@@ -406,17 +350,6 @@ func extractProvider(e struct {
 		}
 	}
 	return "unknown"
-}
-
-// redact returns the first 8 characters of a secret followed by "..."
-// — used in slog output so master keys never appear in full anywhere
-// the operator can grep them out of a logfile. The 8-char prefix is
-// enough to disambiguate two keys without leaking the secret.
-func redact(secret string) string {
-	if len(secret) <= 8 {
-		return "***"
-	}
-	return secret[:8] + "..."
 }
 
 var _ action.Looter = (*Looter)(nil)

--- a/modules/litellmloot/redaction_test.go
+++ b/modules/litellmloot/redaction_test.go
@@ -58,22 +58,3 @@ func TestLoot_MasterKeyNeverInLogs(t *testing.T) {
 		t.Errorf("expected redacted prefix %q in logs; got:\n%s", wantPrefix, logs)
 	}
 }
-
-func TestRedact(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"sk-1234567890abcdef", "sk-12345..."},
-		{"sk-ABC", "***"},   // 6 chars ≤ 8 → fully redacted
-		{"", "***"},         // empty → fully redacted
-		{"12345678", "***"}, // exactly 8 → fully redacted
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			if got := redact(tt.input); got != tt.want {
-				t.Errorf("redact(%q) = %q, want %q", tt.input, got, tt.want)
-			}
-		})
-	}
-}

--- a/modules/litellmloot/redaction_test.go
+++ b/modules/litellmloot/redaction_test.go
@@ -14,7 +14,7 @@ import (
 
 // TestLoot_MasterKeyNeverInLogs is a hard regression guard: the FULL
 // master key MUST NEVER appear in slog output across any code path of
-// the looter. The redact() helper trims to an 8-char prefix; this test
+// the looter. common.Redact trims to an 8-char prefix; this test
 // captures every slog write into a buffer and greps for the full
 // secret.
 //
@@ -52,7 +52,7 @@ func TestLoot_MasterKeyNeverInLogs(t *testing.T) {
 	if strings.Contains(logs, sneakyMasterKey) {
 		t.Errorf("FULL master key leaked into slog output:\n%s", logs)
 	}
-	// Sanity: the redacted prefix should appear, proving redact() ran.
+	// Sanity: the redacted prefix should appear, proving common.Redact ran.
 	wantPrefix := sneakyMasterKey[:8] + "..."
 	if !strings.Contains(logs, wantPrefix) {
 		t.Errorf("expected redacted prefix %q in logs; got:\n%s", wantPrefix, logs)

--- a/modules/mlflowloot/looter.go
+++ b/modules/mlflowloot/looter.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
@@ -45,12 +46,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		timeout = DefaultProbeTimeout
 	}
 
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := common.NoRedirectClient(timeout)
 
 	res := &action.LootResult{IngestData: &ingest.IngestData{}}
 
@@ -106,7 +102,7 @@ type experiment struct {
 }
 
 func fetchExperiments(ctx context.Context, client *http.Client, baseURL string) ([]experiment, error) {
-	body, err := getJSON(ctx, client, baseURL+"/api/2.0/mlflow/experiments/search")
+	body, err := common.GetJSON(ctx, client, baseURL+"/api/2.0/mlflow/experiments/search", "", 4<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -141,27 +137,6 @@ func fetchRuns(ctx context.Context, client *http.Client, baseURL, experimentID s
 		return nil, fmt.Errorf("decode runs: %w", err)
 	}
 	return parsed.Runs, nil
-}
-
-func getJSON(ctx context.Context, client *http.Client, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return body, nil
 }
 
 func postJSON(ctx context.Context, client *http.Client, url string, payload []byte) ([]byte, error) {

--- a/modules/ollamaloot/looter.go
+++ b/modules/ollamaloot/looter.go
@@ -110,12 +110,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		return nil, errors.New("ollama loot: --include-weights requires --weights-dir <path>")
 	}
 
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := common.NoRedirectClient(timeout)
 
 	res := &action.LootResult{IngestData: &ingest.IngestData{}}
 
@@ -261,7 +256,7 @@ type tagEntry struct {
 }
 
 func fetchTags(ctx context.Context, client *http.Client, url string, maxItems int) ([]tagEntry, error) {
-	body, err := getJSON(ctx, client, url)
+	body, err := common.GetJSON(ctx, client, url, "", 1<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -431,29 +426,6 @@ func providesModelEdge(ollamaID, modelID, engagementID, digest string) ingest.Ed
 			},
 		},
 	}
-}
-
-// getJSON does the GET-and-read dance. 1 MiB cap matches the
-// fingerprint engine's body cap; /api/tags responses are tiny.
-func getJSON(ctx context.Context, client *http.Client, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return body, nil
 }
 
 func sanitizeFilename(s string) string {

--- a/modules/openwebuiloot/looter.go
+++ b/modules/openwebuiloot/looter.go
@@ -39,7 +39,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -102,12 +101,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		apiKey = strings.TrimSpace(opts.Credentials["api_key"])
 	}
 
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := common.NoRedirectClient(timeout)
 
 	res := &action.LootResult{IngestData: &ingest.IngestData{}}
 
@@ -162,7 +156,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		if credErr != nil {
 			slog.Warn("openwebui loot: /openai/config failed",
 				"endpoint", baseURL,
-				"key_prefix", redact(apiKey),
+				"key_prefix", common.Redact(apiKey),
 				"engagement_id", opts.EngagementID,
 				"error", credErr)
 			res.PartialErrors = append(res.PartialErrors, fmt.Sprintf("openai/config: %v", credErr))
@@ -192,7 +186,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 				Properties: cprops,
 			})
 			res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges,
-				exposesCredentialEdge(openwebuiID, credID, opts.EngagementID, "openai_config", uc.Endpoint))
+				ingest.ExposesCredentialEdge(openwebuiID, credID, opts.EngagementID, "openai_config", uc.Endpoint))
 			res.Summary.CredentialsFound++
 		}
 	}
@@ -223,7 +217,7 @@ type configPosture struct {
 // The ollama backend URL matches the fingerprinter's $.ollama.base_url
 // capture when present.
 func fetchConfig(ctx context.Context, client *http.Client, baseURL string) (configPosture, error) {
-	body, err := getJSON(ctx, client, strings.TrimRight(baseURL, "/")+"/api/config", "")
+	body, err := common.GetJSON(ctx, client, strings.TrimRight(baseURL, "/")+"/api/config", "", 4<<20)
 	if err != nil {
 		return configPosture{}, err
 	}
@@ -271,7 +265,7 @@ type upstreamCred struct {
 // Parsing is defensive: a missing array yields zero credentials, not an
 // error.
 func fetchOpenAIConfig(ctx context.Context, client *http.Client, baseURL, apiKey string, maxItems int) ([]upstreamCred, error) {
-	body, err := getJSON(ctx, client, strings.TrimRight(baseURL, "/")+"/openai/config", apiKey)
+	body, err := common.GetJSON(ctx, client, strings.TrimRight(baseURL, "/")+"/openai/config", apiKey, 4<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -302,65 +296,6 @@ func fetchOpenAIConfig(ctx context.Context, client *http.Client, baseURL, apiKey
 		out = append(out, uc)
 	}
 	return out, nil
-}
-
-// exposesCredentialEdge builds an EXPOSES_CREDENTIAL edge from the
-// OpenWebUIInstance to a Credential. SourceKind is AIService to match the
-// kinds registry's EXPOSES_CREDENTIAL constraint (source must be
-// AIService — see sdk/ingest/kinds.go).
-func exposesCredentialEdge(instanceID, credID, engagementID, source, endpoint string) ingest.Edge {
-	return ingest.Edge{
-		Source:     instanceID,
-		Target:     credID,
-		Kind:       "EXPOSES_CREDENTIAL",
-		SourceKind: "AIService",
-		TargetKind: "Credential",
-		Properties: map[string]any{
-			"confidence":  1.0,
-			"risk_weight": 0.1,
-			"evidence": map[string]any{
-				"endpoint":      endpoint,
-				"source":        source,
-				"engagement_id": engagementID,
-			},
-		},
-	}
-}
-
-// getJSON does the GET-and-read dance. When apiKey is non-empty a Bearer
-// header is attached (authenticated mode). 4 MiB cap matches the config
-// scale of these endpoints.
-func getJSON(ctx context.Context, client *http.Client, url, apiKey string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	if apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return body, nil
-}
-
-// redact returns the first 8 characters of a secret followed by "..." so
-// the operator's API key never appears in full in slog output.
-func redact(secret string) string {
-	if len(secret) <= 8 {
-		return "***"
-	}
-	return secret[:8] + "..."
 }
 
 var _ action.Looter = (*Looter)(nil)

--- a/modules/qdrantloot/looter.go
+++ b/modules/qdrantloot/looter.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -34,6 +33,7 @@ import (
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
@@ -65,12 +65,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		maxItems = DefaultMaxItems
 	}
 
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := common.NoRedirectClient(timeout)
 
 	res := &action.LootResult{IngestData: &ingest.IngestData{}}
 
@@ -144,7 +139,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 // is defensive — a missing or empty result yields an empty slice, not an
 // error (an anonymous Qdrant with zero collections is still a finding).
 func fetchCollections(ctx context.Context, client *http.Client, baseURL string, maxItems int) ([]string, error) {
-	body, err := getJSON(ctx, client, strings.TrimRight(baseURL, "/")+"/collections")
+	body, err := common.GetJSON(ctx, client, strings.TrimRight(baseURL, "/")+"/collections", "", 4<<20)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +174,7 @@ func fetchCollections(ctx context.Context, client *http.Client, baseURL string, 
 // count without inflating total_points with fabricated data.
 func fetchCollectionPoints(ctx context.Context, client *http.Client, baseURL, name string) (int64, error) {
 	u := strings.TrimRight(baseURL, "/") + "/collections/" + url.PathEscape(name)
-	body, err := getJSON(ctx, client, u)
+	body, err := common.GetJSON(ctx, client, u, "", 4<<20)
 	if err != nil {
 		return 0, err
 	}
@@ -192,29 +187,6 @@ func fetchCollectionPoints(ctx context.Context, client *http.Client, baseURL, na
 		return 0, fmt.Errorf("decode /collections/%s: %w", name, err)
 	}
 	return parsed.Result.PointsCount, nil
-}
-
-// getJSON does the GET-and-read dance. 4 MiB cap matches the metadata
-// scale of /collections responses — collection lists are small.
-func getJSON(ctx context.Context, client *http.Client, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-	return body, nil
 }
 
 var _ action.Looter = (*Looter)(nil)

--- a/sdk/common/httpget.go
+++ b/sdk/common/httpget.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// NoRedirectClient returns the looter-standard HTTP client: a fixed
+// timeout and a CheckRedirect that stops at the first response (looters
+// probe a specific endpoint and must not be bounced to an arbitrary host
+// by a 30x).
+func NoRedirectClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// GetJSON performs the GET-and-read dance shared by every looter: build a
+// GET request, set Accept: application/json, optionally attach a Bearer
+// token, execute, and read at most limit bytes of the body. A Bearer
+// header is attached only when bearer != "". A non-2xx status is returned
+// as an error. The raw body is returned as []byte; callers unmarshal it
+// themselves (response shapes differ per service).
+func GetJSON(ctx context.Context, client *http.Client, url, bearer string, limit int64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return body, nil
+}

--- a/sdk/common/httpget_test.go
+++ b/sdk/common/httpget_test.go
@@ -1,0 +1,98 @@
+package common
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetJSON_SendsGETWithAcceptAndNoBearerByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q, want application/json", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization = %q, want empty (no bearer)", got)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	body, err := GetJSON(context.Background(), srv.Client(), srv.URL, "", 4<<20)
+	if err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want {\"ok\":true}", body)
+	}
+}
+
+func TestGetJSON_AttachesBearerWhenSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok-123" {
+			t.Errorf("Authorization = %q, want Bearer tok-123", got)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	if _, err := GetJSON(context.Background(), srv.Client(), srv.URL, "tok-123", 4<<20); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+}
+
+func TestGetJSON_TruncatesAtLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("a", 1000)))
+	}))
+	defer srv.Close()
+
+	body, err := GetJSON(context.Background(), srv.Client(), srv.URL, "", 10)
+	if err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if len(body) != 10 {
+		t.Errorf("len(body) = %d, want 10 (LimitReader cap)", len(body))
+	}
+}
+
+func TestGetJSON_Non2xxIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := GetJSON(context.Background(), srv.Client(), srv.URL, "", 4<<20)
+	if err == nil {
+		t.Fatal("GetJSON: want error on HTTP 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("error = %v, want to contain 'status 500'", err)
+	}
+}
+
+func TestNoRedirectClient_DoesNotFollowRedirects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/elsewhere", http.StatusFound)
+			return
+		}
+		t.Errorf("redirect was followed to %s (NoRedirectClient must stop)", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	resp, err := NoRedirectClient(5 * time.Second).Get(srv.URL + "/start")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status = %d, want 302 (redirect not followed)", resp.StatusCode)
+	}
+}

--- a/sdk/common/redact.go
+++ b/sdk/common/redact.go
@@ -1,0 +1,14 @@
+package common
+
+// Redact returns a non-reversible prefix of a secret for safe logging:
+// the first 8 characters followed by "..." for values longer than 8
+// characters, or "***" for anything 8 characters or shorter (where an
+// 8-char prefix would expose too large a fraction of the secret). Looters
+// route operator-supplied keys through this before any slog call so a
+// full credential never lands in a log file or SIEM.
+func Redact(secret string) string {
+	if len(secret) <= 8 {
+		return "***"
+	}
+	return secret[:8] + "..."
+}

--- a/sdk/common/redact_test.go
+++ b/sdk/common/redact_test.go
@@ -1,0 +1,23 @@
+package common
+
+import "testing"
+
+func TestRedact(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"sk-1234567890abcdef", "sk-12345..."},
+		{"123456789", "12345678..."}, // 9 chars (> 8) → prefix + ...
+		{"sk-ABC", "***"},            // 6 chars ≤ 8 → fully redacted
+		{"", "***"},                  // empty → fully redacted
+		{"12345678", "***"},          // exactly 8 → fully redacted
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := Redact(tt.input); got != tt.want {
+				t.Errorf("Redact(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/ingest/exposes_credential.go
+++ b/sdk/ingest/exposes_credential.go
@@ -1,0 +1,27 @@
+package ingest
+
+// ExposesCredentialEdge builds the standard EXPOSES_CREDENTIAL edge from
+// an AIService node to a Credential node. Looters that enumerate exposed
+// upstream/provider secrets (litellmloot, openwebuiloot, ...) share this
+// constructor so the edge's confidence, risk_weight, and evidence shape
+// stay identical across collectors. SourceKind is AIService to satisfy
+// the kinds registry's EXPOSES_CREDENTIAL constraint (source must be an
+// AIService — see sdk/ingest/kinds.go).
+func ExposesCredentialEdge(sourceID, credID, engagementID, source, endpoint string) Edge {
+	return Edge{
+		Source:     sourceID,
+		Target:     credID,
+		Kind:       "EXPOSES_CREDENTIAL",
+		SourceKind: "AIService",
+		TargetKind: "Credential",
+		Properties: map[string]any{
+			"confidence":  1.0,
+			"risk_weight": 0.1,
+			"evidence": map[string]any{
+				"endpoint":      endpoint,
+				"source":        source,
+				"engagement_id": engagementID,
+			},
+		},
+	}
+}

--- a/sdk/ingest/exposes_credential_test.go
+++ b/sdk/ingest/exposes_credential_test.go
@@ -1,0 +1,49 @@
+package ingest
+
+import "testing"
+
+// TestExposesCredentialEdge locks the EXPOSES_CREDENTIAL contract shared by
+// every Looter that emits exposed upstream secrets (litellmloot,
+// openwebuiloot, ...). A typo in Kind or a swap of confidence/risk_weight
+// here would silently propagate to all of them, so the constants are
+// asserted explicitly rather than via an integration test.
+func TestExposesCredentialEdge(t *testing.T) {
+	e := ExposesCredentialEdge("svc-1", "cred-1", "ENG-1", "litellm_keys", "/key/info")
+
+	if e.Source != "svc-1" {
+		t.Errorf("Source: got %q, want %q", e.Source, "svc-1")
+	}
+	if e.Target != "cred-1" {
+		t.Errorf("Target: got %q, want %q", e.Target, "cred-1")
+	}
+	if e.Kind != "EXPOSES_CREDENTIAL" {
+		t.Errorf("Kind: got %q, want %q", e.Kind, "EXPOSES_CREDENTIAL")
+	}
+	if e.SourceKind != "AIService" {
+		t.Errorf("SourceKind: got %q, want %q", e.SourceKind, "AIService")
+	}
+	if e.TargetKind != "Credential" {
+		t.Errorf("TargetKind: got %q, want %q", e.TargetKind, "Credential")
+	}
+
+	if e.Properties["confidence"] != 1.0 {
+		t.Errorf("confidence: got %v, want 1.0", e.Properties["confidence"])
+	}
+	if e.Properties["risk_weight"] != 0.1 {
+		t.Errorf("risk_weight: got %v, want 0.1", e.Properties["risk_weight"])
+	}
+
+	ev, ok := e.Properties["evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("evidence: got %T, want map[string]any", e.Properties["evidence"])
+	}
+	if ev["endpoint"] != "/key/info" {
+		t.Errorf("evidence.endpoint: got %v, want %q", ev["endpoint"], "/key/info")
+	}
+	if ev["source"] != "litellm_keys" {
+		t.Errorf("evidence.source: got %v, want %q", ev["source"], "litellm_keys")
+	}
+	if ev["engagement_id"] != "ENG-1" {
+		t.Errorf("evidence.engagement_id: got %v, want %q", ev["engagement_id"], "ENG-1")
+	}
+}


### PR DESCRIPTION
## Summary
Centralizes HTTP/credential helpers that were duplicated across all six looters into the SDK, so a single change to timeout/redirect/redaction/credential-edge policy applies everywhere.

- `sdk/common.GetJSON(ctx, client, url, bearer, limit)` and `sdk/common.NoRedirectClient(timeout)` (new `sdk/common/httpget.go`)
- `sdk/common.Redact` secret-prefix redaction (new `sdk/common/redact.go`)
- `sdk/ingest.ExposesCredentialEdge` shared EXPOSES_CREDENTIAL constructor (new `sdk/ingest/exposes_credential.go`)
- Migrated jupyter / mlflow / ollama / litellm / qdrant / openwebui to the shared helpers (net -258 lines in `modules/`).

### Behavior preserved
- Per-looter read caps kept via the `limit` arg: 4 MiB default, 1 MiB ollama, 16 MiB litellm (no silent truncation).
- Bearer attached only when non-empty (matches prior openwebui semantics; litellm always supplies a master key).
- `mlflowloot.postJSON` (search POST) stays in-module; all six `get_only_test.go` guards still pass.
- `litellm` `TestRedact` moved to `sdk/common/redact_test.go`; `TestLoot_MasterKeyNeverInLogs` retained.
- Helpers live in already-allowlisted `sdk/common` / `sdk/ingest` -> no collector deps-allowlist change.

## Test plan
- [x] `gofmt -l .` (clean)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (modules, sdk, server, collector all pass)
- [x] `scripts/deps-check.sh`
- [x] `scripts/size-check.sh` (collector 9.98 MiB < 10.84 MiB limit)

Made with [Cursor](https://cursor.com)