### PR TITLE
ci: enforce version consistency + catch docs breakage pre-merge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,11 @@
 name: Docs
 
-# Build the MkDocs site and deploy to GitHub Pages on docs changes.
-# Pages source must be set to "GitHub Actions" in Settings -> Pages (one-time).
+# Build the MkDocs site (strict) and deploy to GitHub Pages.
+# - pull_request: build-only gate, so doc-structure breakage (orphan pages,
+#   broken links, bad anchors) fails the PR instead of slipping to main.
+# - push to main: build + deploy. Pages source must be "GitHub Actions"
+#   (Settings -> Pages, one-time).
+# Path-filtered so it runs only when docs actually change.
 on:
   push:
     branches: [main]
@@ -9,12 +13,18 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-# Allow one concurrent deployment; don't cancel an in-progress prod deploy.
+# One deploy at a time on main (never cancel a prod deploy); PR builds are
+# per-ref and cancel their own superseded runs.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: pages-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -37,12 +47,15 @@ jobs:
         run: pip install -r docs/requirements.txt
       - name: Build site (strict)
         run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: site
 
   deploy:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,15 @@
 name: Docs
 
 # Build the MkDocs site (strict) and deploy to GitHub Pages.
-# - pull_request: build-only gate, so doc-structure breakage (orphan pages,
-#   broken links, bad anchors) fails the PR instead of slipping to main.
-# - push to main: build + deploy. Pages source must be "GitHub Actions"
+# - pull_request: strict build only; doc-structure breakage (orphan pages,
+#   broken links, bad anchors) surfaces as a red check on the PR.
+# - push to main / workflow_dispatch: build + deploy. Deploy needs a green
+#   strict build (deploy: needs: build), so broken docs can never publish —
+#   this is the real backstop. Pages source must be "GitHub Actions"
 #   (Settings -> Pages, one-time).
-# Path-filtered so it runs only when docs actually change.
+# Path-filtered so it runs only when docs actually change. Because GitHub leaves
+# a skipped path-filtered workflow "pending", do NOT make this a required status
+# check or it would block every code-only PR; rely on the deploy backstop above.
 on:
   push:
     branches: [main]
@@ -48,14 +52,14 @@ jobs:
       - name: Build site (strict)
         run: mkdocs build --strict
       - name: Upload Pages artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: site
 
   deploy:
     needs: build
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,29 @@
+name: Version Check
+
+# Runs only when the hand-maintained version strings change, so a release-prep
+# PR can't merge with install.sh / README pins that disagree with the CHANGELOG.
+# The release pipeline (release.yml -> make prerelease -> scripts/version-check.sh)
+# re-checks at tag time, so a mismatch can never reach a published release.
+on:
+  pull_request:
+    paths:
+      - "install.sh"
+      - "README.md"
+      - "CHANGELOG.md"
+      - "scripts/version-check.sh"
+      - ".github/workflows/version-check.yml"
+
+concurrency:
+  group: version-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Version pins match the CHANGELOG
+        run: bash scripts/version-check.sh

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,9 +1,12 @@
 name: Version Check
 
-# Runs only when the hand-maintained version strings change, so a release-prep
-# PR can't merge with install.sh / README pins that disagree with the CHANGELOG.
-# The release pipeline (release.yml -> make prerelease -> scripts/version-check.sh)
-# re-checks at tag time, so a mismatch can never reach a published release.
+# Early-feedback check on the hand-maintained version strings: surfaces (as a red
+# check) a release-prep PR whose install.sh / README pins disagree with the
+# CHANGELOG. Path-filtered to those files, so do NOT make it a required status
+# check -- a skipped path-filtered workflow stays "pending" and would block
+# code-only PRs. The hard guarantee is the release pipeline: release.yml ->
+# make prerelease -> scripts/version-check.sh re-checks (including the tag)
+# before GoReleaser publishes, so a mismatched version can never ship.
 on:
   pull_request:
     paths:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,13 @@ go test ./... -race         # All tests pass with race detector
 
 CI also runs: `golangci-lint` (errcheck + gofmt), `govulncheck`, `go-licenses check`, `scripts/deps-check.sh`, `scripts/size-check.sh`.
 
