### PR TITLE
fix(install): avoid rate-limited API and correct cosign identity case

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -86,10 +86,10 @@ Every release artifact is signed with cosign (keyless, GitHub Actions OIDC). Ver
 
 ```bash
 cosign verify-blob \
-    --bundle agenthound_0.6.0_checksums.txt.sigstore.json \
+    --bundle checksums.txt.sigstore.json \
     --certificate-identity-regexp 'https://github.com/adithyan-ak/AgentHound/.*' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-    agenthound_0.6.0_checksums.txt
+    checksums.txt
 ```
 
 The signature and Fulcio certificate are bundled into a single

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -87,7 +87,7 @@ Every release artifact is signed with cosign (keyless, GitHub Actions OIDC). Ver
 ```bash
 cosign verify-blob \
     --bundle agenthound_0.6.0_checksums.txt.sigstore.json \
-    --certificate-identity-regexp 'https://github.com/adithyan-ak/agenthound/.*' \
+    --certificate-identity-regexp 'https://github.com/adithyan-ak/AgentHound/.*' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
     agenthound_0.6.0_checksums.txt
 ```

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,10 @@
 
 set -e
 
-GITHUB_REPO="adithyan-ak/agenthound"
+# Canonical owner/repo case matters: GitHub URLs are case-insensitive, but the
+# cosign keyless signature's certificate identity (SAN) is the exact slug the
+# release workflow ran under, so this must match it verbatim or cosign rejects it.
+GITHUB_REPO="adithyan-ak/AgentHound"
 INSTALL_DIR="${AGENTHOUND_INSTALL_DIR:-$HOME/.local/bin}"
 
 echo ""
@@ -28,10 +31,18 @@ esac
 
 # Resolve version. Default to the latest GitHub Release tag.
 if [ -z "$AGENTHOUND_VERSION" ]; then
-  VERSION=$(curl -sSfL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" \
-    | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
-  if [ -z "$VERSION" ]; then
-    echo "Error: could not determine latest release"; exit 1
+  # Resolve "latest" via the github.com redirect, NOT api.github.com. The REST
+  # API is rate-limited to 60 requests/hour per IP for anonymous callers, which
+  # is permanently exhausted behind shared / corporate NAT egress IPs and breaks
+  # the installer with a 403. The /releases/latest redirect carries no such
+  # budget: it 302s to /releases/tag/<version>, which we parse out.
+  resolved=$(curl -sSL -o /dev/null -w '%{url_effective}' \
+    "https://github.com/${GITHUB_REPO}/releases/latest" || true)
+  VERSION=${resolved##*/tag/}
+  if [ -z "$VERSION" ] || [ "$VERSION" = "$resolved" ]; then
+    echo "Error: could not determine latest release"
+    echo "       Set AGENTHOUND_VERSION=vX.Y.Z to pin a specific version."
+    exit 1
   fi
 else
   VERSION="$AGENTHOUND_VERSION"


### PR DESCRIPTION
## Summary

Fixes that broke `curl -sSfL .../install.sh | sh` and the documented release-verification flow:

- **Rate-limited version detection (403).** The installer resolved the latest release via `api.github.com/repos/.../releases/latest`, capped at **60 requests/hour per IP** for anonymous callers. Behind shared/corporate NAT egress that budget is permanently exhausted, so the call returns `403` and the script aborts with `Error: could not determine latest release` — regardless of waiting or switching machines (same egress IP pool). Over HTTP/2 `curl --fail` surfaces this as `curl: (56) ... 403`. Now resolved via the `github.com/.../releases/latest` **redirect** (302 → `/releases/tag/<version>`), which carries no API budget. `AGENTHOUND_VERSION` still overrides.
- **cosign verification rejected the signature (script).** `GITHUB_REPO` was lowercase (`adithyan-ak/agenthound`), but the certificate identity (SAN) is the canonical slug the release workflow ran under: `adithyan-ak/AgentHound`. URLs are case-insensitive (downloads worked), but cosign requires an **exact** SAN match. Fixed to canonical case (also corrects the printed manual-verify hint).
- **Docs cosign example was doubly broken (`docs/getting-started/install.md`).** (a) Same lowercase identity bug — fails identically when copy-pasted; corrected to `AgentHound`. (b) Wrong filenames — referenced `agenthound_0.6.0_checksums.txt[.sigstore.json]`, but GoReleaser publishes plain `checksums.txt` + `checksums.txt.sigstore.json` (confirmed against v0.6.0 assets and `.goreleaser.yml`), so it failed with `no such file`. Both fixed; the example now matches the prose below it and the canonical command in `.goreleaser.yml`.

## Scope notes

- Go module import paths (`github.com/adithyan-ak/agenthound/...`) and `go install` lines are **intentionally unchanged** — case-sensitive Go identifiers tied to `go.mod` that work as-is.
- `docs/operator/scanner.md` / `rules-bundle.yml` use the generic `https://github.com/.*` regex, which verifies fine (left as-is).
- Cosmetic lowercase URLs (header comment, README, CHANGELOG, quickstart) are case-insensitive (verified `200`) and left unchanged.

## Test plan

- [x] `sh -n install.sh` — no syntax errors
- [x] Redirect resolution returns `v0.6.0` with **zero** `api.github.com` calls
- [x] Full documented command (corrected identity + filenames) → `Verified OK`; lowercase identity → fails; wrong filenames → `no such file`
- [x] `cosign verify-blob` with corrected script identity → `Verified OK`
- [x] Archive + `checksums.txt` download endpoints return `200`
- [ ] End-to-end on a clean machine: `curl -sSfL https://raw.githubusercontent.com/adithyan-ak/AgentHound/main/install.sh | sh` (after merge)