### PR TITLE
chore(release): prep v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.6.1
+
+Patch release. Repairs the release pipeline, hardens the collector installer, and polishes the Explorer UI.
+
+### Release pipeline
+
+- Homebrew tap publishing now authenticates with a dedicated `HOMEBREW_TAP_GITHUB_TOKEN`. The v0.6.0 release run pushed every other artifact (binaries, Docker images + manifests, cosign signatures, SBOMs, checksums, GitHub release) but failed at the final GoReleaser step: the `agenthound` / `agenthound-server` formula push to `adithyan-ak/homebrew-agenthound` returned `404` under the default `GITHUB_TOKEN`, which has no write access to the separate tap repo.
+
+### Install
+
+- `install.sh` resolves the latest release via the `github.com/<repo>/releases/latest` redirect instead of `api.github.com`. The REST API is rate-limited to 60 requests/hour per IP for anonymous callers — permanently exhausted behind shared / corporate NAT egress — which `403`'d the installer. The redirect path carries no such budget. (#58)
+- Corrected the cosign certificate-identity case to match the canonical `adithyan-ak/AgentHound` slug the release workflow signs under, so keyless signature verification no longer rejects a valid signature. (#58)
+
+### UI
+
+- Uniform Explorer empty states across the canvas, and fixed a phantom lens-filter indicator dot. (#59)
+
+### Documentation
+
+- README Quick Start rewritten into per-step copy-paste blocks (one command per fenced block); added a "Recon to Report" CLI lifecycle showcase and reordered sections so the tool is runnable sooner. (#60)
+
 ## v0.6.0
 
 The "moat detectors + read-only loot expansion" milestone. Triples the read-only Looter surface (Qdrant, Open WebUI, MLflow), adds four taint- and identity-aware post-processors with their composite edges, persists findings to Postgres for triage and cross-scan diff, crosswalks detections to MITRE ATLAS, and rebuilds the dashboard on the Obsidian Terminal theme. Also ships the OriginGuard CSRF rework that retires the on-disk bearer token, plus a zero-toolchain Docker install path.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ go install github.com/adithyan-ak/agenthound/server/cmd/agenthound-server@latest
 agenthound-server serve
 
 # Pin install.sh to a release tag (verifies checksums; uses cosign when available)
-curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.6.0/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.6.1/install.sh | sh
 ```
 
 See the full [installation guide](https://docs.agenthound.io/getting-started/install/) for Homebrew, release binaries, signature verification, and source builds.

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # AgentHound collector installer.
 #
 # Pin to a release tag for integrity:
-#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.6.0/install.sh | sh
+#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.6.1/install.sh | sh
 #
 # Verifies the downloaded archive against checksums.txt before extracting,
 # and against cosign signatures if cosign is available on $PATH.


### PR DESCRIPTION
## Summary

Release-prep for **v0.6.1**, a patch release whose primary goal is to prove the release pipeline goes fully green (v0.6.0's run failed only at the Homebrew tap publish step).

- Bump `install.sh` + `README.md` pin examples `v0.6.0` → `v0.6.1`
- Add `CHANGELOG.md` `## v0.6.1` entry

## What ships in v0.6.1

- **Release pipeline:** Homebrew tap publishing now authenticates with `HOMEBREW_TAP_GITHUB_TOKEN` (v0.6.0 pushed all other artifacts but 404'd pushing formulae to `homebrew-agenthound` under the default `GITHUB_TOKEN`).
- **Install:** `install.sh` resolves latest via the `releases/latest` redirect (avoids the anon `api.github.com` 60/hr rate limit) and corrects the cosign cert-identity case. (#58)
- **UI:** uniform Explorer empty states + phantom lens-filter dot fix. (#59)
- **Docs:** README Quick Start per-step blocks, "Recon to Report" showcase, section reorder. (#60)

Note: the binary version is injected from the git tag via GoReleaser ldflags, so no source version bump is required.

## Verification

- `make prerelease` — all 12 gates pass locally (gofmt, golangci-lint, vet, govulncheck, go-licenses, build, `test -race -short`, deps-check, size-check, slop-check, UI build, cross-compile).
- Docs-only diff; no code paths touched.

## Test plan

- [ ] CI green on this PR
- [ ] After merge + tag, release run finishes **fully green** (esp. the Homebrew step)
- [ ] Tap formulae bump to `0.6.1`; `install.sh` latest resolves to v0.6.1

Made with [Cursor](https://cursor.com)