-IMPORTANT: Before any release tag, run `make prerelease` — it gates on all 8 checks (gofmt, vet, build, test -race, deps-check, size-check, UI build, cross-compile). Never tag without a passing `make prerelease`.
+IMPORTANT: Before any release tag, run `make prerelease` — it gates on all release checks (version-check, gofmt, golangci-lint, vet, govulncheck, go-licenses, build, test -race, deps-check, size-check, slop-check, UI build, cross-compile). Never tag without a passing `make prerelease`.
+
+### Release versioning (single source of truth)
+
+The first `## vX.Y.Z` header in `CHANGELOG.md` is the SSOT for the human-maintained version. The binary / Docker / Homebrew versions are injected by GoReleaser from the git tag, so the only strings to bump are the install pins in `install.sh` and `README.md`.
+
+Release prep: write the new `CHANGELOG.md` section, run `make sync-version` (rewrites both pins from the CHANGELOG), then `make prerelease`. `scripts/version-check.sh` runs as a `prerelease` step (and as a path-filtered CI job on `install.sh` / `README.md` / `CHANGELOG.md` changes); it fails if the pins or the pushed tag disagree with the CHANGELOG, so a mismatched version can never ship.
 
 ## Key Constraints
 
@@ -56,6 +62,7 @@ IMPORTANT: When making changes that affect any of these, update the correspondin
 - New detection rules → `docs/reference/detection-rules.md`
 - Deployment changes → `docs/operator/deployment.md`
 - Security posture changes → `docs/operator/security.md`
+- New docs page → add it to the `nav` in `mkdocs.yml` (Docs CI runs `mkdocs build --strict` on every docs PR, so an orphan page, broken link, or bad anchor fails the build; run `make docs-check` locally first).
 
 ## Quick Reference
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-collector build-server build-all test lint docker docker-collector docker-server docker-standard up down clean seed demo release ui-build ui-dev ui-test standard standard-run standard-stop deps-check size-check slop-check prerelease preflight-build preflight-collector preflight-server preflight-docker preflight-docker-compose preflight-server-running preflight-demo
+.PHONY: build build-collector build-server build-all test lint docker docker-collector docker-server docker-standard up down clean seed demo release ui-build ui-dev ui-test standard standard-run standard-stop deps-check size-check slop-check version-check sync-version docs-check prerelease preflight-build preflight-collector preflight-server preflight-docker preflight-docker-compose preflight-server-running preflight-demo
 
 # Preflight gates. Verify required tools are present and at the expected
 # major versions BEFORE attempting a build, so newcomers get a friendly
@@ -119,35 +119,55 @@ size-check:
 slop-check:
 	@bash scripts/slop-check.sh
 
-# Pre-release gate — run BEFORE tagging a release. Covers everything CI
-# checks across all job types (push + PR). Fails fast on first error.
-# Usage: make prerelease
+# Assert the install.sh + README version pins match the CHANGELOG (the version
+# source of truth). Also runs inside `make prerelease`, so release.yml enforces
+# it at tag time too.
+version-check:
+	@bash scripts/version-check.sh
+
+# Rewrite the install.sh + README version pins from the CHANGELOG top header
+# (or VERSION=). Usage: make sync-version   or   make sync-version VERSION=0.7.1
+sync-version:
+	@bash scripts/sync-version.sh $(VERSION)
+
+# Build the MkDocs site in --strict mode (orphan pages, broken links, bad
+# anchors). Mirrors the path-filtered Docs CI; needs the docs toolchain.
+docs-check:
+	@bash scripts/docs-check.sh
+
+# Pre-release gate — run BEFORE tagging a release. Mirrors the CI checks that
+# gate every release; fails fast on first error. Usage: make prerelease
+# (Docs `mkdocs build --strict` is enforced separately by the path-filtered
+# Docs workflow + `make docs-check`, so it is intentionally NOT folded in here
+# to keep this gate Go/Node-only.)
 prerelease:
-	@echo "=== [1/12] gofmt ==="
+	@echo "=== [1/13] version-check ==="
+	@bash scripts/version-check.sh
+	@echo "=== [2/13] gofmt ==="
 	@test -z "$$(gofmt -l .)" || (echo "FAIL: gofmt found unformatted files:" && gofmt -l . && exit 1)
-	@echo "=== [2/12] golangci-lint ==="
+	@echo "=== [3/13] golangci-lint ==="
 	golangci-lint run ./...
-	@echo "=== [3/12] go vet ==="
+	@echo "=== [4/13] go vet ==="
 	go vet ./...
-	@echo "=== [4/12] govulncheck ==="
+	@echo "=== [5/13] govulncheck ==="
 	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
-	@echo "=== [5/12] go-licenses ==="
+	@echo "=== [6/13] go-licenses ==="
 	go run github.com/google/go-licenses@latest check --allowed_licenses=Apache-2.0,MIT,BSD-2-Clause,BSD-3-Clause,ISC,MPL-2.0,Unlicense,Zlib ./collector/cmd/agenthound/... ./server/cmd/agenthound-server/...
-	@echo "=== [6/12] go build ==="
+	@echo "=== [7/13] go build ==="
 	go build ./...
-	@echo "=== [7/12] go test -race -short ==="
+	@echo "=== [8/13] go test -race -short ==="
 	go test ./... -race -short -count=1
