### PR TITLE
perf(qdrantloot): parallelize per-collection point fetch

### DIFF
--- a/modules/qdrantloot/looter.go
+++ b/modules/qdrantloot/looter.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
@@ -41,6 +42,13 @@ const (
 	DefaultPort         = 6333
 	DefaultProbeTimeout = 30 * time.Second
 	DefaultMaxItems     = 1000
+
+	// DefaultCollectionConcurrency bounds the per-collection detail
+	// fetches. Qdrant's /collections returns only names, so points_count
+	// requires one GET per collection (an N+1 stall when done serially);
+	// these run in a small worker pool instead. 16 is gentle on a single
+	// host (networkscan uses 50 across many hosts).
+	DefaultCollectionConcurrency = 16
 )
 
 // Looter is the registered module.
@@ -101,21 +109,57 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 
 	sort.Strings(names)
 
+	// Fetch per-collection point counts in a bounded worker pool. Each
+	// worker writes only to its own pre-indexed slot (race-free, no
+	// mutex); the shared result and counters are folded in a single
+	// serial pass after Wait(), iterating the sorted names so output is
+	// deterministic regardless of goroutine completion order. ctx is
+	// threaded into every fetch, so a cancelled context fails the
+	// in-flight and remaining GETs fast (recorded as partial failures),
+	// matching the prior serial behavior.
+	conc := DefaultCollectionConcurrency
+	if conc > len(names) {
+		conc = len(names)
+	}
+
+	points := make([]int64, len(names))
+	detErrs := make([]string, len(names))
+	idxs := make(chan int)
+
+	var wg sync.WaitGroup
+	for w := 0; w < conc; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range idxs {
+				p, detErr := fetchCollectionPoints(ctx, client, baseURL, names[i])
+				if detErr != nil {
+					detErrs[i] = fmt.Sprintf("collections/%s: %v", names[i], detErr)
+					continue
+				}
+				points[i] = p
+			}
+		}()
+	}
+	for i := range names {
+		idxs <- i
+	}
+	close(idxs)
+	wg.Wait()
+
 	var totalPoints int64
