### PR TITLE
feat(scan): minimal progress + summary output for scan/discover

### DIFF
--- a/collector/cli/discover.go
+++ b/collector/cli/discover.go
@@ -60,6 +60,7 @@ func init() {
 	discoverCmd.Flags().Bool("allow-large-cidr", false, "Allow probing CIDRs larger than /16")
 	discoverCmd.Flags().String("authorization-file", "", "Path to a written-authorization document; recorded in the watermark")
 	discoverCmd.Flags().String("scan-output", "", "Write ingest JSON to this path. Use '-' for stdout.")
+	discoverCmd.Flags().Bool("verbose", false, "List per-endpoint discover results. Default is a one-line summary.")
 	rootCmd.AddCommand(discoverCmd)
 }
 
@@ -75,6 +76,8 @@ func runDiscover(cmd *cobra.Command, args []string) error {
 	allowPublic, _ := cmd.Flags().GetBool("allow-public-targets")
 	allowLarge, _ := cmd.Flags().GetBool("allow-large-cidr")
 	authzFile, _ := cmd.Flags().GetString("authorization-file")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	quiet := quietEnabled(cmd)
 	output, _ := cmd.Flags().GetString("scan-output")
 	if output == "" {
 		if cfg != nil && cfg.Output != "" {
@@ -126,19 +129,35 @@ func runDiscover(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	reporter := newProgressReporter(cmd.OutOrStderr(), "[discover] probing "+spec, quiet)
+	scanner.Progress = reporter.update
+
 	ctx := context.Background()
-	_, _ = fmt.Fprintf(cmd.OutOrStderr(), "[discover] expanding targets: %s\n", spec)
+	if !quiet {
+		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "[discover] expanding targets: %s\n", spec)
+	}
 	targets, err := scanner.Scan(ctx, spec)
+	reporter.clear()
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("discover: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-		"[discover] discovered %d endpoint(s)\n", len(targets))
-	for _, t := range targets {
+	// Default output is a single summary line; the full per-endpoint listing
+	// is gated behind --verbose. --quiet suppresses both.
+	if !quiet {
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-			"[discover]   %s — protocol=%s url=%s\n",
-			t.Address, t.Meta["protocol"], t.Meta["url"])
+			"[discover] %s: %d endpoint(s)\n", spec, len(targets))
+		switch {
+		case verbose:
+			for _, t := range targets {
+				_, _ = fmt.Fprintf(cmd.OutOrStderr(),
+					"[discover]   %s — protocol=%s url=%s\n",
+					t.Address, t.Meta["protocol"], t.Meta["url"])
+			}
+		case len(targets) > 0:
+			_, _ = fmt.Fprintf(cmd.OutOrStderr(),
+				"[discover] (re-run with --verbose to list per-endpoint details)\n")
+		}
 	}
 
 	envelope := buildDiscoverEnvelope(spec, targets, authzFile, authzHash, allowPublic)

--- a/collector/cli/progress.go
+++ b/collector/cli/progress.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// isTerminal reports whether w is a character device (a TTY). Non-file
+// writers (a bytes.Buffer in tests, a pipe, a regular file) return false so
+// the rewriting progress line never pollutes piped or redirected output with
+// carriage returns.
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// progressReporter renders a single rewriting status line to a TTY. When the
+// destination is not a terminal (or --quiet is set) every method is a no-op,
+// so CI logs and piped output stay clean.
+//
+// It is NOT safe for concurrent use. Callers drive it from a single
+// goroutine — the scanners invoke their Progress callback from one dedicated
+// reporter goroutine, and the fingerprint loop is sequential.
+type progressReporter struct {
+	w       io.Writer
+	label   string
+	enabled bool
+	lastLen int
+}
+
+func newProgressReporter(w io.Writer, label string, quiet bool) *progressReporter {
+	return &progressReporter{
+		w:       w,
+		label:   label,
+		enabled: !quiet && isTerminal(w),
+	}
+}
+
+// update redraws the progress line with the current done/total counts. The
+// line is padded to overwrite any longer previous render before the carriage
+// return, so a shrinking count never leaves stale characters behind.
+func (p *progressReporter) update(done, total int) {
+	if !p.enabled || total <= 0 {
+		return
+	}
+	pct := done * 100 / total
+	line := fmt.Sprintf("%s %d/%d (%d%%)", p.label, done, total, pct)
+	pad := ""
+	if p.lastLen > len(line) {
+		pad = strings.Repeat(" ", p.lastLen-len(line))
+	}
+	_, _ = fmt.Fprintf(p.w, "\r%s%s", line, pad)
+	p.lastLen = len(line)
+}
+
+// clear erases the current progress line so a following summary prints on a
+// clean line. No-op when disabled or when nothing has been drawn.
+func (p *progressReporter) clear() {
+	if !p.enabled || p.lastLen == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(p.w, "\r%s\r", strings.Repeat(" ", p.lastLen))
+	p.lastLen = 0
+}

--- a/collector/cli/progress_test.go
+++ b/collector/cli/progress_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestIsTerminal_NonFileWriterIsFalse guards the core safety property: a
+// non-*os.File writer (bytes.Buffer here, a pipe in real piped output) is
+// never treated as a TTY, so progress carriage returns can't pollute it.
+func TestIsTerminal_NonFileWriterIsFalse(t *testing.T) {
+	if isTerminal(&bytes.Buffer{}) {
+		t.Error("bytes.Buffer must not be reported as a terminal")
+	}
+}
+
+// TestProgressReporter_DisabledIsNoop verifies that a reporter built over a
+// non-TTY writer writes nothing at all — the piped/CI path stays clean.
+func TestProgressReporter_DisabledIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	r := newProgressReporter(&buf, "[scan]", false)
+	r.update(1, 10)
+	r.clear()
+	if buf.Len() != 0 {
+		t.Errorf("disabled reporter wrote %q, want nothing", buf.String())
+	}
+}
+
+// TestProgressReporter_QuietDisables verifies --quiet disables rendering even
+// if the destination were a terminal.
+func TestProgressReporter_QuietDisables(t *testing.T) {
+	if newProgressReporter(&bytes.Buffer{}, "[scan]", true).enabled {
+		t.Error("reporter must be disabled when quiet is set")
+	}
+}
+
+// TestProgressReporter_RendersWhenEnabled exercises the rendering path with a
+// force-enabled reporter (no real TTY needed) and locks the line format.
+func TestProgressReporter_RendersWhenEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	r := &progressReporter{w: &buf, label: "[scan] probing x", enabled: true}
+
+	r.update(3, 10)
+	out := buf.String()
+	if !strings.HasPrefix(out, "\r") {
+		t.Errorf("update output must start with a carriage return, got %q", out)
+	}
+	if !strings.Contains(out, "[scan] probing x 3/10 (30%)") {
+		t.Errorf("update output = %q, want it to contain '3/10 (30%%)'", out)
+	}
+
+	buf.Reset()
+	r.clear()
+	cleared := buf.String()
+	if !strings.HasPrefix(cleared, "\r") || !strings.HasSuffix(cleared, "\r") {
+		t.Errorf("clear output = %q, want it wrapped in carriage returns", cleared)
+	}
+	if r.lastLen != 0 {
+		t.Errorf("lastLen after clear = %d, want 0", r.lastLen)
+	}
+}
+
+// TestProgressReporter_PadsShrinkingLine ensures a shorter render overwrites a
+// previous longer one so no stale glyphs remain on the line.
+func TestProgressReporter_PadsShrinkingLine(t *testing.T) {
+	var buf bytes.Buffer
+	r := &progressReporter{w: &buf, label: "L", enabled: true}
+
+	r.update(100, 100) // "L 100/100 (100%)" — the longer render
+	prevLen := len("L 100/100 (100%)")
+
+	buf.Reset()
+	r.update(1, 100) // "L 1/100 (1%)" — shorter, must be padded
+	rendered := strings.TrimPrefix(buf.String(), "\r")
+	if len(rendered) < prevLen {
+		t.Errorf("shrinking update rendered %d cols (%q), want >= %d to overwrite stale chars",
+			len(rendered), rendered, prevLen)
+	}
+}

--- a/collector/cli/root.go
+++ b/collector/cli/root.go
@@ -69,6 +69,18 @@ func init() {
 	rootCmd.PersistentFlags().String("rules-bundle", "", "Path to a fingerprint rules bundle (directory or .tar.gz). Same-id rules from the bundle override the embedded set. Verify cosign signature manually before pointing AgentHound at it; see https://docs.agenthound.io/reference/rule-syntax/. (env: AGENTHOUND_RULES_BUNDLE)")
 }
 
+// quietEnabled resolves the effective quiet setting for a command: the
+// --quiet persistent flag OR AGENTHOUND_QUIET=1, mirroring the resolution in
+// PersistentPreRunE. It is safe to call on a command with no parent (the
+// flag lookup simply fails and we fall back to the env var), so unit tests
+// that build bare commands don't panic.
+func quietEnabled(cmd *cobra.Command) bool {
+	if q, err := cmd.Root().PersistentFlags().GetBool("quiet"); err == nil && q {
+		return true
+	}
+	return os.Getenv("AGENTHOUND_QUIET") == "1"
+}
+
 func setupLogger(level string, quiet, jsonLog bool) {
 	var logLevel slog.Level
 	switch level {

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -95,6 +95,8 @@ func init() {
 	scanCmd.Flags().Bool("allow-large-cidr", false, "Allow scanning CIDRs larger than /16 (IPv4) or /112 (IPv6).")
 	scanCmd.Flags().String("authorization-file", "", "Path to a written-authorization document. The path and SHA-256 are recorded in the scan-output watermark.")
 
+	scanCmd.Flags().Bool("verbose", false, "List per-host scan results (network mode). Default is a one-line summary.")
+
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -394,6 +396,8 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 	concurrency, _ := cmd.Flags().GetInt("network-scan-concurrency")
 	authzFile, _ := cmd.Flags().GetString("authorization-file")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	quiet := quietEnabled(cmd)
 
 	// AUTHORIZED prompt — required when --allow-public-targets is set, before
 	// any network IO. Skipped when the spec is a private/loopback host
@@ -439,6 +443,7 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 	// possible — avoids constructing a parallel options struct. We don't
 	// type-assert here because module.Get returns the concrete value the
 	// init() registered.
+	reporter := newProgressReporter(cmd.OutOrStderr(), "[scan] probing "+spec, quiet)
 	if ns, ok := mod.(*networkscan.Scanner); ok {
 		if len(ports) > 0 {
 			ns.Ports = ports
@@ -451,21 +456,36 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 		if timeout > 0 {
 			ns.Timeout = timeout
 		}
+		ns.Progress = reporter.update
 	}
 
 	ctx := context.Background()
-	_, _ = fmt.Fprintf(cmd.OutOrStderr(), "[scan] expanding targets: %s\n", spec)
+	if !quiet {
+		_, _ = fmt.Fprintf(cmd.OutOrStderr(), "[scan] expanding targets: %s\n", spec)
+	}
 	targets, err := scanner.Scan(ctx, spec)
+	reporter.clear()
 	if err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("scan: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-		"[scan] discovered %d host(s) with at least one open port\n", len(targets))
-	for _, t := range targets {
+	// Default output is a single summary line. The full per-host listing —
+	// which can run to thousands of lines on a large sweep — is gated behind
+	// --verbose. --quiet suppresses both.
+	if !quiet {
 		_, _ = fmt.Fprintf(cmd.OutOrStderr(),
-			"[scan]   %s — open: %s — candidates: %s\n",
-			t.Address, t.Meta["open_ports"], t.Meta["candidate_kinds"])
+			"[scan] %s: %d host(s) with at least one open port\n", spec, len(targets))
+		switch {
+		case verbose:
+			for _, t := range targets {
+				_, _ = fmt.Fprintf(cmd.OutOrStderr(),
+					"[scan]   %s — open: %s — candidates: %s\n",
+					t.Address, t.Meta["open_ports"], t.Meta["candidate_kinds"])
+			}
+		case len(targets) > 0:
+			_, _ = fmt.Fprintf(cmd.OutOrStderr(),
+				"[scan] (re-run with --verbose to list per-host open ports)\n")
+		}
 	}
 
 	// Phase 2: fingerprint each target against its candidate kinds. The
@@ -476,7 +496,7 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 	// Jupyter, LangServe, OpenWebUI in v0.2 — fingerprinters land in
 	// v0.3/v0.4) emit no node; this is intentional per design F.
 	envelope := buildNetworkScanEnvelope(spec, targets, authzFile, authzHash, allowPublic)
-	dispatchFingerprints(ctx, cmd.OutOrStderr(), targets, envelope)
+	dispatchFingerprints(ctx, cmd.OutOrStderr(), targets, envelope, quiet)
 
 	if output == "" {
 		output = fmt.Sprintf("scan-%s.json", envelope.Meta.ScanID)
@@ -567,7 +587,14 @@ func sha256OfFile(path string) (string, error) {
 //
 // Failures are logged but never fatal: a misbehaving fingerprinter
 // against one target should not block the rest of the scan.
-func dispatchFingerprints(ctx context.Context, stderr io.Writer, targets []action.Target, envelope *ingest.IngestData) {
+func dispatchFingerprints(ctx context.Context, stderr io.Writer, targets []action.Target, envelope *ingest.IngestData, quiet bool) {
+	// Pre-count the probes we will actually attempt (open port → candidate
+	// kind → registered fingerprinter) so the progress line has an exact
+	// denominator. This walks the same decision tree as the dispatch loop
+	// below but does no network IO.
+	total := countFingerprintProbes(targets)
+	reporter := newProgressReporter(stderr, "[scan] fingerprinting", quiet)
+
 	matched := 0
 	probed := 0
 	for _, t := range targets {
@@ -607,6 +634,7 @@ func dispatchFingerprints(ctx context.Context, stderr io.Writer, targets []actio
 					continue
 				}
 				probed++
+				reporter.update(probed, total)
 				result, err := fp.Fingerprint(ctx, action.Target{
 					Kind:    "host",
 					Address: fmt.Sprintf("%s:%s", host, portStr),
@@ -620,16 +648,50 @@ func dispatchFingerprints(ctx context.Context, stderr io.Writer, targets []actio
 					continue
 				}
 				matched++
-				_, _ = fmt.Fprintf(stderr,
-					"[fingerprint] %s:%s → %s (version=%s, auth=%s)\n",
-					host, portStr, result.ServiceKind, result.Version, result.AuthMethod)
+				if !quiet {
+					// Clear the progress line so the match prints cleanly,
+					// then let the next update() redraw it.
+					reporter.clear()
+					_, _ = fmt.Fprintf(stderr,
+						"[fingerprint] %s:%s → %s (version=%s, auth=%s)\n",
+						host, portStr, result.ServiceKind, result.Version, result.AuthMethod)
+				}
 				envelope.Graph.Nodes = append(envelope.Graph.Nodes, result.IngestData.Graph.Nodes...)
 				envelope.Graph.Edges = append(envelope.Graph.Edges, result.IngestData.Graph.Edges...)
 			}
 		}
 	}
-	_, _ = fmt.Fprintf(stderr,
-		"[scan] fingerprint summary: %d probe(s), %d match(es)\n", probed, matched)
+	reporter.clear()
+	if !quiet {
+		_, _ = fmt.Fprintf(stderr,
+			"[scan] fingerprint summary: %d probe(s), %d match(es)\n", probed, matched)
+	}
+}
+
+// countFingerprintProbes returns the exact number of fingerprint probes
+// dispatchFingerprints will attempt for the given targets — one per
+// (open port, candidate kind) pair that has a registered fingerprinter.
+// It performs no network IO; it only consults the module registry.
+func countFingerprintProbes(targets []action.Target) int {
+	total := 0
+	for _, t := range targets {
+		for _, portStr := range splitCSV(t.Meta["open_ports"]) {
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				continue
+			}
+			kinds, ok := networkscan.PortToKind[port]
+			if !ok {
+				continue
+			}
+			for _, kind := range kinds {
+				if _, ok := module.GetByTarget(kind, action.Fingerprint); ok {
+					total++
+				}
+			}
+		}
+	}
+	return total
 }
 
 // splitCSV is the no-op-on-empty companion of strings.Split. Returns nil

--- a/collector/cli/scan_fixes_test.go
+++ b/collector/cli/scan_fixes_test.go
@@ -66,7 +66,7 @@ func TestDispatchFingerprints_DerivesKindFromPort(t *testing.T) {
 	}}
 
 	envelope := &ingest.IngestData{}
-	dispatchFingerprints(context.Background(), io.Discard, targets, envelope)
+	dispatchFingerprints(context.Background(), io.Discard, targets, envelope, false)
 
 	if fp.probeCount != 1 {
 		t.Fatalf("fingerprinter probed %d time(s), want exactly 1", fp.probeCount)
@@ -154,7 +154,7 @@ func TestDispatchFingerprints_TriesAllCandidateKinds(t *testing.T) {
 	}}
 
 	envelope := &ingest.IngestData{}
-	dispatchFingerprints(context.Background(), io.Discard, targets, envelope)
+	dispatchFingerprints(context.Background(), io.Discard, targets, envelope, false)
 
 	if vllm.probeCount != 1 {
 		t.Errorf("vllm probed %d time(s), want exactly 1", vllm.probeCount)

--- a/collector/cli/scan_test.go
+++ b/collector/cli/scan_test.go
@@ -31,6 +31,7 @@ func newScanCmdForTest() *cobra.Command {
 	cmd.Flags().Duration("timeout", 0, "")
 	cmd.Flags().Bool("insecure", false, "")
 	cmd.Flags().String("scan-output", "", "")
+	cmd.Flags().Bool("verbose", false, "")
 	return cmd
 }
 

--- a/docs/operator/scanner.md
+++ b/docs/operator/scanner.md
@@ -117,6 +117,8 @@ The envelope contains:
 
 ## Operational notes
 
+**Progress and output volume.** By default the scanner prints a single summary line — `[scan] <spec>: N host(s) with at least one open port` — followed by the per-match fingerprint lines and a fingerprint summary. The full per-host listing (open ports + candidate kinds for every host) is gated behind `--verbose`, because a `/24` sweep over a bridge or VPN can otherwise emit hundreds of near-identical lines. When stderr is an interactive terminal, a single rewriting progress line tracks the port sweep and the fingerprint phase; it is omitted automatically when output is piped or redirected (so logs stay clean) and when `--quiet` / `AGENTHOUND_QUIET=1` is set. Progress and summaries go to stderr and never affect the JSON written to `--output`.
+
 **Cancellation.** Ctrl-C cancels the worker pool cleanly. The producer stops queueing tasks before the next port probe; in-flight probes drain to completion (3-second timeout). Partial results are written to `--output` so a long-running scan that gets interrupted still produces useful JSON.
 
 **False positives on private networks with weird routing.** If your dev machine runs Tailscale / a corporate VPN / CGNAT routing, TCP connect probes against unrouted private IPs can return success because the kernel's connect path catches the SYN locally. The scanner reports what it sees at the TCP layer; the fingerprinters in the next step are the actual correctness layer (an open port that doesn't speak Ollama produces no `OllamaInstance` node).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -86,8 +86,11 @@ At least one of `--target`, `--targets`, `--targets-file`, or `--discover-domain
 | `--allow-public-targets` | `false` | Allow scanning non-RFC1918 IPs. Requires interactive `AUTHORIZED` prompt. |
 | `--allow-large-cidr` | `false` | Allow CIDRs larger than /16 (IPv4) or /112 (IPv6). |
 | `--authorization-file` | | Path to a written-authorization document. Path + SHA-256 recorded in scan watermark. |
+| `--verbose` | `false` | List every discovered host (open ports + candidate kinds). Default is a one-line summary. |
 
 Link-local and multicast addresses are refused unconditionally.
+
+By default network-mode `scan` prints a one-line summary (`N host(s) with at least one open port`) plus a final fingerprint summary; pass `--verbose` to list every host, which can run to thousands of lines on a large sweep. On an interactive terminal a single rewriting progress line is shown during the port sweep and fingerprint phase. `--quiet` (or `AGENTHOUND_QUIET=1`) suppresses the progress line, the per-host summary, and the fingerprint output, leaving only errors. None of this affects the JSON written to `--output`.
 
 #### Shared Flags
 
@@ -136,6 +139,9 @@ agenthound discover <cidr|host|@file> [flags]
 | `--allow-large-cidr` | `false` | Allow CIDRs larger than /16. |
 | `--authorization-file` | | Written-authorization doc; recorded in watermark. |
 | `--scan-output` | | Output path (defaults to `./discover-<scan_id>.json`). |
+| `--verbose` | `false` | List every discovered endpoint (protocol + URL). Default is a one-line summary. |
+
+Like `scan`, `discover` prints a one-line summary by default (`N endpoint(s)`), shows a rewriting progress line on an interactive terminal, and honors `--quiet` / `AGENTHOUND_QUIET=1`. Pass `--verbose` to list each endpoint.
 
 #### Example
 

--- a/modules/networkscan/scanner.go
+++ b/modules/networkscan/scanner.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
@@ -79,6 +80,13 @@ type Scanner struct {
 	// Dialer is overridable in tests so the worker pool can be exercised
 	// without binding to real ports. nil → net.Dialer with Timeout.
 	Dialer dialer
+
+	// Progress, if non-nil, is called periodically with the number of
+	// completed probes and the total probe count (hosts × ports). It is
+	// invoked from a single dedicated goroutine on a fixed cadence, plus
+	// once at the end, so implementations may render directly without
+	// locking. nil disables progress reporting (the default).
+	Progress func(done, total int)
 }
 
 // hostResult aggregates open ports for a single host with mutex-protected
@@ -140,6 +148,30 @@ func (s *Scanner) Scan(ctx context.Context, cidr string) ([]action.Target, error
 	}
 	tasks := make(chan probeTask, concurrency*2)
 
+	// Progress accounting: workers bump completed after each probe; a single
+	// reporter goroutine samples it on a fixed cadence so rendering never
+	// contends with the worker pool. Guarded so a nil Progress costs nothing.
+	total := len(hosts) * len(ports)
+	var completed atomic.Int64
+	var stopReporter, reporterDone chan struct{}
+	if s.Progress != nil && total > 0 {
+		stopReporter = make(chan struct{})
+		reporterDone = make(chan struct{})
+		go func() {
+			defer close(reporterDone)
+			ticker := time.NewTicker(150 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopReporter:
+					return
+				case <-ticker.C:
+					s.Progress(int(completed.Load()), total)
+				}
+			}
+		}()
+	}
+
 	var wg sync.WaitGroup
 	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
@@ -147,6 +179,7 @@ func (s *Scanner) Scan(ctx context.Context, cidr string) ([]action.Target, error
 			defer wg.Done()
 			for t := range tasks {
 				probe(ctx, d, t.host, t.port, timeout, results[t.host])
+				completed.Add(1)
 			}
 		}()
 	}
@@ -165,6 +198,16 @@ producer:
 	}
 	close(tasks)
 	wg.Wait()
+
+	// Stop the reporter and emit one final sample. Receiving on reporterDone
+	// guarantees the ticker goroutine has returned, so this last call can
+	// never race with it. On a clean run completed == total (every probe ran);
+	// on cancellation it reflects the partial count.
+	if s.Progress != nil && total > 0 {
+		close(stopReporter)
+		<-reporterDone
+		s.Progress(int(completed.Load()), total)
+	}
 
 	var out []action.Target
 	for _, host := range hosts {

--- a/modules/networkscan/scanner_test.go
+++ b/modules/networkscan/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -209,6 +210,54 @@ func TestScanner_PanicIsolation(t *testing.T) {
 	}
 	if !panicked.Load() {
 		t.Error("panic was not triggered (test setup wrong)")
+	}
+}
+
+// TestScanner_ProgressReported verifies the optional Progress hook fires and
+// that the final sample reports every probe complete (done == total ==
+// hosts × ports). A /30 is 4 hosts × the 7 default ports = 28 probes.
+func TestScanner_ProgressReported(t *testing.T) {
+	d := &fakeDialer{openSet: map[string]bool{"10.0.0.1:11434": true}}
+
+	var mu sync.Mutex
+	var calls [][2]int
+	s := &Scanner{
+		Dialer:  d,
+		Timeout: 100 * time.Millisecond,
+		Progress: func(done, total int) {
+			mu.Lock()
+			calls = append(calls, [2]int{done, total})
+			mu.Unlock()
+		},
+	}
+
+	if _, err := s.Scan(context.Background(), "10.0.0.0/30"); err != nil {
+		t.Fatalf("Scan err = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) == 0 {
+		t.Fatal("Progress was never called")
+	}
+	wantTotal := 4 * len(DefaultPorts)
+	last := calls[len(calls)-1]
+	if last[0] != wantTotal || last[1] != wantTotal {
+		t.Errorf("final progress = [%d %d], want [%d %d]", last[0], last[1], wantTotal, wantTotal)
+	}
+}
+
+// TestScanner_NoProgressHook is a guard that a nil Progress field is the safe
+// default — Scan must complete normally without ever touching the hook.
+func TestScanner_NoProgressHook(t *testing.T) {
+	d := &fakeDialer{openSet: map[string]bool{"10.0.0.1:11434": true}}
+	s := &Scanner{Dialer: d, Timeout: 100 * time.Millisecond}
+	targets, err := s.Scan(context.Background(), "10.0.0.0/30")
+	if err != nil {
+		t.Fatalf("Scan err = %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("got %d targets, want 1", len(targets))
 	}
 }
 

--- a/modules/protoscan/scanner.go
+++ b/modules/protoscan/scanner.go
@@ -36,6 +36,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/adithyan-ak/agenthound/modules/networkscan"
@@ -74,6 +75,12 @@ type Scanner struct {
 	Timeout     time.Duration
 	Insecure    bool
 	ExpandOpts  networkscan.ExpandOptions
+
+	// Progress, if non-nil, is called periodically with the number of
+	// completed probes and the total probe count (hosts × protocol ports).
+	// It is invoked from a single dedicated goroutine on a fixed cadence,
+	// plus once at the end, so implementations may render without locking.
+	Progress func(done, total int)
 
 	httpClient *http.Client
 }
@@ -153,6 +160,30 @@ func (s *Scanner) Scan(ctx context.Context, spec string) ([]action.Target, error
 	results := make([]action.Target, 0, len(hosts))
 	var mu sync.Mutex
 
+	// Progress accounting: workers bump completed after each probe; a single
+	// reporter goroutine samples it on a fixed cadence so rendering never
+	// contends with the worker pool. Guarded so a nil Progress costs nothing.
+	total := len(jobs)
+	var completed atomic.Int64
+	var stopReporter, reporterDone chan struct{}
+	if s.Progress != nil && total > 0 {
+		stopReporter = make(chan struct{})
+		reporterDone = make(chan struct{})
+		go func() {
+			defer close(reporterDone)
+			ticker := time.NewTicker(150 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopReporter:
+					return
+				case <-ticker.C:
+					s.Progress(int(completed.Load()), total)
+				}
+			}
+		}()
+	}
+
 	jobCh := make(chan job)
 	var wg sync.WaitGroup
 	for i := 0; i < s.Concurrency; i++ {
@@ -168,6 +199,7 @@ func (s *Scanner) Scan(ctx context.Context, spec string) ([]action.Target, error
 					results = append(results, t)
 					mu.Unlock()
 				}
+				completed.Add(1)
 			}
 		}()
 	}
@@ -183,6 +215,15 @@ dispatch:
 	}
 	close(jobCh)
 	wg.Wait()
+
+	// Stop the reporter and emit one final sample. Receiving on reporterDone
+	// guarantees the ticker goroutine has returned, so this last call can
+	// never race with it.
+	if s.Progress != nil && total > 0 {
+		close(stopReporter)
+		<-reporterDone
+		s.Progress(int(completed.Load()), total)
+	}
 
 	if cancelled {
 		return results, ctx.Err()

--- a/modules/protoscan/scanner_test.go
+++ b/modules/protoscan/scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -231,6 +232,39 @@ func TestScan_CancellationReturnsPartialAndError(t *testing.T) {
 		if tgt.Meta["protocol"] != "mcp" {
 			t.Errorf("partial target protocol = %q, want mcp", tgt.Meta["protocol"])
 		}
+	}
+}
+
+// TestScan_ProgressReported verifies the optional Progress hook fires and the
+// final sample reports every probe complete. ModeMCP with a single port over
+// one host is exactly 1 job, so the terminal sample must be [1 1].
+func TestScan_ProgressReported(t *testing.T) {
+	srv := mcpStub(t)
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var calls [][2]int
+	s := &Scanner{
+		Mode:     ModeMCP,
+		MCPPorts: []int{portOf(t, srv)},
+		Progress: func(done, total int) {
+			mu.Lock()
+			calls = append(calls, [2]int{done, total})
+			mu.Unlock()
+		},
+	}
+	if _, err := s.Scan(context.Background(), "127.0.0.1"); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) == 0 {
+		t.Fatal("Progress was never called")
+	}
+	last := calls[len(calls)-1]
+	if last[0] != 1 || last[1] != 1 {
+		t.Errorf("final progress = [%d %d], want [1 1]", last[0], last[1])
 	}
 }
 

--- a/scripts/seed-demo.sh
+++ b/scripts/seed-demo.sh
@@ -21,7 +21,12 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LAB_COMPOSE="$REPO_ROOT/docker/demo/docker-compose.yml"
-LAB_CIDR="172.30.0.0/24"
+# Demo lab hosts (static IPs from docker/demo/docker-compose.yml). We scan an
+# explicit host list rather than the whole 172.30.0.0/24 so the demo reports
+# the real services instead of 254 Docker-bridge phantoms — every address on a
+# bridge network accepts TCP connects, so a /24 sweep "finds" 256 identical
+# hosts (see docs/operator/scanner.md).
+LAB_HOSTS=(172.30.0.10 172.30.0.20 172.30.0.30 172.30.0.40 172.30.0.50 172.30.0.60 172.30.0.70 172.30.0.80)
 LITELLM_HOST="172.30.0.20:4000"
 OLLAMA_HOST="172.30.0.10:11434"
 MASTER_KEY="sk-DEMO-CHAIN-KEY-NOT-REAL"
@@ -72,11 +77,15 @@ EOF
 OUT_DIR=$(mktemp -d)
 trap 'rm -rf "$OUT_DIR"' EXIT
 
-echo "[seed-demo] running agenthound scan against $LAB_CIDR"
-"$CMD_AGENTHOUND" scan "$LAB_CIDR" --output "$OUT_DIR/scan.json"
+# Materialize the explicit host list as an @targets file for scan/discover.
+LAB_TARGETS="$OUT_DIR/lab-hosts.txt"
+printf '%s\n' "${LAB_HOSTS[@]}" > "$LAB_TARGETS"
 
-echo "[seed-demo] running agenthound discover against $LAB_CIDR"
-"$CMD_AGENTHOUND" discover "$LAB_CIDR" --output "$OUT_DIR/discover.json"
+echo "[seed-demo] running agenthound scan against ${#LAB_HOSTS[@]} lab hosts"
+"$CMD_AGENTHOUND" scan "@$LAB_TARGETS" --output "$OUT_DIR/scan.json"
+
+echo "[seed-demo] running agenthound discover against ${#LAB_HOSTS[@]} lab hosts"
+"$CMD_AGENTHOUND" discover "@$LAB_TARGETS" --output "$OUT_DIR/discover.json"
 
 echo "[seed-demo] running agenthound loot --type litellm"
 echo "AUTHORIZED" | "$CMD_AGENTHOUND" loot "$LITELLM_HOST" \


### PR DESCRIPTION
Network-mode `scan`/`discover` printed one stderr line per discovered host/endpoint (256+ lines on a /24) while the actual port/protocol sweep ran silently. Replace the per-host dump with a one-line summary, gate the full listing behind a new `--verbose` flag, and honor `--quiet` (which previously only affected slog, not these prints).

Add a stdlib-only, TTY-aware progressReporter that renders a single rewriting line during the sweep and fingerprint phases; it is a no-op when piped/redirected or quiet, so JSON on `--output -` stays clean. The scanners expose an optional Progress hook (atomic counter + ticker goroutine) with no new dependencies.

Tighten the demo seed to scan an explicit lab-hosts @targets file instead of the whole 172.30.0.0/24, so it reports the real services rather than 256 Docker-bridge phantoms.