-	@echo "=== [8/12] deps-check ==="
+	@echo "=== [9/13] deps-check ==="
 	@bash scripts/deps-check.sh
-	@echo "=== [9/12] size-check ==="
+	@echo "=== [10/13] size-check ==="
 	@bash scripts/size-check.sh
-	@echo "=== [10/12] slop-check ==="
+	@echo "=== [11/13] slop-check ==="
 	# SLOP_SKIP=hardcoded-grids matches the CI ui job: the dashboard grid-cols ->
 	# Every-Layout migration is a deferred, visually-QA'd task.
 	@SLOP_SKIP=hardcoded-grids bash scripts/slop-check.sh
-	@echo "=== [11/12] UI build ==="
+	@echo "=== [12/13] UI build ==="
 	cd server/ui && npm run build
-	@echo "=== [12/12] cross-compile (linux/amd64 + darwin/arm64) ==="
+	@echo "=== [13/13] cross-compile (linux/amd64 + darwin/arm64) ==="
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags='-s -w' -o /dev/null ./collector/cmd/agenthound
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags='-s -w' -o /dev/null ./collector/cmd/agenthound
 	@echo ""

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# docs-check.sh — build the MkDocs site in --strict mode, which fails on
+# orphan pages (present in docs/ but missing from the mkdocs.yml nav), broken
+# internal links, and bad anchors. Mirrors the CI Docs job so doc-structure
+# breakage is caught locally instead of after merge.
+#
+# CI enforces the same strict build on every PR that touches docs/** or
+# mkdocs.yml (.github/workflows/docs.yml). This target is the local
+# equivalent and is intentionally NOT part of `make prerelease` (keeps that
+# gate Go/Node-only — no Python dependency).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v mkdocs >/dev/null 2>&1; then
+  echo "docs-check: mkdocs not found on PATH. Install the docs toolchain:"
+  echo "    python3 -m venv .venv && . .venv/bin/activate"
+  echo "    pip install -r docs/requirements.txt"
+  exit 1
+fi
+
+site_dir="$(mktemp -d)/site"
+mkdocs build --strict --site-dir "$site_dir"
+rm -rf "$site_dir"
+echo "docs-check: strict build OK."

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -20,7 +20,7 @@ if ! command -v mkdocs >/dev/null 2>&1; then
   exit 1
 fi
 
