### PR TITLE
docs(readme): surface full stack coverage in Why AgentHound

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Which poisoned tools sit on high-risk routes?
 Which agents can read sensitive data and send it outbound?
 ```
 
-That is the BloodHound idea applied to AI-agent infrastructure.
+That is the BloodHound idea applied to AI-agent infrastructure — across the whole stack, not one protocol:
+
+- 🔌 **Protocols** — MCP · A2A
+- 🧠 **Services** — LiteLLM · Ollama · vLLM · LangServe · MLflow · Qdrant · Jupyter · Open WebUI
+- 💻 **Agent clients** — Claude Desktop · Claude Code · Cursor · VS Code · Windsurf · Continue · Cline · Zed · JetBrains · Amazon Q · Kiro · Augment
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ agenthound discover 10.0.0.0/24 --mcp
 agenthound loot 172.30.0.20:4000 --type litellm --master-key sk-... --engagement-id RTV --output -
 ```
 
-Looter types: `litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`.
+Looter types: `litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`, `jupyter`.
 
 **3. Exploit** — sanctioned, reversible offensive actions:
 


### PR DESCRIPTION
## Summary

Adds a minimal, grouped **coverage list** to the `Why AgentHound?` section so the README actually showcases the all-in-one breadth AgentHound targets. Until now the README leaned almost entirely on MCP/A2A and only mentioned the rest of the stack in passing.

- 🔌 **Protocols** — MCP · A2A
- 🧠 **Services** — LiteLLM · Ollama · vLLM · LangServe · MLflow · Qdrant · Jupyter · Open WebUI
- 💻 **Agent clients** — Claude Desktop · Claude Code · Cursor · VS Code · Windsurf · Continue · Cline · Zed · JetBrains · Amazon Q · Kiro · Augment

Design notes:
- Kept it a **list, not a capability matrix** — a list of targets doesn't promise loot/active depth on each, so it can't over-claim.
- One distinct, category-relevant emoji per line for scannability (no repeated ✅, which would imply a checked-vs-unchecked comparison).
- Names verified against the registered modules: 8 fingerprinted services + 12 config client parsers + 2 protocols.

## Test plan

- [ ] Render README on GitHub — confirm the list and emojis display correctly
- [ ] Confirm service/client names match registered modules in `collector/cmd/agenthound/main.go` and `modules/config/parser_*.go`

Made with [Cursor](https://cursor.com)