### PR TITLE
feat(ui): uniform explorer empty states & fix phantom lens-filter dot

### DIFF
--- a/server/ui/src/features/explorer/model/store.ts
+++ b/server/ui/src/features/explorer/model/store.ts
@@ -205,10 +205,28 @@ export const useExplorerStore = create<ExplorerState & ExplorerActions>()(
       // restores the user's lens + sub-preset choices without restoring a
       // stale selection.
       name: "agenthound-explorer-view",
+      version: 1,
       partialize: (state) => ({
         activeLens: state.activeLens,
         subPresets: state.subPresets,
       }),
+      // v0 persisted the absolute sub-preset arrays. When a lens' DEFAULTS
+      // later expanded (new edge kinds added to lens-config, e.g. the AI-service
+      // topology edges and CAN_IMPERSONATE), the stored arrays no longer matched
+      // the live defaults — so LensBar lit a spurious "filtered" dot for users
+      // who never actually filtered, and switching lenses couldn't clear it.
+      // Drop the stale selection on upgrade so each lens tracks its live default
+      // again; genuine filters are re-applied in-session and persist normally.
+      migrate: (persisted, version) => {
+        const prev = (persisted ?? {}) as Partial<ExplorerState>;
+        if (version < 1) {
+          return {
+            ...prev,
+            subPresets: DEFAULT_SUB_PRESETS,
+          } as ExplorerState & ExplorerActions;
+        }
+        return prev as ExplorerState & ExplorerActions;
+      },
     },
   ),
 );

--- a/server/ui/src/features/explorer/ui/ChainRibbon.tsx
+++ b/server/ui/src/features/explorer/ui/ChainRibbon.tsx
@@ -1,13 +1,13 @@
 import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import { AlertOctagon, ArrowRight, ExternalLink, Shield } from "lucide-react";
+import { AlertOctagon, ArrowRight, ExternalLink } from "lucide-react";
 import { useExplorerGraph } from "@features/explorer/model/useExplorerGraph";
 import { useExplorerStore } from "@features/explorer/model/store";
 import {
   extractCriticalChains,
   type CriticalChain,
 } from "@features/explorer/model/critical-chains";