-site_dir="$(mktemp -d)/site"
-mkdocs build --strict --site-dir "$site_dir"
-rm -rf "$site_dir"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdocs build --strict --site-dir "$tmp/site"
 echo "docs-check: strict build OK."

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# sync-version.sh [X.Y.Z] — rewrite the install.sh + README install-pin
+# examples so they match a version. With no argument the version is taken from
+# the first "## vX.Y.Z" header in CHANGELOG.md (the source of truth).
+#
+# Release prep:
+#   1. write the new "## vX.Y.Z" section in CHANGELOG.md
+#   2. make sync-version
+#   3. make version-check   (or make prerelease)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ver="${1:-}"
+ver="${ver#v}"
+if [ -z "$ver" ]; then
+  ver=$(grep -m1 -oE '^## v[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | sed 's/^## v//' || true)
+fi
+if [ -z "$ver" ]; then
+  echo "sync-version: no version given and no '## vX.Y.Z' header in CHANGELOG.md"
+  exit 1
+fi
+
+# Portable in-place sed (GNU uses -i; BSD/macOS needs -i '').
+sedi() {
+  if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi
+}
+
+for f in install.sh README.md; do
+  sedi -E "s#agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh#agenthound/v${ver}/install.sh#g" "$f"
+  echo "sync-version: set v${ver} pin in $f"
+done
+echo "sync-version: done. Run 'make version-check' to confirm."

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -21,6 +21,12 @@ if [ -z "$ver" ]; then
   echo "sync-version: no version given and no '## vX.Y.Z' header in CHANGELOG.md"
   exit 1
 fi
+# Guard the substitution: a non-X.Y.Z value (typo'd VERSION= or sed-special
+# characters like & or #) would otherwise mutate / corrupt the pins in place.
+if ! echo "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "sync-version: '$ver' is not a valid X.Y.Z version"
+  exit 1
+fi
 
 # Portable in-place sed (GNU uses -i; BSD/macOS needs -i '').
 sedi() {

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# version-check.sh — assert the hand-maintained version pins agree with the
+# CHANGELOG, the single source of truth (SSOT). GoReleaser injects the
+# binary / Docker / Homebrew versions from the git tag, so the only strings
+# that can silently drift are the install.sh + README curl examples.
+#
+# SSOT: the first "## vX.Y.Z" header in CHANGELOG.md. "## Unreleased" sits
+# above it during a cycle and is skipped, so mid-cycle this resolves to the
+# last released version — which the pins already match.
+#
+# Run via `make version-check`; also runs inside `make prerelease`, so the
+# release pipeline (release.yml -> make prerelease) cannot publish a release
+# whose pins disagree with the CHANGELOG. On a tag build it additionally
+# asserts the pushed tag equals the CHANGELOG version.
+#
+# Blocking gate: returns non-zero on any mismatch.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ver=$(grep -m1 -oE '^## v[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | sed 's/^## v//' || true)
+if [ -z "$ver" ]; then
+  echo "version-check: FAIL — no '## vX.Y.Z' release header found in CHANGELOG.md"
+  exit 1
+fi
+echo "version-check: CHANGELOG source of truth = v$ver"
+
+fail=0
+check_pin() {
+  local file="$1" found
+  found=$(grep -oE 'agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh' "$file" \
+            | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+  if [ -z "$found" ]; then
+    echo "  FAIL: no 'agenthound/vX.Y.Z/install.sh' pin found in $file"
+    fail=1
+  elif [ "$found" != "v$ver" ]; then
+    echo "  FAIL: $file pins $found, expected v$ver"
+    fail=1
+  else
+    echo "  ok: $file -> $found"
+  fi
+}
+check_pin install.sh
+check_pin README.md
+
+# Release context: the pushed tag must also match the CHANGELOG. GitHub Actions
+# sets GITHUB_REF_TYPE / GITHUB_REF_NAME automatically; locally they are unset
+# and this block is skipped.
+if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+  if [ "${GITHUB_REF_NAME:-}" != "v$ver" ]; then
+    echo "  FAIL: tag ${GITHUB_REF_NAME:-<none>} != CHANGELOG v$ver"
+    fail=1
+  else
+    echo "  ok: tag ${GITHUB_REF_NAME} matches CHANGELOG"
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "version-check: FAILED — write the CHANGELOG section, then run 'make sync-version' (or fix the tag)."
+  exit 1
+fi
+echo "version-check: all version references consistent (v$ver)."


### PR DESCRIPTION
## Summary

Lean, path-filtered CI guards (with release-time + main-push backstops) so the version number stays consistent everywhere and docs-structure breakage is caught before merge — without slowing down code-only PRs.

- **Version SSOT = CHANGELOG.** `scripts/version-check.sh` asserts the `install.sh` + `README.md` install pins match the first `## vX.Y.Z` in `CHANGELOG.md`, and on a tag build that the pushed tag matches too. It runs as the first `make prerelease` step (so `release.yml` blocks a mismatched publish) and as a path-filtered PR job.
- **`make sync-version`** rewrites both pins from the CHANGELOG (or `VERSION=`, validated as `X.Y.Z`), removing the manual edit that caused drift.
- **Docs strict on PRs.** `.github/workflows/docs.yml` now runs `mkdocs build --strict` on PRs too (path-filtered to `docs/**` + `mkdocs.yml`); deploy stays main-push / `workflow_dispatch` only. `make docs-check` is the local equivalent.
- **CLAUDE.md** documents the SSOT + commands and fixes the stale prerelease check count.

## Lean by design
- Heavy docs job runs only on docs-touching PRs; version job only on version-file PRs; code-only PRs are untouched.
- `version-check` is pure bash (<1s); no Python dependency added to `make prerelease`.

## Never escapes (via backstops, not required checks)
- **Version:** `release.yml` -> `make prerelease` -> `version-check.sh` re-checks the pins AND the tag before GoReleaser publishes, so a mismatch cannot ship. The PR job is early feedback.
- **Docs:** the `deploy` job `needs: build`, so a failed strict build blocks the deploy — broken docs can never publish. The PR job is early feedback.
- These workflows are **path-filtered and intentionally NOT required status checks**: GitHub leaves a skipped path-filtered workflow "pending", which would block every code-only PR. The backstops above are the hard guarantee.

## Review fixes (2nd commit)
- Restored manual deploy: `docs.yml` upload + deploy now gate on `push || workflow_dispatch` (was push-only, so a manual run built but deployed nothing).
- `docs-check.sh` cleans its temp dir via `trap ... EXIT` (no leak; cleans up even on strict-build failure).
- `sync-version.sh` validates `VERSION=` is `X.Y.Z` before editing files.
- Documented the path-filter / not-required rationale in both workflows.

## Test plan
- [x] `make version-check` passes; tag mismatch fails (exit 1); `make sync-version` no-op on clean tree; `VERSION=garbage` / sed-special rejected with no file change
- [x] `make docs-check` strict build OK; temp dir removed by trap (verified); friendly message when mkdocs absent
- [x] `make -n prerelease` shows version-check as step [1/13]
- [x] Both workflow files are valid YAML
- [x] Do NOT add `Docs / build` or `Version Check / version-check` as required status checks (path-filtered → would block code-only PRs); rely on the backstops above