### PR TITLE
chore(release): prep v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## Unreleased
+## v0.7.0
 
-### Network scanner hardening
+Network `scan` / `discover` usability and hardening. Adds progress and summary output to the network verbs, fixes a `:MCPServer` duplicate-node bug at the cross-collector merge point, and adds memory-safety guards (absolute host ceiling, nested-include rejection, concurrency clamp) across the scan/discover path.
+
+### Scan & discover output (#62)
+
+- **One-line summary by default.** `scan` prints `[scan] <spec>: N host(s) with at least one open port` and `discover` prints `[discover] <spec>: N endpoint(s)`, followed (for `scan`) by per-match fingerprint lines and a fingerprint summary. The full per-host / per-endpoint listing — which can run to thousands of lines on a large sweep — is gated behind `--verbose`.
+- **Interactive progress line.** When stderr is a TTY, a single rewriting line tracks the port sweep and the fingerprint phase. It is omitted automatically when output is piped or redirected, so CI logs and piped output stay clean.
+- **`--quiet` / `AGENTHOUND_QUIET=1`** suppresses the progress line, the summary, and the fingerprint output, leaving only errors. Progress and summaries always go to stderr and never affect the JSON written to `--output`.
+
+### Network scanner & discovery hardening (#64)
 
 Fixes from a focused review of the network-level `scan` / `discover` path:
 
@@ -18,8 +26,12 @@ Robustness and cleanup from the same review:
 - **Overlapping/duplicate targets-file entries are de-duplicated** (order-preserving), eliminating duplicate `Target`s and redundant probes/fingerprint requests.
 - **Worker-pool concurrency is clamped** (`MaxConcurrency = 4096`) in both scanners, preventing an absurd `--network-scan-concurrency` from overflowing the tasks-channel size on 32-bit or allocating a runaway buffer / goroutine count.
 - **MCP discovery handles Streamable HTTP**: the probe sends `Accept: application/json, text/event-stream` (some servers `406` otherwise) and parses an SSE-framed `initialize` response, improving recall without affecting precision.
-- **Nested `@file` / `file://` includes inside a targets file are rejected** (`ErrNestedTargetsFile`), closing a self-referential/cyclic recursion that could exhaust memory / file descriptors.
 - Removed dead code: the unused `protoscan` discover registrations (`mcp.discover` / `a2a.discover`, never dispatched — `discover` constructs its scanner directly) and an unused error/`slog` shim. The fingerprint progress denominator now applies the same `Fingerprinter` type assertion as dispatch, and each fingerprinter receives a per-probe copy of `Meta`.