-import { SEVERITY, SIGNAL_OK } from "@shared/theme/tokens";
+import { SEVERITY } from "@shared/theme/tokens";
 import { cn } from "@shared/lib/utils";
 
 export function ChainRibbon() {
@@ -25,25 +25,9 @@ export function ChainRibbon() {
 
   if (activeLens !== "critical") return null;
 
-  if (chains.length === 0) {
-    return (
-      <div
-        className={cn(
-          "pointer-events-auto absolute bottom-9 left-1/2 z-20 -translate-x-1/2",
-          "overflow-hidden rounded-md border border-border bg-card/95 px-5 py-3 backdrop-blur-md elev-2",
-        )}
-        style={{ boxShadow: `inset 2px 0 0 0 ${SIGNAL_OK}` }}
-      >
-        <div
-          className="flex items-center gap-2 font-mono text-xs uppercase tracking-[0.06em]"
-          style={{ color: SIGNAL_OK }}
-        >
-          <Shield className="h-4 w-4" strokeWidth={2.25} />
-          <span>No critical attack paths detected in this scan.</span>
-        </div>
-      </div>
-    );
-  }
+  // A clean critical scan is rendered by the canvas' uniform empty-state
+  // overlay; the ribbon only appears when there are chains to list.
+  if (chains.length === 0) return null;
 
   return (
     <div

--- a/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
+++ b/server/ui/src/features/explorer/ui/ExplorerCanvas.tsx
@@ -24,10 +24,13 @@ import type {
 } from "@features/explorer/model/graph";
 import type { ExplorerRawData } from "@features/explorer/model/useExplorerGraph";
 import { useEscapeKey } from "@shared/lib/useEscapeKey";
+import { ACCENT } from "@shared/theme/tokens";
+import { Hexagon } from "lucide-react";
 import { HexNode } from "./nodes/HexNode";
 import { OrphanClusterNode } from "./nodes/OrphanClusterNode";
 import { LensEdge } from "./edges/LensEdge";
 import { SelfLoopEdge } from "./edges/SelfLoopEdge";
+import { ExplorerEmptyState, getLensEmptyCopy } from "./ExplorerEmptyState";
 
 const nodeTypes = {
   hex: HexNode,
@@ -288,17 +291,14 @@ export function ExplorerCanvas({
 
   if (!isLoading && data && data.nodes.length === 0 && data.edges.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center bg-explorer-canvas">
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div className="text-4xl text-primary/60">&#x2B22;</div>
-          <p className="font-mono text-xs font-semibold uppercase tracking-[0.14em] text-foreground">
-            No graph data yet
-          </p>
-          <p className="max-w-xs text-xs text-muted-foreground">
-            Run a scan or ingest collector output to populate the graph.
-          </p>
-        </div>
-      </div>
+      <ExplorerEmptyState
+        fill
+        icon={Hexagon}
+        accent={ACCENT}
+        eyebrow="No graph data"
+        title="Nothing ingested yet"
+        hint="Run a scan or ingest collector output to populate the graph."
+      />
     );
   }
 
@@ -313,40 +313,58 @@ export function ExplorerCanvas({
     );
   }
 
+  // The active lens filtered the graph down to nothing visible (a clean scan
+  // for the finding-driven lenses). Float a uniform, theme-matched verdict over
+  // the canvas — the dotted backdrop and any ghosted context still read behind
+  // it. Blast Radius never lands here: it shows every node until one is picked.
+  const lensEmpty =
+    built.metrics.visibleNodeCount === 0 &&
+    built.metrics.visibleEdgeCount === 0;
+  const emptyCopy = getLensEmptyCopy(activeLens);
+
   return (
-    <ReactFlow
-      nodes={displayNodes}
-      edges={edges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onNodeClick={onNodeClick}
-      onEdgeClick={onEdgeClick}
-      onEdgeMouseMove={onEdgeMouseMove}
-      onEdgeMouseLeave={onEdgeMouseLeave}
-      onNodeContextMenu={onNodeContextMenu}
-      onPaneClick={onPaneClick}
-      nodeTypes={nodeTypes}
-      edgeTypes={edgeTypes}
-      fitView
-      minZoom={0.08}
-      maxZoom={2.2}
-      proOptions={{ hideAttribution: true }}
-      defaultEdgeOptions={{ type: "lens" }}
-      onlyRenderVisibleElements
-      nodesDraggable={false}
-      nodesConnectable={false}
-    >
-      <Background
-        variant={BackgroundVariant.Dots}
-        gap={20}
-        size={1.4}
-        color="hsl(215 25% 17%)"
-      />
-      <Controls
-        position="bottom-right"
-        showInteractive={false}
-        className="!overflow-hidden !rounded-md !border !border-border !bg-card !shadow-lg [&_.react-flow__controls-button]:!border-border [&_.react-flow__controls-button]:!bg-card [&_.react-flow__controls-button]:!fill-mauve-11 [&_.react-flow__controls-button:hover]:!bg-white/[0.06] [&_.react-flow__controls-button:hover]:!fill-foreground"
-      />
-    </ReactFlow>
+    <>
+      <ReactFlow
+        nodes={displayNodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={onNodeClick}
+        onEdgeClick={onEdgeClick}
+        onEdgeMouseMove={onEdgeMouseMove}
+        onEdgeMouseLeave={onEdgeMouseLeave}
+        onNodeContextMenu={onNodeContextMenu}
+        onPaneClick={onPaneClick}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        minZoom={0.08}
+        maxZoom={2.2}
+        proOptions={{ hideAttribution: true }}
+        defaultEdgeOptions={{ type: "lens" }}
+        onlyRenderVisibleElements
+        nodesDraggable={false}
+        nodesConnectable={false}
+      >
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={20}
+          size={1.4}
+          color="hsl(215 25% 17%)"
+        />
+        <Controls
+          position="bottom-right"
+          showInteractive={false}
+          className="!overflow-hidden !rounded-md !border !border-border !bg-card !shadow-lg [&_.react-flow__controls-button]:!border-border [&_.react-flow__controls-button]:!bg-card [&_.react-flow__controls-button]:!fill-mauve-11 [&_.react-flow__controls-button:hover]:!bg-white/[0.06] [&_.react-flow__controls-button:hover]:!fill-foreground"
+        />
+      </ReactFlow>
+      {lensEmpty && (
+        <ExplorerEmptyState
+          eyebrow={emptyCopy.eyebrow}
+          title={emptyCopy.title}
+          hint={emptyCopy.hint}
+        />
+      )}
+    </>
   );
 }

--- a/server/ui/src/features/explorer/ui/ExplorerEmptyState.tsx
+++ b/server/ui/src/features/explorer/ui/ExplorerEmptyState.tsx
@@ -1,0 +1,165 @@
+import type { LucideIcon } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
+import type { LensId } from "@features/explorer/model/store";
+import { SIGNAL_OK } from "@shared/theme/tokens";
+import { cn } from "@shared/lib/utils";
+
+export interface ExplorerEmptyStateProps {
+  eyebrow: string;
+  title: string;
+  hint: string;
+  icon?: LucideIcon;
+  /** Accent hue for the medallion, hairline, and eyebrow. Defaults to the OK signal. */
+  accent?: string;
+  /**
+   * When true the overlay paints the canvas backdrop (used when there is no
+   * graph at all). When false it floats transparently over the live graph so
+   * the dotted backdrop and any ghosted context still read through.
+   */
+  fill?: boolean;
+}
+
+/**
+ * Centered, theme-matched empty state for the explorer canvas. Shared by the
+ * "no graph data" case and every lens' "nothing to show" case so the surface
+ * reads uniformly however a scan comes back clean. The medallion is a hexagon
+ * to echo the graph's hex nodes.
+ */
+export function ExplorerEmptyState({
+  eyebrow,
+  title,
+  hint,
+  icon: Icon = ShieldCheck,
+  accent = SIGNAL_OK,
+  fill = false,
+}: ExplorerEmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-0 z-10 flex items-center justify-center p-6",
+        fill && "bg-explorer-canvas",
+      )}
+    >
+      <div
+        role="status"
+        className={cn(
+          "relative flex w-[300px] max-w-[calc(100vw-32px)] flex-col items-center gap-4 text-center",
+          "overflow-hidden rounded-lg border border-border bg-card/80 px-7 py-8 backdrop-blur-md elev-2",
+        )}
+      >
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-white/[0.06]"
+        />
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-1/2 top-0 h-px w-16 -translate-x-1/2"
+          style={{ background: accent, opacity: 0.85 }}
+        />
+
+        <div className="relative flex h-16 w-16 items-center justify-center">
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-full blur-xl"
+            style={{ background: accent, opacity: 0.16 }}
+          />
+          <svg
+            aria-hidden
+            viewBox="0 0 100 100"
+            className="absolute inset-0 h-full w-full"
+          >
+            <polygon
+              points="50,3 91,26.5 91,73.5 50,97 9,73.5 9,26.5"
+              fill={`${accent}14`}
+              stroke={`${accent}66`}
+              strokeWidth="3"
+            />
+          </svg>
+          <Icon
+            className="relative h-7 w-7"
+            style={{ color: accent }}
+            strokeWidth={1.75}
+          />
+        </div>
+
+        <div className="flex flex-col items-center gap-1.5">
+          <div
+            className="flex items-center gap-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.2em]"
+            style={{ color: accent }}
+          >
+            <span
+              className="h-1.5 w-1.5 animate-led-pulse rounded-[1px]"
+              style={{ background: accent }}
+            />
+            {eyebrow}
+          </div>
+          <h2 className="text-[15px] font-semibold leading-tight text-foreground">
+            {title}
+          </h2>
+          <p className="max-w-[15rem] text-xs leading-relaxed text-muted-foreground">
+            {hint}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface LensEmptyCopy {
+  eyebrow: string;
+  title: string;
+  hint: string;
+}
+
+/**
+ * Per-lens copy for the "this lens found nothing" overlay. The design is
+ * uniform; only the wording adapts so the verdict reads true for each view.
+ * The finding-driven lenses frame the empty result as good news; the purely
+ * structural lenses stay neutral.
+ */
+const LENS_EMPTY_COPY: Record<LensId, LensEmptyCopy> = {
+  topology: {
+    eyebrow: "Empty graph",
+    title: "Nothing to map",
+    hint: "No structural relationships were discovered in this scan.",
+  },
+  "attack-surface": {
+    eyebrow: "All clear",
+    title: "No attack surface",
+    hint: "Nothing in scope can reach, execute, or exfiltrate — no attack paths surfaced.",
+  },
+  critical: {
+    eyebrow: "All clear",
+    title: "No critical attack paths",
+    hint: "This scan surfaced zero critical-severity paths. Nothing here needs urgent attention.",
+  },
+  "cross-protocol": {
+    eyebrow: "All clear",
+    title: "No cross-protocol paths",
+    hint: "Nothing crosses the A2A ↔ MCP boundary in this scan.",
+  },
+  credentials: {
+    eyebrow: "All clear",
+    title: "No credential exposure",
+    hint: "No credential flows or exposed secrets were found in this scan.",
+  },
+  poisoning: {
+    eyebrow: "All clear",
+    title: "No poisoning detected",
+    hint: "No prompt-injection, tool-shadowing, or instruction-file attacks were found.",
+  },
+  "blast-radius": {
+    eyebrow: "Blast radius",
+    title: "Pick a node to begin",
+    hint: "Select any node to trace everything reachable from it.",
+  },
+  chokepoints: {
+    eyebrow: "Empty graph",
+    title: "No chokepoints",
+    hint: "No connected nodes to rank in this scan.",
+  },
+};
+
+export function getLensEmptyCopy(lens: LensId): LensEmptyCopy {
+  return LENS_EMPTY_COPY[lens];
+}

--- a/server/ui/src/features/explorer/ui/LensBar.tsx
+++ b/server/ui/src/features/explorer/ui/LensBar.tsx
@@ -67,10 +67,18 @@ function LensPill({ lens, active, onClick }: LensPillProps) {
     <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       <div className={pillClasses} style={pillStyle}>
         {isFiltered && (
-          <span
-            aria-hidden
-            title="Filtered — sub-presets differ from default"
-            className="pointer-events-none absolute -right-1 -top-1 h-2 w-2 rounded-full bg-amber-400 ring-2 ring-card"
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setSubPresets(lens.id, DEFAULT_SUB_PRESETS[lens.id] ?? []);
+            }}
+            title={`Filtered: showing ${subPresets.length} of ${lens.subPresets.length} relationship types. Click to reset to default.`}
+            aria-label={`${lens.label} relationships filtered — click to reset to default`}
+            className={cn(
+              "absolute -right-1 -top-1 z-10 h-2.5 w-2.5 rounded-full bg-amber-400 ring-2 ring-card",
+              "transition-transform duration-150 hover:scale-125 focus-visible:scale-125 focus-visible:outline-none",
+            )}
           />
         )}
         <button onClick={onClick} className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary
Two explorer UI fixes reported from the lens views.

- **Uniform empty states.** When a scan comes back clean, the finding-driven lenses (Attack Surface, Critical, Cross-Protocol, Credentials, Poisoning) filtered the graph down to nothing and rendered a blank canvas — only Critical had a placeholder, a bottom-pinned pill in an off-theme green. Added one themed `ExplorerEmptyState` overlay (hexagon medallion echoing the hex nodes, lens-aware copy) shown whenever the active lens has no visible nodes/edges, reused it for the global "no graph data" state, and removed `ChainRibbon`'s old placeholder. Blast Radius is unaffected — it shows every node until one is picked, so it never reports empty.
- **Phantom lens-filter dot.** The LensBar amber "filtered" dot compares a lens' persisted sub-presets against its live defaults (derived from `lens-config`). Those defaults grew over time (AI-service topology edges, `CAN_IMPERSONATE`) but the persisted store had no migration, so older saved selections no longer matched and lit the dot for users who never filtered — and switching lenses couldn't clear it. Bumped the persisted store to `v1` with a migration that resets stale sub-presets to the live defaults, and made the dot a button with a reachable tooltip + click-to-reset (it was `pointer-events-none`, so its tooltip never showed and clicks did nothing).

## Test plan
- [x] `npm run build` (tsc -b + vite) passes
- [x] `npm run lint` clean
- [x] `npm test` — 77/77 pass
- [ ] Manual: a structural-only scan shows the uniform "All clear" overlay on Attack Surface / Cross-Protocol / Poisoning; Topology / Credentials render normally
- [ ] Manual: with stale `agenthound-explorer-view` localStorage, reload → phantom dots on Topology / Attack Surface are gone
- [ ] Manual: narrow a lens via the `▾` menu → dot appears with tooltip; click the dot → resets to default and the dot disappears