-	for _, name := range names {
-		points, detErr := fetchCollectionPoints(ctx, client, baseURL, name)
+	for i := range names {
 		res.Summary.EndpointsProbed++
-		if detErr != nil {
+		if detErrs[i] != "" {
 			slog.Debug("qdrant loot: collection detail failed",
-				"collection", name,
+				"collection", names[i],
 				"engagement_id", opts.EngagementID,
-				"error", detErr)
-			res.PartialErrors = append(res.PartialErrors,
-				fmt.Sprintf("collections/%s: %v", name, detErr))
+				"error", detErrs[i])
+			res.PartialErrors = append(res.PartialErrors, detErrs[i])
 			res.Summary.PartialFailures++
 			continue
 		}
-		totalPoints += points
+		totalPoints += points[i]
 	}
 
 	props := res.IngestData.Graph.Nodes[0].Properties

--- a/modules/qdrantloot/looter_test.go
+++ b/modules/qdrantloot/looter_test.go
@@ -206,8 +206,77 @@ func TestLoot_Qdrant_ManyCollectionsConcurrent(t *testing.T) {
 	if res.Summary.PartialFailures != wantFailures {
 		t.Errorf("PartialFailures = %d, want %d", res.Summary.PartialFailures, wantFailures)
 	}
+	// Assert the FULL collections slice, not just first/last: the names
+	// arrive pre-sorted from sort.Strings before the pool runs, so this
+	// pins both completeness AND ascending order against a future refactor
+	// that moves assembly into the concurrent fold (where completion order
+	// could leak through).
 	got, _ := node.Properties["collections"].([]string)
-	if len(got) != n || got[0] != "col-00" || got[n-1] != "col-49" {
-		t.Errorf("collections not sorted/complete: got %v", got)
+	if len(got) != n {
+		t.Fatalf("collections length = %d, want %d", len(got), n)
+	}
+	for i, nm := range names {
+		if got[i] != nm {
+			t.Errorf("collections[%d] = %q, want %q (sorted order broken)", i, got[i], nm)
+		}
+	}
+
+	// Assert PartialErrors content/format, not just the count: the worker
+	// pre-formats "collections/%s: %v" into a per-index slot (looter.go),
+	// so a dropped name or mangled prefix would still pass the count check
+	// above. Spot-check one bad collection's entry is present and well-formed.
+	if len(res.PartialErrors) != wantFailures {
+		t.Fatalf("PartialErrors length = %d, want %d", len(res.PartialErrors), wantFailures)
+	}
+	wantPrefix := "collections/col-01: " // col-01 is bad (odd index)
+	var found bool
+	for _, pe := range res.PartialErrors {
+		if strings.HasPrefix(pe, wantPrefix) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("PartialErrors missing well-formed entry with prefix %q; got %v", wantPrefix, res.PartialErrors)
+	}
+}
+
+// TestLoot_Qdrant_ZeroCollections pins the conc=0 boundary: an anonymous
+// Qdrant with zero collections must clamp the worker count to 0 (no
+// goroutines spawned), drain the empty index channel, and return without
+// deadlocking — emitting the node with collection_count=0, total_points=0.
+// This is the riskiest new edge of the worker pool; a deadlock here would
+// hang every scan of an empty instance.
+func TestLoot_Qdrant_ZeroCollections(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/collections" {
+			_, _ = w.Write([]byte(`{"result":{"collections":[]},"status":"ok"}`))
+			return
+		}
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+
+	l := &Looter{}
+	res, err := l.Loot(context.Background(), action.Target{
+		Kind:    "host",
+		Address: strings.TrimPrefix(srv.URL, "http://"),
+	}, action.LootOptions{})
+	if err != nil {
+		t.Fatalf("Loot: %v", err)
+	}
+	if got := len(res.IngestData.Graph.Nodes); got != 1 {
+		t.Fatalf("nodes: got %d, want 1 (QdrantInstance still emitted)", got)
+	}
+	node := res.IngestData.Graph.Nodes[0]
+	if cc, _ := node.Properties["collection_count"].(int); cc != 0 {
+		t.Errorf("collection_count = %v, want 0", node.Properties["collection_count"])
+	}
+	if tp, _ := node.Properties["total_points"].(int64); tp != 0 {
+		t.Errorf("total_points = %v, want 0", node.Properties["total_points"])
+	}
+	if res.Summary.PartialFailures != 0 {
+		t.Errorf("PartialFailures = %d, want 0", res.Summary.PartialFailures)
 	}
 }

--- a/modules/qdrantloot/looter_test.go
+++ b/modules/qdrantloot/looter_test.go
@@ -2,6 +2,7 @@ package qdrantloot
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -131,5 +132,82 @@ func TestLoot_Qdrant_CollectionsListFails(t *testing.T) {
 	}
 	if res.Summary.PartialFailures != 1 {
 		t.Errorf("PartialFailures = %d, want 1", res.Summary.PartialFailures)
+	}
+}
+
+// TestLoot_Qdrant_ManyCollectionsConcurrent exercises the bounded worker
+// pool with more collections than the concurrency bound, where half the
+// per-collection detail probes fail. It asserts the aggregation is
+// correct and order-independent: total_points sums only the good
+// collections, PartialFailures counts the bad ones, and the collections
+// list stays sorted regardless of goroutine completion order. Run under
+// -race, it also guards the disjoint-slot writes against data races.
+func TestLoot_Qdrant_ManyCollectionsConcurrent(t *testing.T) {
+	const n = 50
+	names := make([]string, 0, n)
+	points := make(map[string]int64, n)
+	bad := make(map[string]bool, n)
+	var wantTotal int64
+	wantFailures := 0
+	for i := 0; i < n; i++ {
+		nm := fmt.Sprintf("col-%02d", i)
+		names = append(names, nm)
+		if i%2 == 1 {
+			bad[nm] = true
+			wantFailures++
+		} else {
+			p := int64((i + 1) * 10)
+			points[nm] = p
+			wantTotal += p
+		}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/collections" {
+			var sb strings.Builder
+			sb.WriteString(`{"result":{"collections":[`)
+			for i, nm := range names {
+				if i > 0 {
+					sb.WriteByte(',')
+				}
+				sb.WriteString(`{"name":"`)
+				sb.WriteString(nm)
+				sb.WriteString(`"}`)
+			}
+			sb.WriteString(`]},"status":"ok"}`)
+			_, _ = w.Write([]byte(sb.String()))
+			return
+		}
+		name := strings.TrimPrefix(r.URL.Path, "/collections/")
+		if bad[name] {
+			_, _ = w.Write([]byte(`not-json`))
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"result":{"points_count":%d},"status":"ok"}`, points[name])
+	}))
+	defer srv.Close()
+
+	l := &Looter{}
+	res, err := l.Loot(context.Background(), action.Target{
+		Kind:    "host",
+		Address: strings.TrimPrefix(srv.URL, "http://"),
+	}, action.LootOptions{})
+	if err != nil {
+		t.Fatalf("Loot: %v", err)
+	}
+	node := res.IngestData.Graph.Nodes[0]
+	if cc, _ := node.Properties["collection_count"].(int); cc != n {
+		t.Errorf("collection_count = %v, want %d", node.Properties["collection_count"], n)
+	}
+	if tp, _ := node.Properties["total_points"].(int64); tp != wantTotal {
+		t.Errorf("total_points = %v, want %d", node.Properties["total_points"], wantTotal)
+	}
+	if res.Summary.PartialFailures != wantFailures {
+		t.Errorf("PartialFailures = %d, want %d", res.Summary.PartialFailures, wantFailures)
+	}
+	got, _ := node.Properties["collections"].([]string)
+	if len(got) != n || got[0] != "col-00" || got[n-1] != "col-49" {
+		t.Errorf("collections not sorted/complete: got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary
Parallelizes the Qdrant looter's per-collection `points_count` fetches with a bounded stdlib worker pool, removing the N+1 serial stall (Qdrant's `/collections` returns only names, so each `points_count` needs its own GET).

- `DefaultCollectionConcurrency = 16`; mirrors `modules/networkscan`'s channel + `sync.WaitGroup` pattern -- no `errgroup`, so no collector deps-allowlist change.
- Workers write only to disjoint pre-indexed slots (race-free, no mutex); shared result/counters are folded in a single serial pass after `Wait()`, iterating the sorted names so output stays byte-deterministic regardless of completion order.
- `ctx` is threaded into every fetch, so a cancelled context fails remaining GETs fast (recorded as partial failures) -- matching the prior serial behavior.
- Adds a 50-collection concurrent test (run under `-race`) asserting correct `total_points` sum, `PartialFailures` count, and sorted `collections`.

> Stacked on #52 (looter/SDK dedup) because both touch `modules/qdrantloot/looter.go`. Base will auto-retarget to `main` once #52 merges; the diff against this PR's base is only `modules/qdrantloot/`.

## Test plan
- [x] `gofmt -l .` (clean)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./modules/qdrantloot/... -race -count=5`
- [x] `go test ./... -race`
- [x] `scripts/deps-check.sh`
- [x] `scripts/size-check.sh` (collector 9.99 MiB < 10.84 MiB limit)

Made with [Cursor](https://cursor.com)