+
+### Documentation
+
+- README "Why AgentHound" now surfaces full-stack coverage — protocols (MCP, A2A), services, and agent clients — rather than implying single-protocol scope. (#63)
+- Reference and operator docs refreshed for v0.7.0: documented the scan/discover progress, summary, `--verbose`, and `--quiet` behavior; corrected the `--network-scan-concurrency` default (`50`, was misdocumented as `256`/`64`); completed the looter `--type` list (added `jupyter`); marked all network-scan fingerprinters as shipped; and fixed the `--cors-origins` default and several broken cross-links.
 
 ## v0.6.1
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ go install github.com/adithyan-ak/agenthound/server/cmd/agenthound-server@latest
 agenthound-server serve
 
 # Pin install.sh to a release tag (verifies checksums; uses cosign when available)
-curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.6.1/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.7.0/install.sh | sh
 ```
 
 See the full [installation guide](https://docs.agenthound.io/getting-started/install/) for Homebrew, release binaries, signature verification, and source builds.

--- a/collector/cli/loot.go
+++ b/collector/cli/loot.go
@@ -50,8 +50,8 @@ and EXPOSES_CREDENTIAL edges into the graph, where the
 cross_service_credential_chain post-processor joins them with Config
 Collector emissions to surface credential-chain findings.
 
-Supported Looters include --type litellm (LiteLLM gateway), ollama,
-jupyter, and mlflow.
+Supported Looters: --type litellm (LiteLLM gateway), ollama, mlflow,
+qdrant, openwebui, and jupyter.
 
 Example:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Attack-path discovery for AI agent infrastructure. [BloodHound](https://github.c
 ## Operator Guides
 
 - **[Network Scanning](operator/scanner.md)** — Sweep CIDRs for AI/ML services + fingerprint
+- **[Rules Bundles](operator/rules-bundle.md)** — Out-of-band fingerprint rule updates (`--rules-bundle`)
 - **[Protocol Discovery](operator/discover.md)** — Find MCP servers and A2A agents by protocol shape
 - **[Looting](operator/loot/index.md)** — Extract credentials and model artifacts from discovered services
   - [LiteLLM](operator/loot/litellm.md) — Master key → upstream provider keys

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -114,7 +114,7 @@ agenthound loot 172.30.0.20:4000 --type litellm \
     --output -
 ```
 
-Available looter types: `litellm`, `ollama`. The `--engagement-id` flag is a correlation key recorded on every emitted edge for IR coordination.
+Available looter types: `litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`, `jupyter`. The `--engagement-id` flag is a correlation key recorded on every emitted edge for IR coordination.
 
 Loot Ollama models and modelfiles:
 
@@ -235,7 +235,7 @@ docker compose -f docker/demo/docker-compose.yml down --volumes
 | `AGENTHOUND_PG_URI` | `postgres://agenthound:agenthound@localhost:5432/agenthound?sslmode=disable` | PostgreSQL |
 | `AGENTHOUND_BIND` | `127.0.0.1:8080` | Server bind address |
 | `AGENTHOUND_LOG_LEVEL` | `info` | Log level: debug, info, warn, error |
-| `AGENTHOUND_CORS_ORIGINS` | `http://localhost:8080` | CORS origins for the UI |
+| `AGENTHOUND_CORS_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080` | CORS origins for the UI |
 | `AGENTHOUND_OUTPUT` | `./scan-<id>.json` | Collector output path (`-` for stdout) |
 | `AGENTHOUND_CONCURRENCY` | `5` | Collector parallelism |
 

--- a/docs/operator/discover.md
+++ b/docs/operator/discover.md
@@ -76,16 +76,22 @@ The output file is a standard ingest envelope. `discover` emits raw `:MCPServer`
 | Control | Default | Override flag | Notes |
 |---|---|---|---|
 | Public IP space | refused | `--allow-public-targets` + AUTHORIZED prompt | Mirrors `scan`'s gate exactly. |
-| CIDRs > /16 | refused | `--allow-large-cidr` | A /24 is ~256 hosts × 4 ports per protocol = ~1k probes; a /16 is ~65k hosts. |
+| CIDRs > /16 | refused | `--allow-large-cidr` | A /24 is ~256 hosts × 4 ports per protocol = ~1k probes; a /16 is ~65k hosts. An absolute ceiling of 1,048,576 hosts (exactly IPv4 `/12`, IPv6 `/108`) applies *even with* `--allow-large-cidr`; split larger ranges into chunks. |
 | Link-local | refused (no flag) | n/a | 169.254.x.x and fe80::/10 cannot be routed off-host. |
 | Multicast | refused (no flag) | n/a | Not unicast scan targets. |
 | Authorization watermark | optional | `--authorization-file <path>` | Path + SHA-256 recorded in envelope `meta.extra`. |
 
 ## Concurrency and timeouts
 
-- `--network-scan-concurrency N` — default 50 parallel HTTP probes
+- `--network-scan-concurrency N` — default 50 parallel HTTP probes (hard-clamped to 4096)
 - `--timeout T` — default 5s per probe
 - `--insecure` — skip TLS verification (for self-signed dev MCP servers; do NOT use in engagements)
+
+## Output volume and cancellation
+
+By default `discover` prints a single summary line — `[discover] <spec>: N endpoint(s)` — and gates the full per-endpoint listing (protocol + URL for each match) behind `--verbose`. On an interactive terminal a single rewriting progress line tracks the probe sweep; it is omitted automatically when output is piped or redirected, and `--quiet` / `AGENTHOUND_QUIET=1` suppresses both the progress line and the summary. None of this affects the JSON written to `--output`.
+
+Ctrl-C (SIGINT) or SIGTERM cancels the probe pool cleanly and writes the endpoints found so far to `--output`, so an interrupted sweep still produces useful JSON rather than dying mid-write.
 
 ## Combining with `scan` and `loot`
 
@@ -111,7 +117,7 @@ After each ingest the `cross_service_credential_chain` post-processor folds the 
 
 ## See also
 
-- `docs/scanner.md` — `agenthound scan` operator guide
-- `docs/loot-litellm.md` — LiteLLM Looter operator guide
+- [`agenthound scan` operator guide](scanner.md)
+- [LiteLLM Looter operator guide](loot/litellm.md)
+- [Security model](security.md) — full threat model
 - `modules/protoscan/scanner.go` — implementation
-- `docs/security.md` — full threat model

--- a/docs/operator/loot/index.md
+++ b/docs/operator/loot/index.md
@@ -16,7 +16,7 @@ Every Looter implements `sdk/action.Looter` and adheres to:
 
 | Flag | Required | Default | Notes |
 |------|----------|---------|-------|
-| `--type <module>` | Yes | -- | Module dispatcher key (`litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`) |
+| `--type <module>` | Yes | -- | Module dispatcher key (`litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`, `jupyter`) |
 | `--engagement-id <id>` | Recommended | empty | Correlation key for IR coordination. Recorded on every edge and slog line. |
 | `--include-credential-values` | No | `false` | Emit raw `value` property alongside `value_hash`. Default is hash-only. |
 | `--max-items <n>` | No | 1000 | Cap emitted Credential nodes per category |
@@ -36,6 +36,7 @@ The first `agenthound loot` invocation on a machine triggers an interactive `AUT
 | `mlflow` | MLflow tracking server (port 5000) | Experiment + run inventory (anonymous); `experiment_count`, `total_runs` |
 | `qdrant` | Qdrant vector DB (port 6333) | Collection inventory (anonymous, pure-GET; no Credential nodes) |
 | `openwebui` | Open WebUI (port 3000) | Upstream provider keys with `--api-key`; anonymous config posture otherwise |
+| `jupyter` | Jupyter Server (port 8888) | Active sessions + notebook inventory (anonymous, pure-GET; emits one `:MCPResource` per notebook, no Credential nodes) |
 
 See the [CLI reference](../../reference/cli.md) for the full per-module flag set of each looter.
 

--- a/docs/operator/rules-bundle.md
+++ b/docs/operator/rules-bundle.md
@@ -1,0 +1,124 @@
+# `--rules-bundle` — out-of-band fingerprint rule updates
+
+The fingerprint rules engine ships rules embedded in the AgentHound binary (`sdk/rules/builtin/fingerprints/*.yaml`). AgentHound provides a `--rules-bundle <path>` override so operators can pick up rule fixes without rebuilding the collector.
+
+> **The operator is responsible for verifying the cosign signature on the bundle BEFORE pointing AgentHound at it.** Verification is optional by design — the loader does not call cosign automatically and does not refuse unsigned bundles. Always run `cosign verify-blob` against the tarball yourself (see below) before pointing AgentHound at it.
+
+---
+
+## Quick start
+
+```bash
+# Download a published bundle.
+gh release download rules-v2026.06.01 \
+    --repo adithyan-ak/agenthound \
+    --pattern 'agenthound-rules-*.tar.gz*'
+
+# Verify the cosign signature BEFORE running anything.
+cosign verify-blob \
+    --bundle agenthound-rules-rules-v2026.06.01.tar.gz.sigstore.json \
+    --certificate-identity-regexp 'https://github.com/.*' \
+    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+    agenthound-rules-rules-v2026.06.01.tar.gz
+
+# Use the bundle in any command that runs fingerprinters.
+agenthound --rules-bundle ./agenthound-rules-rules-v2026.06.01.tar.gz scan 10.0.0.0/24
+
+# Or point at a directory of YAML files (during development / lab work).
+agenthound --rules-bundle ./my-custom-rules/ scan 10.0.0.0/24
+
+# Env var alternative.
+AGENTHOUND_RULES_BUNDLE=./bundle.tar.gz agenthound scan 10.0.0.0/24
+```
+
+---
+
+## Override semantics
+
+The bundle merges into the embedded rule set with **same-id rules from the bundle winning**:
+
+| Embedded rule | Bundle rule | Effective rule |
+|---|---|---|
+| `id: ollama` | (absent) | embedded |
+| `id: ollama` | `id: ollama` | bundle (override wins) |
+| (absent) | `id: my-custom` | bundle (additive) |
+
+This is what you want for hot-fixing a broken regex in a shipped rule, or for adding a new fingerprinter rule the binary's rule set doesn't yet include.
+
+---
+
+## Bundle format
+
+A bundle is one of:
+
+- A directory containing `*.yaml` files (one rule per file).
+- A `.tar.gz` archive containing `fingerprints/*.yaml` entries.
+
+The loader reads `*.yaml` and skips other file types. Each YAML file follows the same shape as the embedded rules at `sdk/rules/builtin/fingerprints/`:
+
+```yaml
+id: ollama-hotfix-2026-06
+name: Ollama (CVE-2026-XXXXX hotfix)
+description: refines the Ollama version regex to catch the new patch series
+version: 2
+service_kind: ollama
+probes:
+  - method: GET
+    path: /api/version
+    matchers:
+      - type: http_status
+        status_code: 200
+      - type: json_path
+        path: "$.version"
+        regex: '^\d+\.\d+\.\d+(-rc\d+)?$'
+    captures:
+      version: "$.version"
+emit:
+  node_kinds:
+    - OllamaInstance
+    - AIService
+  properties:
+    service_kind: ollama
+    auth_method: none
+    is_anonymous_loot: "true"
+    version: "{capture:version}"
+```
+
+Rule IDs MUST be globally unique within a bundle (and across the bundle + embedded merge — the bundle's same-id rule wins, but two same-id rules within one bundle is a load-time conflict).
+
+---
+
+## Release cadence
+
+Bundles are published by the `rules-bundle.yml` GitHub Actions workflow. Triggers:
+
+- **`workflow_dispatch`** — manual release, used for ad-hoc rule fixes.
+- **`on: push: tags: ['rules-v*']`** — pushing a `rules-vYYYY.MM.DD` tag automatically cuts a release.
+
+There is **no `on: schedule` trigger**. Bundles are content-driven — a no-changes month produces no bundle. An empty release would confuse cosign verification on the consumer side.
+
+The release artifacts:
+
+- `agenthound-rules-<tag>.tar.gz` — the bundle.
+- `agenthound-rules-<tag>.tar.gz.sha256` — checksum.
+- `agenthound-rules-<tag>.tar.gz.sigstore.json` — cosign keyless bundle (signature + certificate, cosign v3 format).
+
+---
+
+## Troubleshooting
+
+**Bundle doesn't load at all.** Check the path. `agenthound --rules-bundle <path>` surfaces the error from `LoadFingerprintBundle` if the path doesn't exist or doesn't unpack. Check the format with `tar -tzf <bundle>.tar.gz` showing one or more `*.yaml` entries.
+
+**Bundle loads but my override doesn't take effect.** Same-id-wins requires the bundle's rule ID to match the embedded rule ID exactly. Check the embedded set with `agenthound rules list`.
+
+**Bundle loads but a rule is silently dropped.** The loader skips files that fail YAML parsing. Run `agenthound rules validate <yaml-path>` against each file in your bundle to catch parse errors. Per-file size cap is 1 MiB.
+
+**Cosign verification fails.** The `--certificate-identity-regexp` in the example matches GitHub Actions OIDC. If you forked the repo and re-released, your cert identity will differ — adjust the regex. Time skew can cause verification failures if your machine clock is off; sync NTP.
+
+---
+
+## See also
+
+- `sdk/rules/bundle.go` — implementation of `LoadFingerprintBundle` and `MergeFingerprintRules`.
+- `.github/workflows/rules-bundle.yml` — the release pipeline.
+- [`agenthound scan` operator guide](scanner.md) — the network scanner that consumes fingerprint rules.

--- a/docs/operator/scanner.md
+++ b/docs/operator/scanner.md
@@ -34,17 +34,17 @@ agenthound scan 10.0.0.0/24 --network-scan-concurrency 100
 
 ## Default port set
 
-The scanner probes seven ports by default — every port in this set has a v0.2+ fingerprinter or is reserved for v0.3/v0.4:
+The scanner probes seven ports by default. Every port in this set now has a shipped fingerprinter:
 
 | Port | Service | Fingerprinter status |
 |------|---------|---------------------|
-| 11434 | Ollama | **v0.2 — shipped** |
-| 4000 | LiteLLM | **v0.2 — shipped** |
-| 8000 | vLLM AND LangServe (port collision; fingerprint dispatch resolves) | v0.3 (vLLM), v0.4 (LangServe) |
-| 6333 | Qdrant | v0.4 |
-| 5000 | MLflow | v0.4 |
-| 8888 | Jupyter | v0.3 |
-| 3000 | Open WebUI | v0.3 |
+| 11434 | Ollama | shipped |
+| 4000 | LiteLLM | shipped |
+| 8000 | vLLM AND LangServe (port collision; fingerprint dispatch resolves) | shipped (both) |
+| 6333 | Qdrant | shipped |
+| 5000 | MLflow | shipped |
+| 8888 | Jupyter | shipped |
+| 3000 | Open WebUI | shipped |
 
 Hosts with open ports for which no fingerprinter ships in your binary version emit no node. The open-port set is captured in `Target.Meta["open_ports"]` so a future re-fingerprint against the same scan output can populate the missing services without a fresh scan.
 
@@ -129,7 +129,7 @@ The envelope contains:
 
 **Concurrency vs. `--scan-concurrency`.** Two separate knobs. `--scan-concurrency` (default 5) controls MCP/A2A enumeration worker count when running the legacy `agenthound scan` (no positional arg) flow. `--network-scan-concurrency` (default 50) controls the network probe pool. Different cost profiles — MCP/A2A do JSON-RPC handshakes; network probes do raw TCP connects.
 
-**TLS.** The probes are HTTP today. v0.3 adds HTTPS coverage when the fingerprinters need it (some services bind TLS by default). The `--insecure` flag from the legacy collector flow does not apply to the network scanner — fingerprinters that opt into TLS handshakes will declare their own per-module flag via `FlagsModule` (v0.3).
+**TLS.** The network-scan fingerprint probes are HTTP today; HTTPS coverage is not yet wired into the network scanner. The `--insecure` flag applies only to the legacy local MCP/A2A collectors (`scan --mcp` / `scan --a2a`), not to the network sweep — a fingerprinter that needs a TLS handshake would declare its own per-module flag via `FlagsModule`.
 
 ---
 
@@ -155,128 +155,5 @@ cat /tmp/scan.json | jq '.meta'
 ## See also
 
 - [LiteLLM looting](loot/litellm.md) — extracting credentials from a fingerprinted LiteLLM gateway.
+- [Rules bundles](rules-bundle.md) — out-of-band fingerprint rule updates (`--rules-bundle`).
 - [Security model](security.md) — overall AgentHound threat model.
-# `--rules-bundle` — out-of-band fingerprint rule updates
-
-The fingerprint rules engine ships rules embedded in the AgentHound binary (`sdk/rules/builtin/fingerprints/*.yaml`). v0.3 adds a `--rules-bundle <path>` override so operators can pick up rule fixes without rebuilding the collector.
-
-> **The operator is responsible for verifying the cosign signature on the bundle BEFORE pointing AgentHound at it.** v0.3 ships with optional verification — the loader does not call cosign automatically. Mandatory signature verification (refuse to load unsigned bundles) lands in v0.5 once the release pipeline has cut at least one bundle.
-
----
-
-## Quick start
-
-```bash
-# Download a published bundle.
-gh release download rules-v2026.06.01 \
-    --repo adithyan-ak/agenthound \
-    --pattern 'agenthound-rules-*.tar.gz*'
-
-# Verify the cosign signature BEFORE running anything.
-cosign verify-blob \
-    --bundle agenthound-rules-rules-v2026.06.01.tar.gz.sigstore.json \
-    --certificate-identity-regexp 'https://github.com/.*' \
-    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-    agenthound-rules-rules-v2026.06.01.tar.gz
-
-# Use the bundle in any command that runs fingerprinters.
-agenthound --rules-bundle ./agenthound-rules-rules-v2026.06.01.tar.gz scan 10.0.0.0/24
-
-# Or point at a directory of YAML files (during development / lab work).
-agenthound --rules-bundle ./my-custom-rules/ scan 10.0.0.0/24
-
-# Env var alternative.
-AGENTHOUND_RULES_BUNDLE=./bundle.tar.gz agenthound scan 10.0.0.0/24
-```
-
----
-
-## Override semantics
-
-The bundle merges into the embedded rule set with **same-id rules from the bundle winning**:
-
-| Embedded rule | Bundle rule | Effective rule |
-|---|---|---|
-| `id: ollama` | (absent) | embedded |
-| `id: ollama` | `id: ollama` | bundle (override wins) |
-| (absent) | `id: my-custom` | bundle (additive) |
-
-This is what you want for hot-fixing a broken regex in a shipped rule, or for adding a new fingerprinter rule the binary's rule set doesn't yet include.
-
----
-
-## Bundle format
-
-A bundle is one of:
-
-- A directory containing `*.yaml` files (one rule per file).
-- A `.tar.gz` archive containing `fingerprints/*.yaml` entries.
-
-The loader reads `*.yaml` and skips other file types. Each YAML file follows the same shape as the embedded rules at `sdk/rules/builtin/fingerprints/`:
-
-```yaml
-id: ollama-hotfix-2026-06
-name: Ollama (CVE-2026-XXXXX hotfix)
-description: refines the Ollama version regex to catch the new patch series
-version: 2
-service_kind: ollama
-probes:
-  - method: GET
-    path: /api/version
-    matchers:
-      - type: http_status
-        status_code: 200
-      - type: json_path
-        path: "$.version"
-        regex: '^\d+\.\d+\.\d+(-rc\d+)?$'
-    captures:
-      version: "$.version"
-emit:
-  node_kinds:
-    - OllamaInstance
-    - AIService
-  properties:
-    service_kind: ollama
-    auth_method: none
-    is_anonymous_loot: "true"
-    version: "{capture:version}"
-```
-
-Rule IDs MUST be globally unique within a bundle (and across the bundle + embedded merge — the bundle's same-id rule wins, but two same-id rules within one bundle is a load-time conflict).
-
----
-
-## Release cadence
-
-Bundles are published by the `rules-bundle.yml` GitHub Actions workflow. Triggers:
-
-- **`workflow_dispatch`** — manual release, used for ad-hoc rule fixes.
-- **`on: push: tags: ['rules-v*']`** — pushing a `rules-vYYYY.MM.DD` tag automatically cuts a release.
-
-There is **no `on: schedule` trigger**. Bundles are content-driven — a no-changes month produces no bundle. An empty release would confuse cosign verification on the consumer side.
-
-The release artifacts:
-
-- `agenthound-rules-<tag>.tar.gz` — the bundle.
-- `agenthound-rules-<tag>.tar.gz.sha256` — checksum.
-- `agenthound-rules-<tag>.tar.gz.sigstore.json` — cosign keyless bundle (signature + certificate, cosign v3 format).
-
----
-
-## Troubleshooting
-
-**Bundle doesn't load at all.** Check the path. `agenthound --rules-bundle <path>` surfaces the error from `LoadFingerprintBundle` if the path doesn't exist or doesn't unpack. Check the format with `tar -tzf <bundle>.tar.gz` showing one or more `*.yaml` entries.
-
-**Bundle loads but my override doesn't take effect.** Same-id-wins requires the bundle's rule ID to match the embedded rule ID exactly. Check the embedded set with `agenthound rules list`.
-
-**Bundle loads but a rule is silently dropped.** The loader skips files that fail YAML parsing. Run `agenthound rules validate <yaml-path>` against each file in your bundle to catch parse errors. Per-file size cap is 1 MiB.
-
-**Cosign verification fails.** The `--certificate-identity-regexp` in the example matches GitHub Actions OIDC. If you forked the repo and re-released, your cert identity will differ — adjust the regex. Time skew can cause verification failures if your machine clock is off; sync NTP.
-
----
-
-## See also
-
-- `sdk/rules/bundle.go` — implementation of `LoadFingerprintBundle` and `MergeFingerprintRules`.
-- `.github/workflows/rules-bundle.yml` — the release pipeline.
-- [`docs/scanner.md`](scanner.md) — the network scanner that consumes fingerprint rules.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,7 +34,7 @@ agenthound scan [CIDR|host|@targets-file] [flags]
 **Two modes:**
 
 1. **Local mode** (no positional arg) — runs config + MCP collectors against the local host.
-2. **Network mode** (positional arg) — sweeps targets for AI/ML services on standard ports (Ollama 11434, vLLM 8000, Qdrant 6333, MLflow 5000, LiteLLM 4000, Jupyter 8888, LangServe/OpenWebUI 3000), then fingerprints each match.
+2. **Network mode** (positional arg) — sweeps targets for AI/ML services on standard ports (Ollama 11434, vLLM/LangServe 8000, Qdrant 6333, MLflow 5000, LiteLLM 4000, Jupyter 8888, Open WebUI 3000), then fingerprints each match.
 
 #### Collector Selection
 
@@ -82,7 +82,7 @@ At least one of `--target`, `--targets`, `--targets-file`, or `--discover-domain
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--ports` | `11434,8000,6333,5000,4000,8888,3000` | Override the default AI-service port set. |
-| `--network-scan-concurrency` | `256` | Max parallel TCP connect probes. |
+| `--network-scan-concurrency` | `50` | Max parallel TCP connect probes. |
 | `--allow-public-targets` | `false` | Allow scanning non-RFC1918 IPs. Requires interactive `AUTHORIZED` prompt. |
 | `--allow-large-cidr` | `false` | Allow CIDRs larger than /16 (IPv4) or /112 (IPv6), up to an absolute ceiling of 1,048,576 hosts (exactly /12 IPv4, /108 IPv6) that applies even with this flag. |
 | `--authorization-file` | | Path to a written-authorization document. Path + SHA-256 recorded in scan watermark. |
@@ -132,7 +132,7 @@ agenthound discover <cidr|host|@file> [flags]
 | `--a2a` | (both if neither set) | Probe for A2A agents only. |
 | `--mcp-ports` | `3000,8000,8080,8443` | Override MCP probe port set. |
 | `--a2a-ports` | `80,443,3000,8080` | Override A2A probe port set. |
-| `--network-scan-concurrency` | `64` | Max parallel HTTP probes. |
+| `--network-scan-concurrency` | `50` | Max parallel HTTP probes. |
 | `--timeout` | `5s` | Per-probe HTTP timeout. |
 | `--insecure` | `false` | Skip TLS verification on HTTPS probes. |
 | `--allow-public-targets` | `false` | Allow probing public IPs (requires `AUTHORIZED` prompt). |
@@ -169,7 +169,7 @@ agenthound loot <host:port> --type <kind> [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--type` | **(required)** | Looter kind: `litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`. |
+| `--type` | **(required)** | Looter kind: `litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`, `jupyter`. |
 | `--master-key` | | Sugar for `--credential master_key=...`. |
 | `--credential` | | Operator-supplied credential as `KEY=VALUE` (repeatable). |
 | `--include-credential-values` | `false` | Emit raw values on Credential nodes. |
@@ -192,6 +192,8 @@ agenthound loot <host:port> --type <kind> [flags]
 | `--api-key` | | Open WebUI admin API key (or session JWT). When supplied, enumerates upstream provider keys via authenticated `GET /openai/config` and emits Credential + EXPOSES_CREDENTIAL. Omit for anonymous posture only (`GET /api/config`). |
 
 `--type qdrant` is anonymous and pure-GET (no per-module flags): it inventories collections via `GET /collections` and `GET /collections/{name}`, folding `collection_count`, `collections`, `total_points`, and `anonymous_listing` onto the `QdrantInstance` node. It emits **no** Credential nodes.
+
+`--type jupyter` is also anonymous and pure-GET (no per-module flags): it inventories active sessions via `GET /api/sessions` and the notebook tree via `GET /api/contents/`, emitting one `:MCPResource` per discovered notebook.
 
 #### Example
 
@@ -421,7 +423,7 @@ Print version string and commit hash.
 | `--neo4j-user` | `AGENTHOUND_NEO4J_USER` | `neo4j` | Neo4j username. |
 | `--neo4j-password` | `AGENTHOUND_NEO4J_PASSWORD` | `agenthound` | Neo4j password. |
 | `--pg-uri` | `AGENTHOUND_PG_URI` | `postgres://agenthound:agenthound@localhost:5432/agenthound?sslmode=disable` | PostgreSQL URI. |
-| `--cors-origins` | `AGENTHOUND_CORS_ORIGINS` | `http://localhost:8080` | Comma-separated CORS origins. |
+| `--cors-origins` | `AGENTHOUND_CORS_ORIGINS` | `http://localhost:8080,http://127.0.0.1:8080` | Comma-separated CORS origins. |
 | `--log-level` | `AGENTHOUND_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error`. |
 
 Priority: CLI flag > env var > default.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,7 +17,7 @@ Both binaries read environment variables at startup. The collector has no config
 | `AGENTHOUND_LOG_LEVEL` | `--log-level` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 | `AGENTHOUND_OUTPUT` | `--output` | `./scan-<scan_id>.json` | Output path. Use `-` for stdout. |
 | `AGENTHOUND_CONCURRENCY` | `--concurrency` | `5` | Max parallel collector goroutines. For `scan`, used as the fallback for `--scan-concurrency` when that flag is not set explicitly (explicit `--scan-concurrency` wins; `--network-scan-concurrency` is unaffected). |
-| `AGENTHOUND_QUIET` | `--quiet` | _(unset)_ | Set to `1` to suppress all non-error log output |
+| `AGENTHOUND_QUIET` | `--quiet` | _(unset)_ | Set to `1` to suppress non-error log output, plus the `scan` / `discover` progress line, the per-host/endpoint summary, and fingerprint output |
 | `AGENTHOUND_LOG_JSON` | `--log-json` | _(unset)_ | Set to `1` for structured JSON logs to stderr |
 | `AGENTHOUND_RULES_BUNDLE` | `--rules-bundle` | _(unset)_ | Path to a fingerprint rules bundle (directory or `.tar.gz`). Same-id rules override the embedded set. Verify cosign signature before use. |
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # AgentHound collector installer.
 #
 # Pin to a release tag for integrity:
-#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.6.1/install.sh | sh
+#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.7.0/install.sh | sh
 #
 # Verifies the downloaded archive against checksums.txt before extracting,
 # and against cosign signatures if cosign is available on $PATH.


### PR DESCRIPTION
## Summary

Promotes the `Unreleased` CHANGELOG to **v0.7.0** and refreshes the docs to be accurate for this release.

- **Release prep:** CHANGELOG `## v0.7.0` (scan/discover progress + summary #62, network scan/discover hardening #64, full-stack README #63); `install.sh` + `README.md` install-pin examples bumped `v0.6.1` → `v0.7.0`.
- **Doc accuracy fixes (verified against code):** corrected `--network-scan-concurrency` default (`50`, was `256`/`64`), completed the looter `--type` list (added `jupyter`), fixed the `--cors-origins` default and the vLLM/LangServe/OpenWebUI port mapping, marked all network-scan fingerprinters as shipped, corrected the rules-bundle signature-verification status (still optional), documented the discover host ceiling + `--verbose`/`--quiet`/progress/SIGINT behavior, and fixed broken `See also` links.
- **Structure:** split the rules-bundle guide out of `scanner.md` into `operator/rules-bundle.md` and added it to the docs nav.
- **CLI:** `loot --help` now lists all six looters.

## Test plan

- [x] `make prerelease` — all 12 gates pass (gofmt, golangci-lint, vet, govulncheck, go-licenses, build, test -race, deps-check, size-check, slop-check, UI build, cross-compile)
- [ ] After merge: tag `v0.7.0` on the merge commit to trigger the GoReleaser release pipeline

Made with [Cursor](https://cursor.com)