### PR TITLE
docs: AgentHound as an offensive/red-team framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AgentHound
 
-BloodHound for AI agent infrastructure. Two binaries: `agenthound` (lean collector, ~9.9 MiB) and `agenthound-server` (Neo4j + Postgres + React UI, binds 127.0.0.1:8080).
+Offensive security framework for AI agent infrastructure (BloodHound for the agentic stack). Two binaries: `agenthound` (lean collector, ~9.9 MiB) and `agenthound-server` (Neo4j + Postgres + React UI, binds 127.0.0.1:8080).
 
 ## Pre-Commit Checks (MANDATORY)
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ agenthound scan --config --output - | curl --data-binary @- -H "Content-Type: ap
 open http://127.0.0.1:8080   # xdg-open on Linux
 ```
 
+Prefer a reproducible, pinned install? Every release is cosign-signed with an SBOM:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.7.0/install.sh | sh
+```
+
+Also available via Homebrew (`brew install agenthound agenthound-server`), `go install`, and signed release binaries — see the [installation guide](https://docs.agenthound.io/getting-started/install/).
+
 Want the full arc against a safe target? `make demo` spins up 8 deliberately-vulnerable AI services on an isolated network and seeds scan → loot → ingest end-to-end.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,297 +1,220 @@
 <div align="center">
 
-<img src="docs/readme-assets/agenthound-banner.png" alt="AgentHound banner" width="100%">
+<img src="docs/readme-assets/agenthound-banner.png" alt="AgentHound" width="100%">
 
+### The offensive security framework for AI agent infrastructure
 
-**Attack-path discovery for MCP, A2A, and AI-agent infrastructure.**
----
-BloodHound for MCP servers, A2A agents, AI services, local configs, credentials, tools, prompts, and agent sprawl.
+**Recon · fingerprint · loot · extract · exploit · persist · analyze · revert — across the entire agentic stack, from one binary, into one graph.**
 
-[Docs](https://docs.agenthound.io) ·
-[Quickstart](https://docs.agenthound.io/getting-started/quickstart/) ·
+MCP · A2A · model gateways · inference servers · vector stores · MLOps · notebooks · 12 agent clients
+
+[Quickstart](#-quick-start) ·
+[Capabilities](#-capabilities) ·
+[Lifecycle](#-the-offensive-lifecycle) ·
 [Graph Model](https://docs.agenthound.io/reference/graph-model/) ·
-[CLI](https://docs.agenthound.io/reference/cli/) ·
-[Security](https://docs.agenthound.io/operator/security/) ·
-[Contributing](CONTRIBUTING.md)
+[Docs](https://docs.agenthound.io) ·
+[Safety](#-safety--authorization)
 
 [![CI](https://github.com/adithyan-ak/agenthound/actions/workflows/ci.yml/badge.svg)](https://github.com/adithyan-ak/agenthound/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/adithyan-ak/agenthound?logo=github)](https://github.com/adithyan-ak/agenthound/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/adithyan-ak/agenthound)](https://goreportcard.com/report/github.com/adithyan-ak/agenthound)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![cosign](https://img.shields.io/badge/releases-cosign%20signed-0b7285)](https://docs.agenthound.io/getting-started/install/)
 
 </div>
 
+> **Authorized use only.** AgentHound ships read-only discovery **and** active exploitation modules. Run it only against infrastructure you own or are written-authorized to assess. See [Safety & Authorization](#-safety--authorization).
+
+**AgentHound is an open-source offensive security framework for AI agent infrastructure.** It runs the full engagement — recon, fingerprinting, credential looting, **model & weight exfiltration**, model inversion, tool and instruction poisoning, and config-implant persistence — across every layer of the modern agentic stack, then merges every fact into one Neo4j graph and proves the attack paths that tie it all together. One data model, one graph, one `revert` to clean up.
+
+## ⚡ Capabilities
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+🌐 **Full-spectrum agentic attack surface**<br/>
+One framework attacks every layer — MCP, A2A, model gateways, inference servers, vector stores, MLOps, notebooks, and 12 agent clients. The whole estate is one target set.
+
+</td>
+<td width="50%" valign="top">
+
+🔓 **Credential looting across the gateway & service plane**<br/>
+Hand the LiteLLM looter one master key and get back every upstream provider key it brokers — OpenAI, Anthropic, Bedrock — plus virtual keys and spend. Secrets fuse across services by `value_hash`.
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+🧬 **Model & weight exfiltration**<br/>
+Stream raw model weights straight off an unauthenticated Ollama to disk — alongside modelfiles, templates, and system prompts. Not metadata about the model. The model.
+
+</td>
+<td width="50%" valign="top">
+
+🔬 **Model inversion / training-data residue extraction**<br/>
+A pure-Go GGUF parser runs statistical inversion on the embedding matrix to recover likely **fine-tune vocabulary tokens** — surfacing what a model was trained on as graph nodes.
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+☠️ **Active exploitation — tool/instruction poisoning + config implant**<br/>
+Rewrite the tool description the LLM reads, inject `CLAUDE.md` / `.cursorrules`, or implant a malicious MCP server for persistence. Every mutation is dry-run by default and byte-exact reversible.
+
+</td>
+<td width="50%" valign="top">
+
+🗄️ **RAG, vector-store & notebook attack surface**<br/>
+Inventory Qdrant collections and Jupyter sessions and notebook trees — the data-layer surfaces that ship unauthenticated by default.
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+🕸️ **Cross-protocol & credential-chain attack paths**<br/>
+15 post-processors compute the routes raw facts can't show — credential chains, cross-protocol pivots, exfiltration paths — up to 6 hops, across MCP and A2A.
+
+</td>
+<td width="50%" valign="top">
+
+🧪 **Indirect prompt injection, modeled as data-flow**<br/>
+Prompt injection treated as taint propagation: untrusted-input tools → tainted siblings → high-impact sinks, traced as real graph edges.
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+📊 **Detection & standards intelligence**<br/>
+19 prebuilt attack-path queries, 35 detection rules, 0–100 risk scoring, and retest-as-diff — crosswalked to OWASP MCP / Agentic Top 10 and MITRE ATLAS.
+
+</td>
+<td width="50%" valign="top">
+
+🧩 **Write your own attacks**<br/>
+A new attack against a new AI service is one module away — implement an action interface, drop a `register.go`, blank-import it. Same SDK, same lifecycle, same graph.
+
+</td>
+</tr>
+</table>
+
 <p align="center">
-  <img src="docs/readme-assets/agenthound-attack-surface.png" alt="AgentHound attack surface graph" width="900">
+  <img src="docs/readme-assets/agenthound-attack-surface.png" alt="AgentHound attack-surface graph" width="900">
 </p>
 
-> **Authorized use only.** AgentHound includes read-only discovery and active assessment modules. Run it only against infrastructure you own or have written authorization to assess. See [Responsible Use & Security Posture](#responsible-use--security-posture).
+## 🎯 Every plane of the stack is a target
 
-AgentHound maps the trust relationships inside modern AI-agent stacks, turns them into a Neo4j graph, and surfaces the paths that matter: what an agent can reach, execute, impersonate, or exfiltrate through.
+| Plane | What AgentHound attacks | Modules |
+|---|---|---|
+| **Agent client** | 12 MCP client configs + instruction files (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`) | `config` |
+| **Protocol** | MCP servers (stdio + HTTP/SSE), A2A agents (agent cards, JWS, delegation) | `mcp`, `a2a`, `protoscan` |
+| **Model gateway** | LiteLLM — one master key → the whole upstream provider keyring | `litellmfp`, `litellmloot` |
+| **Inference** | Ollama, vLLM — including **raw weight exfiltration** | `ollamafp`, `ollamaloot`, `vllmfp` |
+| **Vector / RAG** | Qdrant collections | `qdrantfp`, `qdrantloot` |
+| **MLOps** | MLflow experiments + runs | `mlflowfp`, `mlflowloot` |
+| **Notebook** | Jupyter sessions + notebook tree | `jupyterfp`, `jupyterloot` |
+| **Frontend** | Open WebUI (RAG docs, upstream keys), LangServe | `openwebuifp`, `openwebuiloot`, `langservefp` |
 
-It ships as two binaries:
+## 📦 By the numbers
 
-- **`agenthound`**: a lean collector that enumerates local configs, MCP, A2A, and AI-service surfaces, then emits JSON.
-- **`agenthound-server`**: a localhost analysis server with Neo4j, PostgreSQL, a REST API, post-processors, and a React graph UI.
+- **23 module packages** — 22 self-registering attack modules + the `protoscan` discovery engine
+- **8 offensive verbs** — `scan` · `discover` · `loot` · `extract` · `poison` · `implant` · `revert` (+ enumerate / fingerprint dispatch)
+- **8 fingerprinters · 6 looters · 1 model-inversion extractor · 2 poisoners · 1 implanter**
+- **Graph:** 25 node labels · 30 edge kinds (18 raw + 12 composite) · **15 post-processors**
+- **Intelligence:** 35 detection rules + 8 fingerprint rules · 19 prebuilt attack-path queries · OWASP MCP Top 10 + OWASP Agentic Top 10 + **7 MITRE ATLAS techniques**
+- **One static collector binary (~9.9 MiB, no DB/UI/server deps, offline by default).** Apache-2.0, cosign-signed releases with SBOM.
 
-## Why AgentHound?
+## 🚀 Quick start
 
-Static config scanners read one file at a time. Attack paths do not.
-
-An agent may trust one MCP server. That server may expose a credential. A separate service may be authorized by the same credential. No single config file declares the full path, but the combined graph does.
-
-AgentHound joins those facts into a directed trust graph so you can ask:
-
-```text
-Which agents can reach shell-capable tools?
-Which credentials create cross-service paths?
-Which poisoned tools sit on high-risk routes?
-Which agents can read sensitive data and send it outbound?
-```
-
-That is the BloodHound idea applied to AI-agent infrastructure — across the whole stack, not one protocol:
-
-- 🔌 **Protocols** — MCP · A2A
-- 🧠 **Services** — LiteLLM · Ollama · vLLM · LangServe · MLflow · Qdrant · Jupyter · Open WebUI
-- 💻 **Agent clients** — Claude Desktop · Claude Code · Cursor · VS Code · Windsurf · Continue · Cline · Zed · JetBrains · Amazon Q · Kiro · Augment
-
-## How It Works
-
-```mermaid
-flowchart LR
- subgraph Field["Field / scanned environment"]
- Config["Local configs"]
- MCP["MCP servers"]
- A2A["A2A agents"]
- Services["AI services"]
- Collector["agenthound collector"]
- end
-
- subgraph Operator["Operator workstation"]
- JSON["Scan JSON"]
- Ingest["Ingest"]
- Neo4j[("Neo4j")]
- Postgres[("PostgreSQL")]
- Analyze["Post-processors<br/>Risk scoring"]
- API["REST API"]
- UI["Graph UI"]
- end
-
- Config --> Collector
- MCP --> Collector
- A2A --> Collector
- Services --> Collector
- Collector --> JSON
- JSON --> Ingest
- Ingest --> Neo4j
- Ingest --> Postgres
- Neo4j --> Analyze
- Analyze --> API
- Analyze --> UI
-```
-
-The collector stays small and portable: no Neo4j driver, no PostgreSQL client, no UI, and no server dependencies. It writes JSON and exits. The server owns ingestion, deduplication, graph writes, post-processing, query APIs, and visualization.
-
-AgentHound's graph model includes agents, MCP servers, tools, resources, prompts, credentials, hosts, config files, instruction files, A2A agents, AI-service nodes, and model nodes. Composite edges such as `CAN_REACH`, `CAN_EXECUTE`, `CAN_EXFILTRATE_VIA`, `CAN_IMPERSONATE`, `SHADOWS`, `POISONED_DESCRIPTION`, and `POISONED_INSTRUCTIONS` are computed after ingest.
-
-Read the full schema in the [graph model reference](https://docs.agenthound.io/reference/graph-model/).
-
-<p align="center">
-  <img src="docs/readme-assets/agenthound-dashboard.png" alt="AgentHound graph explorer dashboard" width="900">
-</p>
-
-## Quick Start
-
-Prerequisites: Docker + Compose v2. No Go, no Node.js, no `git clone` — the server runs from a pre-built image and the collector is a single static binary.
-
-**1. Start the analysis server** (Neo4j + Postgres + UI, binds `127.0.0.1:8080`). `--wait` blocks until the healthcheck is green, so step 3 can't race it:
+Prerequisites: Docker + Compose v2. No Go, no Node, no `git clone`.
 
 ```bash
+# 1. Start the analysis server (Neo4j + Postgres + UI, binds 127.0.0.1:8080)
 curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/main/docker/docker-compose.public.yml | docker compose -f - -p agenthound up -d --wait
-```
 
-**2. Install the collector** (single static binary, ~9 MiB → `~/.local/bin`):
-
-```bash
+# 2. Install the collector (single static binary, ~9.9 MiB → ~/.local/bin)
 curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/main/install.sh | sh
-```
-
-Add it to your `PATH` for this session (persist by appending to `~/.zshrc` or `~/.bashrc`; fish users run `fish_add_path ~/.local/bin` instead):
-
-```bash
 export PATH="$HOME/.local/bin:$PATH"
-```
 
-**3. Scan and stream straight into the running server:**
-
-```bash
+# 3. Scan your own machine — offline, read-only, secrets hashed — and stream it in
 agenthound scan --config --output - | curl --data-binary @- -H "Content-Type: application/json" http://127.0.0.1:8080/api/v1/ingest
+
+# 4. Open the graph
+open http://127.0.0.1:8080   # xdg-open on Linux
 ```
 
-**4. Open the UI** at `http://127.0.0.1:8080` (`open` on macOS, `xdg-open` on Linux):
+Want the full arc against a safe target? `make demo` spins up 8 deliberately-vulnerable AI services on an isolated network and seeds scan → loot → ingest end-to-end.
 
-```bash
-open http://127.0.0.1:8080
-```
+<p align="center">
+  <img src="docs/readme-assets/agenthound-dashboard.png" alt="AgentHound dashboard" width="900">
+</p>
 
-No tokens, no logins, no drag-drop. The server admits non-browser callers (curl, the agenthound CLI, cron) and rejects cross-origin POSTs from your browser. Single-user, localhost-only — see [security model](docs/operator/security.md).
+## 🔪 The offensive lifecycle
 
-<details>
-<summary><strong>Other install and ingest options</strong></summary>
+One binary runs the whole offensive lifecycle. Every stage emits the same ingest envelope, so results land in the same graph. Active verbs (`loot`, `extract`, `poison`, `implant`) require an interactive `AUTHORIZED` confirmation; `extract`, `poison`, and `implant` are dry-run until `--commit` and are undone by `agenthound revert` — see [Safety & Authorization](#-safety--authorization).
 
-```bash
-# Drag-drop a scan file into the UI's Scan Manager (zero-CLI ingest)
-agenthound scan --config
-open http://127.0.0.1:8080   # then drop scan-*.json into the Scan Manager
-
-# Build from source (requires Go 1.25+ and Node.js 20+)
-git clone https://github.com/adithyan-ak/agenthound.git && cd agenthound
-docker compose -f docker/docker-compose.yml up -d --build   # builds server image locally
-make build                                                  # bin/agenthound + bin/agenthound-server
-
-# Install the collector with Go
-go install github.com/adithyan-ak/agenthound/collector/cmd/agenthound@latest
-
-# Install and start the server with Go (skips Docker entirely; you supply Neo4j + Postgres)
-go install github.com/adithyan-ak/agenthound/server/cmd/agenthound-server@latest
-agenthound-server serve
-
-# Pin install.sh to a release tag (verifies checksums; uses cosign when available)
-curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.7.0/install.sh | sh
-```
-
-See the full [installation guide](https://docs.agenthound.io/getting-started/install/) for Homebrew, release binaries, signature verification, and source builds.
-
-</details>
-
-## Recon to Report
-
-One binary runs the whole attack-path lifecycle. Every stage emits the same ingest envelope, so results land in the same graph. Active verbs (`loot`, `poison`, `implant`) require an interactive `AUTHORIZED` confirmation; `poison` and `implant` are dry-run until `--commit` and are undone by `agenthound revert` — see [Responsible Use & Security Posture](#responsible-use--security-posture).
-
-**1. Recon** — find the surface:
+**1. Recon** — find the AI estate:
 
 ```bash
 agenthound scan 10.0.0.0/24
-agenthound discover 10.0.0.0/24 --mcp
+agenthound discover 10.0.0.0/24 --mcp --a2a
 ```
 
-**2. Loot** — pull latent credentials, read-only (GET/HEAD):
+**2. Loot** — pull latent credentials and model weights, read-only (GET/HEAD):
 
 ```bash
-agenthound loot 172.30.0.20:4000 --type litellm --master-key sk-... --engagement-id RTV --output -
+agenthound loot 10.0.0.20:4000 --type litellm --master-key sk-... --engagement-id ENG-1 --output -
+agenthound loot 10.0.0.10:11434 --type ollama --include-weights --weights-dir /tmp/loot --engagement-id ENG-1
 ```
 
-Looter types: `litellm`, `ollama`, `mlflow`, `qdrant`, `openwebui`, `jupyter`.
+Looter types: `litellm`, `ollama`, `openwebui`, `mlflow`, `qdrant`, `jupyter`.
 
-**3. Exploit** — sanctioned, reversible offensive actions:
+**3. Extract** — invert a looted model to recover fine-tune residue:
 
 ```bash
-agenthound poison 10.0.0.30:8080 --type mcp.tool.description --target-id support_lookup --inject "Ignore prior instructions." --engagement-id RTV --commit
-agenthound revert RTV
+agenthound extract <model-id> --type embedding-invert --artifact /tmp/loot/model.bin --commit --engagement-id ENG-1
 ```
 
-**4. Analyze** — pathfind and gate:
+**4. Exploit + persist** — sanctioned, reversible offensive actions:
 
 ```bash
-agenthound-server query --prebuilt credential-chain
+agenthound poison 10.0.0.30:8080 --type mcp.tool.description --target-id support_lookup --inject "Ignore prior instructions." --commit --engagement-id ENG-1
+agenthound implant --type mcp.config.malicious-server --target-id ~/.cursor/mcp.json --inject "..." --commit --engagement-id ENG-1
+agenthound revert ENG-1
+```
+
+**5. Analyze** — pathfind and gate:
+
+```bash
+agenthound-server query --prebuilt litellm-credential-leak
 agenthound-server query --findings --fail-on critical
 ```
 
 See the full [CLI reference](https://docs.agenthound.io/reference/cli/) for every verb, flag, and module.
 
-## What AgentHound Finds
+## 🛡️ Safety & authorization
 
-AgentHound's detections are built around the questions security teams ask when they need to understand reachability, blast radius, and pathing risk.
+Built to be run under authorization, with the controls this audience checks for:
 
-| Finding | What it means | Security question |
-|---|---|---|
-| **Credential-chain paths** | The same secret appears in multiple contexts, letting trust cross service boundaries. | Which reused credential gives an agent access it never explicitly had? |
-| **Reachability** | Agents, MCP servers, tools, resources, prompts, A2A skills, and AI services are joined into one graph. | What can this agent actually reach if trust edges are followed? |
-| **Execution paths** | An agent can reach shell-like, database, network, or other high-impact tools. | Which agents have a path to command execution, data-plane control, or production impact? |
-| **Exfiltration paths** | An agent can read sensitive data and also reach an outbound channel. | Where can sensitive data leave the environment? |
-| **Cross-protocol pivots** | MCP, A2A, host context, and AI-service infrastructure combine into one reachable path. | Can one agent protocol become a bridge into another trust domain? |
-| **Tool poisoning** | Tool descriptions, prompts, or instruction files contain suspicious model-steering content. | Which tools or instructions could influence model behavior in unsafe ways? |
-| **Tool shadowing** | A lookalike tool mimics a trusted capability or name. | Which tool could intercept or hijack an expected action? |
-| **Rug pulls** | A tool's description changed between scans. | What changed since the last known-good graph, and did it create a new risk path? |
-| **Unauthenticated servers or agents** | MCP servers or A2A agents are reachable without expected authentication. | Which exposed agent surfaces need immediate review? |
-| **Risk hotspots** | Nodes and paths are prioritized with risk scores and prebuilt graph queries. | Where should investigation or remediation start first? |
+- **Read-only looter contract** — GET/HEAD only (narrow idempotent-search carve-outs), each guarded by a `get_only_test.go` regression test.
+- **Destructive verbs dry-run by default** — `poison` / `implant` / `extract` do nothing mutating without `--commit`.
+- **Compile-time-mandatory reverter** — `Poisoner` / `Implanter` embed `Reverter`; a module that can't undo itself won't build.
+- **Receipt before mutation** — the undo receipt is persisted to disk *before* the write lands.
+- **AUTHORIZED gates + `--engagement-id`** — interactive first-run prompts; every receipt and edge threaded for IR coordination.
+- **Recon guardrails** — public-IP targets require opt-in + an authorization-file watermark; link-local/multicast refused outright.
 
-See [Detection Rules](https://docs.agenthound.io/reference/detection-rules/) and [Risk Scoring](https://docs.agenthound.io/reference/risk-scoring/) for the full catalog.
-
-## Path Primitives
-
-AgentHound does not just list findings. It creates graph edges you can chain, query, and report:
-
-- **`CAN_REACH`**: an agent can traverse trust, credential, host, or protocol relationships to reach a target.
-- **`CAN_EXECUTE`**: an agent can reach a tool capable of command, database, network, or code execution.
-- **`CAN_EXFILTRATE_VIA`**: an agent can read sensitive data and send it through an outbound channel.
-- **`CAN_IMPERSONATE`**: an agent or identity can act as another trust principal.
-- **`SHADOWS`**: a tool mimics a trusted tool closely enough to hijack expected behavior.
-- **`POISONED_DESCRIPTION` / `POISONED_INSTRUCTIONS`**: tool or instruction text contains model-steering content.
-
-These edges turn AI-agent infrastructure into something you can pathfind instead of manually reason about.
-
-## Example Path
-
-```mermaid
-flowchart LR
-  Agent["AgentInstance<br/>claude-desktop"]
-  Notes["MCPServer<br/>internal-notes"]
-  Cred["Credential<br/>value_hash: a3f9..."]
-  Gateway["LiteLLMGateway<br/>prod"]
-  Providers["LLM providers<br/>OpenAI / Anthropic / Bedrock"]
-
-  Agent -- TRUSTS_SERVER --> Notes
-  Notes -- HAS_ENV_VAR --> Cred
-  Gateway -- EXPOSES_CREDENTIAL --> Cred
-  Agent -- CAN_REACH --> Gateway
-  Gateway -- PROVIDES_MODEL --> Providers
-```
-
-No single config file declares this path. AgentHound computes it once collector output lands in the same graph.
-
-## Where It Fits
-
-- **Initial access triage**: identify agent surfaces exposed without expected authentication.
-- **Privilege expansion**: find reused credentials and trust paths between agents, tools, hosts, and services.
-- **Objective pathing**: query routes to shell-like tools, databases, model gateways, and sensitive resources.
-- **Evidence packaging**: report graph-backed paths instead of hand-wavy config observations.
-- **Retest validation**: compare scans to prove a critical path disappeared.
-
-## Responsible Use & Security Posture
-
-AgentHound is built for authorized assessment and internal visibility. Active modules are for sanctioned testing only and are documented separately. The operator is responsible for authorization for every target.
-
-- The collector is offline by default and writes JSON to a file or stdout.
-- The server binds to `127.0.0.1:8080` by default.
-- The server is single-user with no application-layer login. Do not expose it beyond localhost; read endpoints may surface collected graph contents.
-- Mutating localhost API endpoints are gated by an Origin allowlist (`OriginGuard`); cross-origin browser POSTs are rejected, non-browser callers (curl, the agenthound CLI) pass through.
-- TLS verification is strict by default for supported network modules.
-- Destructive or mutating assessment workflows require explicit operator intent and should be used only within a written scope.
+**It is explicitly not** a C2, not an evasion implant (EDR will flag a binary named `agenthound`), and not a multi-user SaaS. It is an authorized-assessment framework, and the design says so.
 
 Read the [security posture guide](https://docs.agenthound.io/operator/security/) and [offensive actions guide](https://docs.agenthound.io/operator/offensive-actions/).
 
-## Documentation
+## 📚 Docs · Contributing · License
 
-Full documentation lives at [docs.agenthound.io](https://docs.agenthound.io).
+[Quickstart](https://docs.agenthound.io/getting-started/quickstart/) · [CLI](https://docs.agenthound.io/reference/cli/) · [Graph Model](https://docs.agenthound.io/reference/graph-model/) · [Detection Rules](https://docs.agenthound.io/reference/detection-rules/) · [Security](https://docs.agenthound.io/operator/security/)
 
-Start with:
-
-- [Quickstart](https://docs.agenthound.io/getting-started/quickstart/)
-- [Installation Guide](https://docs.agenthound.io/getting-started/install/)
-- [CLI Reference](https://docs.agenthound.io/reference/cli/)
-- [Configuration Guide](https://docs.agenthound.io/reference/configuration/)
-- [Graph Model](https://docs.agenthound.io/reference/graph-model/)
-- [Detection Rules](https://docs.agenthound.io/reference/detection-rules/)
-- [Deployment Guide](https://docs.agenthound.io/operator/deployment/)
-- [Security Posture](https://docs.agenthound.io/operator/security/)
-
-## Contributing
-
-AgentHound is built around small, self-registering modules and a stable ingest format. Collectors, detections, and post-processors are designed to be extended without pulling server dependencies into the collector.
-
-Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the [module authoring guide](https://docs.agenthound.io/contributing/modules/). Found a vulnerability in AgentHound itself? See [SECURITY.md](SECURITY.md).
-
-## License
+Write your own attack: implement an action interface, drop a `register.go`, blank-import it — see [CONTRIBUTING.md](CONTRIBUTING.md) and the [module authoring guide](https://docs.agenthound.io/contributing/modules/). Found a vulnerability in AgentHound itself? See [SECURITY.md](SECURITY.md).
 
 AgentHound is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 MCP · A2A · model gateways · inference servers · vector stores · MLOps · notebooks · 12 agent clients
 
+[![DEF CON 34 · Red Team Village](https://img.shields.io/badge/DEF_CON_34-Red_Team_Village-E4002B?style=for-the-badge&labelColor=000000)](https://redteamvillage.io/)
+
 [Quickstart](#-quick-start) ·
 [Capabilities](#-capabilities) ·
 [Lifecycle](#-the-offensive-lifecycle) ·
@@ -25,7 +27,7 @@ MCP · A2A · model gateways · inference servers · vector stores · MLOps · n
 
 > **Authorized use only.** AgentHound ships read-only discovery **and** active exploitation modules. Run it only against infrastructure you own or are written-authorized to assess. See [Safety & Authorization](#-safety--authorization).
 
-**AgentHound is an open-source offensive security framework for AI agent infrastructure.** It runs the full engagement — recon, fingerprinting, credential looting, **model & weight exfiltration**, model inversion, tool and instruction poisoning, and config-implant persistence — across every layer of the modern agentic stack, then merges every fact into one Neo4j graph and proves the attack paths that tie it all together. One data model, one graph, one `revert` to clean up.
+**AgentHound is an open-source offensive security framework for AI agent infrastructure.** It runs the full engagement — recon, fingerprinting, credential looting, **model & weight exfiltration**, model inversion, tool and instruction poisoning, and config-implant persistence — across every layer of the modern agentic stack, then merges every fact into one Neo4j graph and proves the attack paths that tie it all together. One data model, one graph, one `revert` to clean up. If you know BloodHound, you already know the shape — this is BloodHound for the agentic stack.
 
 ## ⚡ Capabilities
 
@@ -122,7 +124,7 @@ A new attack against a new AI service is one module away — implement an action
 ## 📦 By the numbers
 
 - **23 module packages** — 22 self-registering attack modules + the `protoscan` discovery engine
-- **8 offensive verbs** — `scan` · `discover` · `loot` · `extract` · `poison` · `implant` · `revert` (+ enumerate / fingerprint dispatch)
+- **7 offensive CLI verbs** — `scan` · `discover` · `loot` · `extract` · `poison` · `implant` · `revert` (`enumerate` + `fingerprint` run inside `scan`)
 - **8 fingerprinters · 6 looters · 1 model-inversion extractor · 2 poisoners · 1 implanter**
 - **Graph:** 25 node labels · 30 edge kinds (18 raw + 12 composite) · **15 post-processors**
 - **Intelligence:** 35 detection rules + 8 fingerprint rules · 19 prebuilt attack-path queries · OWASP MCP Top 10 + OWASP Agentic Top 10 + **7 MITRE ATLAS techniques**
@@ -203,6 +205,57 @@ agenthound-server query --findings --fail-on critical
 ```
 
 See the full [CLI reference](https://docs.agenthound.io/reference/cli/) for every verb, flag, and module.
+
+## 🔎 What AgentHound finds
+
+AgentHound's findings are built around the questions red teams and defenders ask when they need to understand reachability, blast radius, and pathing risk.
+
+| Finding | What it means | Question it answers |
+|---|---|---|
+| **Credential-chain paths** | The same secret appears in multiple contexts, letting trust cross service boundaries. | Which reused credential gives an agent access it never explicitly had? |
+| **Reachability** | Agents, MCP servers, tools, resources, prompts, A2A skills, and AI services are joined into one graph. | What can this agent actually reach if trust edges are followed? |
+| **Execution paths** | An agent can reach shell-like, database, network, or other high-impact tools. | Which agents have a path to command execution, data-plane control, or production impact? |
+| **Exfiltration paths** | An agent can read sensitive data and also reach an outbound channel. | Where can sensitive data leave the environment? |
+| **Cross-protocol pivots** | MCP, A2A, host context, and AI-service infrastructure combine into one reachable path. | Can one agent protocol become a bridge into another trust domain? |
+| **Tool poisoning** | Tool descriptions, prompts, or instruction files contain suspicious model-steering content. | Which tools or instructions could influence model behavior in unsafe ways? |
+| **Tool shadowing** | A lookalike tool mimics a trusted capability or name. | Which tool could intercept or hijack an expected action? |
+| **Rug pulls** | A tool's description, schema, or server instructions changed between scans. | What changed since the last known-good graph, and did it create a new risk path? |
+| **Unauthenticated servers or agents** | MCP servers or A2A agents are reachable without expected authentication. | Which exposed agent surfaces need immediate review? |
+| **Risk hotspots** | Nodes and paths are prioritized with risk scores and prebuilt graph queries. | Where should investigation or remediation start first? |
+
+See [Detection Rules](https://docs.agenthound.io/reference/detection-rules/) and [Risk Scoring](https://docs.agenthound.io/reference/risk-scoring/) for the full catalog.
+
+## 🔗 Path primitives
+
+AgentHound doesn't just list findings — it creates graph edges you can chain, query, and report:
+
+- **`CAN_REACH`**: an agent can traverse trust, credential, host, or protocol relationships to reach a target.
+- **`CAN_EXECUTE`**: an agent can reach a tool capable of command, database, network, or code execution.
+- **`CAN_EXFILTRATE_VIA`**: an agent can read sensitive data and send it through an outbound channel.
+- **`CAN_IMPERSONATE`**: an agent or identity can act as another trust principal.
+- **`SHADOWS`**: a tool mimics a trusted tool closely enough to hijack expected behavior.
+- **`POISONED_DESCRIPTION` / `POISONED_INSTRUCTIONS`**: tool or instruction text contains model-steering content.
+
+These edges turn AI-agent infrastructure into something you can pathfind instead of manually reason about.
+
+## 🗺️ Example path
+
+```mermaid
+flowchart LR
+  Agent["AgentInstance<br/>claude-desktop"]
+  Notes["MCPServer<br/>internal-notes"]
+  Cred["Credential<br/>value_hash: a3f9..."]
+  Gateway["LiteLLMGateway<br/>prod"]
+  Providers["LLM providers<br/>OpenAI / Anthropic / Bedrock"]
+
+  Agent -- TRUSTS_SERVER --> Notes
+  Notes -- HAS_ENV_VAR --> Cred
+  Gateway -- EXPOSES_CREDENTIAL --> Cred
+  Agent -- CAN_REACH --> Gateway
+  Gateway -- PROVIDES_MODEL --> Providers
+```
+
+No single config file declares this path. AgentHound computes it once collector output lands in the same graph.
 
 ## 🛡️ Safety & authorization
 

--- a/collector/cli/root.go
+++ b/collector/cli/root.go
@@ -14,9 +14,11 @@ var cfg *clientcfg.Config
 
 var rootCmd = &cobra.Command{
 	Use:   "agenthound",
-	Short: "BloodHound for AI Agent Infrastructure — collector",
-	Long: `AgentHound enumerates MCP servers, A2A agents, and client configurations,
-then writes the trust graph as JSON to a file or stdout.
+	Short: "Offensive security framework for AI agent infrastructure — collector",
+	Long: `AgentHound is an offensive security framework for AI agent infrastructure.
+The collector runs the field side of the engagement — recon, fingerprinting,
+enumeration, credential looting, model extraction, poisoning, and config
+implants — and writes the results as JSON to a file or stdout.
 
 The collector is auth-less and offline-by-default. Operators ingest the
 resulting JSON on their analysis box via 'agenthound-server ingest <file>',

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # AgentHound Documentation
 
-Attack-path discovery for AI agent infrastructure. [BloodHound](https://github.com/BloodHoundAD/BloodHound) for MCP, A2A, and AI services.
+The offensive security framework for AI agent infrastructure — run the full red-team lifecycle (recon, credential looting, model & weight exfiltration, model inversion, tool/instruction poisoning, config-implant persistence, and attack-path analysis) across MCP, A2A, and AI services. [BloodHound](https://github.com/BloodHoundAD/BloodHound) for the agentic stack.
 
 ---
 
@@ -27,8 +27,8 @@ Attack-path discovery for AI agent infrastructure. [BloodHound](https://github.c
 
 - **[CLI Reference](reference/cli.md)** — Every command, flag, and env var
 - **[API Reference](reference/api.md)** — REST endpoints, auth, request/response schemas
-- **[Graph Model](reference/graph-model.md)** — 25 node types, 25 edge types, ID strategy, merge semantics
-  - [CAN_REACH](reference/edges/can-reach.md) — The marquee composite edge (transitive agent→resource access)
+- **[Graph Model](reference/graph-model.md)** — 25 node types, 30 edge types (18 raw + 12 composite), ID strategy, merge semantics
+  - [CAN_REACH](reference/edges/can-reach.md) — Transitive agent→resource access (one of the 12 composite edges)
 - **[Detection Rules](reference/detection-rules.md)** — 19 pre-built queries + OWASP mapping
 - **[Rule Syntax](reference/rule-syntax.md)** — YAML schema for detection + fingerprint rules
 - **[Configuration](reference/configuration.md)** — Env vars, state directories, defaults
@@ -38,7 +38,7 @@ Attack-path discovery for AI agent infrastructure. [BloodHound](https://github.c
 
 - **[System Design](architecture/system-design.md)** — Two-binary split, data flow, tech stack
 - **[Ingest Pipeline](architecture/ingest-pipeline.md)** — Validate → normalize → deduplicate → write → post-process
-- **[Post-Processors](architecture/post-processors.md)** — 11 composite-edge processors with dependency ordering
+- **[Post-Processors](architecture/post-processors.md)** — 15 post-processors computing 12 composite edges, in dependency order
 
 ## Contributing
 

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -9,10 +9,10 @@ AgentHound is an offensive security framework for AI agent infrastructure. It ru
    |    agenthound         |  JSON file   |     agenthound-server           |
    |    (collector)        | -- or stdin->|     (single-user)               |
    |                       |  pipe / UI   |                                 |
-   |  scan / rules /       |  drag-drop   |  serve / ingest / query         |
-   |  version (+ stub      |              |  +---------------------------+  |
-   |  loot/extract/        |              |  |    API Server (chi/v5)    |  |
-   |  poison/implant)      |              |  | /api/v1/* — read=open,    |  |
+   |  scan / discover /    |  drag-drop   |  serve / ingest / query         |
+   |  loot / extract /     |              |  +---------------------------+  |
+   |  poison / implant /   |              |  |    API Server (chi/v5)    |  |
+   |  revert (+ rules)     |              |  | /api/v1/* — read=open,    |  |
    +-----------------------+              |  |  mutate=Origin allowlist  |  |
                                           |  |  +---------------------+  |  |
                                           |  |  | Embedded React SPA  |  |  |

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-AgentHound enumerates MCP servers and A2A agents, builds a directed trust graph in Neo4j, and uses shortest-path algorithms to discover attack paths across protocol boundaries. It ships as **two binaries** in the BloodHound/SharpHound style: a lean field collector (`agenthound`) and a single-user analysis server (`agenthound-server`).
+AgentHound is an offensive security framework for AI agent infrastructure. It runs the full red-team lifecycle — recon, fingerprinting, credential looting, model and weight exfiltration, model inversion, tool/instruction poisoning, and config-implant persistence — then merges every fact into a Neo4j graph and computes the attack paths that tie it together. It ships as **two binaries** in the BloodHound/SharpHound mold: a lean field collector (`agenthound`) and a single-user analysis server (`agenthound-server`).
 
 ## Components
 
@@ -50,7 +50,7 @@ scan --config         scan --mcp --url <url>           scan --a2a --target <url>
          |  2. Normalize (snake_case)   |
          |  3. Deduplicate (MERGE)      |
          |  4. Batch write to Neo4j     |
-         |  5. Post-process (9 stages   |
+         |  5. Post-process (15 stages  |
          |     producing composite      |
          |     edges, plus risk score)  |
          +------------------------------+
@@ -98,14 +98,14 @@ scan --config         scan --mcp --url <url>           scan --a2a --target <url>
 Node IDs are deterministic SHA-256 hashes of `Kind:` + identifying properties. MCPServer IDs
 match across Config and MCP collectors -- this is the merge point connecting trust to capabilities.
 
-### Edge Types (25 total)
+### Edge Types (30 total)
 
-**17 raw edges** (from collectors): TRUSTS_SERVER, PROVIDES_TOOL, PROVIDES_RESOURCE,
+**18 raw edges** (from collectors): TRUSTS_SERVER, PROVIDES_TOOL, PROVIDES_RESOURCE,
 PROVIDES_PROMPT, ADVERTISES_SKILL, DELEGATES_TO, AUTHENTICATES_WITH, USES_CREDENTIAL,
 RUNS_ON, CONFIGURED_IN, HAS_ENV_VAR, LOADS_INSTRUCTIONS, SAME_AUTH_DOMAIN, EXPOSES,
-EXPOSES_CREDENTIAL, PROVIDES_MODEL, EXTRACTED_FROM.
+EXPOSES_CREDENTIAL, PROVIDES_MODEL, EXTRACTED_FROM, INGESTS_UNTRUSTED.
 
-**8 composite edges** (computed by post-processors in dependency order):
+**12 composite edges** (computed by post-processors in dependency order):
 
 | # | Edge | Meaning |
 |---|------|---------|
@@ -113,10 +113,14 @@ EXPOSES_CREDENTIAL, PROVIDES_MODEL, EXTRACTED_FROM.
 | 2 | CAN_EXECUTE | Tool can execute commands on a host |
 | 3 | SHADOWS | Tool mimics another tool's description cross-server |
 | 4 | POISONED_DESCRIPTION | Tool description contains injection patterns |
-| 5 | CAN_REACH | Agent has transitive access to a resource |
-| 6 | CAN_EXFILTRATE_VIA | Agent can reach sensitive data + outbound channel |
-| 7 | CAN_IMPERSONATE | A2A agent mimics another (TF-IDF cosine > 0.8) |
-| 8 | Cross-protocol CAN_REACH | A2A agent reaches MCP resources via host correlation |
+| 5 | POISONED_INSTRUCTIONS | Instruction file contains injection patterns |
+| 6 | TAINTS | Untrusted-input tool shares schema keys with a tool on another server |
+| 7 | CAN_REACH | Agent has transitive access to a resource (incl. credential-chain + cross-protocol, up to 6 hops) |
+| 8 | CAN_EXFILTRATE_VIA | Agent can reach sensitive data + an outbound channel |
+| 9 | IFC_VIOLATION | Untrusted source shares a resource with a high-impact sink |
+| 10 | CAN_IMPERSONATE | A2A agent mimics another (TF-IDF cosine > 0.8) |
+| 11 | CONFUSED_DEPUTY | Weakly-authed agent delegates to a strongly-authed one |
+| 12 | POISONS_CONTEXT | Injection-bearing tool poisons context driving a high-capability tool |
 
 All edges carry: `scan_id`, `last_seen`, `confidence`, `risk_weight`, `is_composite`, `evidence`.
 

--- a/docs/getting-started/demo-lab.md
+++ b/docs/getting-started/demo-lab.md
@@ -1,6 +1,6 @@
 # Demo Lab
 
-A self-contained Docker environment for the DEFCON demo path: config scan, network scan, protocol discovery, LiteLLM/Ollama loot, HTTP ingest, and validation of the credential-chain finding. Poison/revert remains available as a manual workshop extension, but `make demo` does not mutate the lab.
+A self-contained Docker environment that runs the offensive lifecycle end-to-end: config scan, network scan, protocol discovery, LiteLLM/Ollama loot, HTTP ingest, and validation of the resulting attack-path findings (e.g., the LiteLLM credential-leak path). Poison/revert remains available as a manual workshop extension, but `make demo` does not mutate the lab.
 
 ## Lab topology
 

--- a/docs/operator/attack-paths.md
+++ b/docs/operator/attack-paths.md
@@ -1,69 +1,108 @@
 # Attack Path Analysis
 
-Once the offensive lifecycle has harvested the estate — configs, MCP/A2A enumeration, looted credentials and models — AgentHound's analysis layer turns that loot into attack paths that span protocol boundaries, paths no single-protocol scanner can see. The graph combines MCP trust relationships, A2A delegation chains, network-discovered AI services, and looted credentials into a unified directed graph where Cypher queries reveal multi-hop exploitation routes.
+Once the offensive lifecycle has collected configs, MCP/A2A enumeration, AI-service posture, looted credentials, and model artifacts, AgentHound's analysis layer turns those facts into attack paths. The graph combines MCP trust relationships, A2A delegation chains, network-discovered AI services, instruction files, untrusted-input signals, and credential reuse into one directed graph where composite edges and Cypher queries reveal multi-hop exploitation routes.
 
-## 1. Credential chains via value_hash
+The canonical graph schema is in [Graph Model](../reference/graph-model.md). The canonical processor details and cleanup semantics are in [Post-Processors](../architecture/post-processors.md).
 
-The `value_hash` property on `Credential` nodes is the cross-collector merge primitive. When two collectors independently discover the same secret value, they emit `Credential` nodes with identical `value_hash` (SHA-256 of the raw value). The `cross_service_credential_chain` post-processor joins these into transitive access paths.
+## Path Families
 
-### How it works
+AgentHound computes 12 composite edge types. Operators usually reason about them in these path families:
 
-1. **Config Collector** parses an MCP client config and finds `LITELLM_MASTER_KEY=sk-...` as an env var on an MCPServer. Emits:
-   ```
-   (:MCPServer)-[:HAS_ENV_VAR]->(:Credential {type: "envVar", value_hash: H1})
-   ```
+| Family | Composite edges | What it answers |
+|---|---|---|
+| Reachability | `HAS_ACCESS_TO`, `CAN_REACH` | What can an agent, tool, or A2A boundary reach if trust edges are followed? |
+| Credential chains | `CAN_REACH` with `via_credential` or `source_collector='cross_service_credential_chain'` | Where does credential reuse create implicit access? |
+| Execution and exfiltration | `CAN_EXECUTE`, `CAN_EXFILTRATE_VIA` | Which paths lead to command/code execution or sensitive-data egress? |
+| Poisoning and context manipulation | `SHADOWS`, `POISONED_DESCRIPTION`, `POISONED_INSTRUCTIONS`, `POISONS_CONTEXT` | Which tools or instruction files can steer model behavior? |
+| Untrusted-input data flow | `TAINTS`, `IFC_VIOLATION` | Can attacker-controlled input flow into compatible tools or high-impact sinks? |
+| A2A identity and delegation | `CAN_IMPERSONATE`, `CONFUSED_DEPUTY`, cross-protocol `CAN_REACH` | Can an A2A agent mimic, delegate into, or pivot across trust boundaries? |
 
-2. **LiteLLM Looter** authenticates with the same master key and discovers upstream provider keys. Emits:
-   ```
-   (:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(:Credential {type: "master_key", value_hash: H1})
-   (:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(:Credential {type: "apiKey", provider: "openai", value_hash: H2})
-   (:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(:Credential {type: "apiKey", provider: "anthropic", value_hash: H3})
-   ```
+Not every composite edge has a named pre-built query. Pre-built queries live under `agenthound-server query --prebuilt <id>`; composite-edge findings are always available through `agenthound-server query --findings` and `GET /api/v1/analysis/findings`.
 
-3. **Post-processor** matches `H1 == H1` across collectors, then walks the full path:
-   ```
-   (:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)-[:HAS_ENV_VAR]->(c1)-[value_hash join]->
-   (:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(upstream_cred)
-   ```
-   Emits: `(:AgentInstance)-[:CAN_REACH {type: "credential_chain"}]->(upstream_cred)`
+## 1. Reachability (`HAS_ACCESS_TO`, `CAN_REACH`)
 
-### Query: surface all credential chains
+`HAS_ACCESS_TO` links tools to resources when capability surface and resource URI scheme line up, or when a tool description references a resource. `CAN_REACH` then folds agent trust into transitive access:
 
-```cypher
-MATCH path = (a:AgentInstance)-[:CAN_REACH {evidence_type: "credential_chain"}]->(c:Credential)
-WHERE c.type = 'apiKey'
-RETURN a.name AS agent, c.provider AS provider, c.value_hash AS hash,
-       length(path) AS hops
-ORDER BY hops ASC
+```text
+(:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)
+  -[:PROVIDES_TOOL]->(:MCPTool)
+  -[:HAS_ACCESS_TO]->(:MCPResource)
 ```
+
+The `can_reach` processor emits:
+
+```text
+(:AgentInstance)-[:CAN_REACH {hops: 3, via_server, via_tool}]->(:MCPResource)
+```
+
+Credential-mediated reachability is also a `CAN_REACH` variant. If an agent can reach a tool that can read credentials, and another MCP server authenticates with one of those credentials, AgentHound emits a longer `CAN_REACH` path with `via_credential` and `hops: 6`.
+
+### Pre-built queries
+
+```bash
+agenthound-server query --prebuilt credential-chain
+agenthound-server query --prebuilt shortest-to-database
+agenthound-server query --prebuilt agents-shell-access
+```
+
+## 2. Cross-Service Credential Chains (`value_hash`)
+
+`Credential.value_hash` is the cross-collector merge primitive. Every collector and looter that emits a `Credential` must populate it with `SHA-256(raw credential value)`. When two independently discovered credentials share the same `value_hash`, AgentHound can prove that they represent the same secret without storing the raw value by default.
+
+Example: a local MCP config exposes a LiteLLM master key, and the LiteLLM looter uses that same key to enumerate upstream provider keys.
+
+```text
+(:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)
+  -[:HAS_ENV_VAR]->(:Credential {value_hash: H1})
+
+(:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(:Credential {value_hash: H1})
+(:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(:Credential {type: "apiKey"})
+```
+
+The `cross_service_credential_chain` processor joins on `value_hash` and emits:
+
+```text
+(:AgentInstance)-[:CAN_REACH {
+  source_collector: "cross_service_credential_chain",
+  via_gateway,
+  merge_value_hash,
+  upstream_provider,
+  hops: 5
+}]->(:Credential)
+```
+
+It also writes `blast_radius` on the joined credential nodes: the number of distinct agents that can reach the merged secret.
 
 ### Pre-built query
 
 ```bash
-agenthound-server query --prebuilt credential-chain
+agenthound-server query --prebuilt litellm-credential-leak
 ```
 
-## 2. Cross-protocol CAN_REACH (A2A to MCP)
+## 3. Cross-Protocol Pivots (`CAN_REACH`)
 
-When an A2A agent delegates to another agent that runs on the same host as an MCP server, the graph reveals transitive access from the A2A protocol boundary into MCP resources -- a path invisible to tools that only analyze one protocol.
+When an external A2A agent delegates to another A2A agent running on the same host as an MCP server, AgentHound can emit a cross-protocol `CAN_REACH` path from the A2A boundary into MCP resources.
 
-### How it works
-
-1. A2A Collector emits: `(:A2AAgent)-[:DELEGATES_TO]->(:A2AAgent)-[:RUNS_ON]->(:Host)`
-2. Config/MCP Collector emits: `(:MCPServer)-[:RUNS_ON]->(:Host)` and `(:MCPServer)-[:PROVIDES_TOOL]->(:MCPTool)-[:HAS_ACCESS_TO]->(:MCPResource)`
-3. The `cross_protocol` post-processor correlates via shared Host nodes and emits:
-   ```
-   (:A2AAgent)-[:CAN_REACH {type: "cross_protocol"}]->(:MCPResource)
-   ```
-
-### Query: all cross-protocol paths
-
-```cypher
-MATCH path = (a:A2AAgent)-[:DELEGATES_TO*1..3]->(delegate:A2AAgent)-[:RUNS_ON]->(h:Host)<-[:RUNS_ON]-(s:MCPServer)-[:PROVIDES_TOOL]->(t:MCPTool)-[:HAS_ACCESS_TO]->(r:MCPResource)
-RETURN a.name AS source_agent, delegate.name AS pivot_agent,
-       h.hostname AS shared_host, s.name AS mcp_server,
-       t.name AS tool, r.uri AS resource
+```text
+(:A2AAgent)-[:DELEGATES_TO*1..3]->(:A2AAgent)
+  -[:RUNS_ON]->(:Host)<-[:RUNS_ON]-(:MCPServer)
+  -[:PROVIDES_TOOL]->(:MCPTool)
+  -[:HAS_ACCESS_TO]->(:MCPResource)
 ```
+
+The emitted edge is:
+
+```text
+(:A2AAgent)-[:CAN_REACH {
+  cross_protocol: true,
+  source_collector: "a2a",
+  via_host,
+  via_mcp_server,
+  via_mcp_tool
+}]->(:MCPResource)
+```
+
+The current processor requires the external A2A agent to have no authentication (`auth_method IS NULL` or `auth_method = 'none'`).
 
 ### Pre-built query
 
@@ -71,61 +110,23 @@ RETURN a.name AS source_agent, delegate.name AS pivot_agent,
 agenthound-server query --prebuilt cross-protocol-paths
 ```
 
-## 3. Tool poisoning paths
+## 4. Execution and Exfiltration
 
-Two post-processors detect tool-level manipulation that can redirect agent behavior:
+`CAN_EXECUTE` links an MCP tool to its host when the tool has `shell_access` or `code_execution` in `capability_surface`.
 
-### SHADOWS
-
-A tool on Server B references Server A's tool by name or description fragment, enabling tool confusion attacks where an agent calls the shadow instead of the original.
-
-```cypher
-MATCH (shadow:MCPTool)-[:SHADOWS]->(original:MCPTool)
-MATCH (shadow)<-[:PROVIDES_TOOL]-(shadow_server:MCPServer)
-MATCH (original)<-[:PROVIDES_TOOL]-(original_server:MCPServer)
-WHERE shadow_server <> original_server
-RETURN shadow.name AS shadow_tool, shadow_server.name AS shadow_on,
-       original.name AS original_tool, original_server.name AS original_on
+```text
+(:MCPTool)-[:CAN_EXECUTE]->(:Host)
 ```
 
-### POISONED_DESCRIPTION
+`CAN_EXFILTRATE_VIA` links an agent to an outbound-capable tool when both conditions are true:
 
-A tool's description contains injection patterns (imperative overrides, exfiltration URLs, instruction hijacking). Self-referencing edge on the MCPTool node.
+1. The agent can reach a `critical` or `high` sensitivity `MCPResource`.
+2. The agent trusts a server with an outbound-capable tool.
 
-```cypher
-MATCH (t:MCPTool)-[p:POISONED_DESCRIPTION]->(t)
-MATCH (t)<-[:PROVIDES_TOOL]-(s:MCPServer)<-[:TRUSTS_SERVER]-(a:AgentInstance)
-RETURN a.name AS exposed_agent, s.name AS server, t.name AS tool,
-       p.evidence AS injection_evidence
-```
+Outbound-capable means the tool has one of:
 
-### Pre-built queries
-
-```bash
-agenthound-server query --prebuilt tool-shadowing
-agenthound-server query --prebuilt poisoned-tools
-```
-
-## 4. Exfiltration routes (CAN_EXFILTRATE_VIA)
-
-The `CAN_EXFILTRATE_VIA` edge connects an agent to a tool that provides BOTH access to sensitive data (via `CAN_REACH` to a sensitive resource) AND an outbound channel (network_outbound or email_send capability).
-
-### How it works
-
-1. `CAN_REACH` post-processor establishes agent-to-resource reachability
-2. Tool capability classification identifies outbound channels (`capability_surface` includes `network_outbound` or `email_send`)
-3. Post-processor joins: agent can reach sensitive data AND has a tool to send it somewhere
-
-### Query: all exfiltration routes
-
-```cypher
-MATCH (a:AgentInstance)-[e:CAN_EXFILTRATE_VIA]->(t:MCPTool)
-MATCH (a)-[:CAN_REACH]->(r:MCPResource)
-WHERE r.sensitivity IN ['critical', 'high']
-RETURN a.name AS agent, t.name AS exfil_tool,
-       collect(r.uri) AS sensitive_resources,
-       t.capability_surface AS capabilities
-ORDER BY size(collect(r.uri)) DESC
+```text
+email_send, network_outbound, file_write, auto_fetch_render, allowlisted_proxy
 ```
 
 ### Pre-built query
@@ -134,35 +135,160 @@ ORDER BY size(collect(r.uri)) DESC
 agenthound-server query --prebuilt exfiltration-routes
 ```
 
-## Combining findings
+## 5. Poisoning and Context Manipulation
 
-The real power is in composition. An operator running the full chain (config scan + network scan + discover + loot + ingest) gets all four attack-path types computed automatically by the post-processor pipeline. The Findings API returns them ranked by severity:
+AgentHound models both direct poisoning indicators and graph-level paths where poisoned context can influence high-impact tools.
+
+### `SHADOWS`
+
+A tool on one server references a tool on another server by name in its description. This can support tool-confusion attacks where the agent calls the shadowing tool instead of the intended capability.
+
+```cypher
+MATCH (shadow:MCPTool)-[r:SHADOWS]->(original:MCPTool)
+MATCH (shadow)<-[:PROVIDES_TOOL]-(shadow_server:MCPServer)
+MATCH (original)<-[:PROVIDES_TOOL]-(original_server:MCPServer)
+WHERE shadow_server.objectid <> original_server.objectid
+RETURN shadow.name AS shadowing_tool,
+       shadow_server.name AS shadowing_server,
+       original.name AS shadowed_tool,
+       original_server.name AS shadowed_server,
+       r.confidence AS confidence
+ORDER BY r.confidence DESC
+```
+
+### `POISONED_DESCRIPTION`
+
+A tool description contains injection patterns detected by the rules engine. This is a self-edge on the tool:
+
+```text
+(:MCPTool)-[:POISONED_DESCRIPTION]->(:MCPTool)
+```
+
+### `POISONED_INSTRUCTIONS`
+
+An instruction file loaded by an agent contains suspicious patterns such as imperative overrides, exfiltration commands, or hidden Unicode:
+
+```text
+(:InstructionFile)-[:POISONED_INSTRUCTIONS]->(:InstructionFile)
+```
+
+### `POISONS_CONTEXT`
+
+The `shadows` processor also emits `POISONS_CONTEXT` when an injection-bearing tool can poison the same agent context that drives a high-capability sibling tool:
+
+```text
+(:MCPTool)-[:POISONS_CONTEXT]->(:MCPTool)
+```
+
+The sink tool must carry one of:
+
+```text
+shell_access, code_execution, credential_access, email_send
+```
+
+Fan-out is capped to 20 sinks per `(agent, source tool)` pair to avoid cartesian blowups while still surfacing high-risk sources.
+
+### Pre-built queries
+
+```bash
+agenthound-server query --prebuilt tool-shadowing
+agenthound-server query --prebuilt poisoned-tools
+agenthound-server query --prebuilt instruction-poisoning
+```
+
+## 6. Untrusted-Input Data Flow (`TAINTS`, `IFC_VIOLATION`)
+
+The MCP collector emits raw `INGESTS_UNTRUSTED` edges for tools tagged by rules such as untrusted web, email, or fileshare input.
+
+```text
+(:MCPTool)-[:INGESTS_UNTRUSTED]->(:MCPResource)
+```
+
+The `taints` processor emits `TAINTS` when an untrusted-input tool shares at least two input-schema keys with a tool on another server:
+
+```text
+(:MCPTool)-[:TAINTS]->(:MCPTool)
+```
+
+The `ifc_violation` processor emits `IFC_VIOLATION` when an untrusted-input tool shares a resource path, within three `HAS_ACCESS_TO` hops, with a high-impact sink:
+
+```text
+(:MCPTool)-[:IFC_VIOLATION]->(:MCPTool)
+```
+
+High-impact sink capabilities are:
+
+```text
+credential_access, file_write, email_send
+```
+
+These edges surface through findings rather than dedicated pre-built query IDs.
+
+## 7. A2A Identity and Delegation
+
+### `CAN_IMPERSONATE`
+
+The `can_impersonate` processor computes TF-IDF cosine similarity over A2A skill descriptions and emits bidirectional `CAN_IMPERSONATE` edges for cross-provider agent pairs with similarity greater than `0.8`.
+
+```text
+(:A2AAgent)-[:CAN_IMPERSONATE]->(:A2AAgent)
+```
+
+### `CONFUSED_DEPUTY`
+
+The `auth_strength` pre-pass writes numeric auth weakness scores onto `MCPServer` and `A2AAgent` nodes. Higher is weaker (`none=100`, `apiKey=70`, `bearer=50`, `oauth=25`, `mtls=10`).
+
+The `confused_deputy` processor emits `CONFUSED_DEPUTY` when a weakly authenticated A2A agent delegates to a strongly authenticated one:
+
+```text
+(:A2AAgent {auth_strength >= 80})
+  -[:CONFUSED_DEPUTY]->
+(:A2AAgent {auth_strength <= 30})
+```
+
+This models a low-trust caller borrowing the privileges of a higher-trust callee.
+
+## Findings and Path Details
+
+The Findings API returns composite-edge findings ranked by severity. The response shape uses `edge_kind`, not a processor name.
 
 ```bash
 # All critical and high findings
 agenthound-server query --findings --severity critical,high
 
-# Specific finding detail with full path
+# All CAN_REACH findings
 curl -s localhost:8080/api/v1/analysis/findings | \
-    jq '.[] | select(.processor == "cross_service_credential_chain")'
+    jq '.[] | select(.edge_kind == "CAN_REACH")'
+
+# Fetch one finding detail, including composite edge properties and reconstructed path
+finding_id=$(curl -s localhost:8080/api/v1/analysis/findings | jq -r '.[0].id')
+curl -s "localhost:8080/api/v1/analysis/findings/${finding_id}" | jq .
 ```
 
-The UI's Findings panel renders each path as an interactive graph with the attack narrative annotated on edges. The Graph Explorer allows click-through from any node to its blast radius (N-hop reachable subgraph).
+The finding detail response includes `composite_props`, which is where processor-specific properties such as `source_collector`, `via_gateway`, `merge_value_hash`, and `cross_protocol` appear.
 
-## Post-processor execution order
+The UI's Findings panel renders each path as an interactive graph with the attack narrative annotated on edges. The Graph Explorer allows click-through from any node to its blast radius.
 
-Attack-path edges depend on lower-level edges being computed first:
+## Post-Processor Execution Order
 
-1. HAS_ACCESS_TO
-2. CAN_EXECUTE
-3. SHADOWS
-4. POISONED_DESCRIPTION
-5. POISONED_INSTRUCTIONS
-6. CAN_REACH (depends on 1)
-7. cross_service_credential_chain (depends on 1, 6)
-8. CAN_EXFILTRATE_VIA (depends on 6)
-9. CAN_IMPERSONATE
-10. Cross-protocol CAN_REACH (depends on 1)
-11. RiskScore (depends on all above)
+Processors run in dependency order. A processor may only read edges or properties produced by earlier processors.
 
-Each post-processor is idempotent. Re-ingesting the same scan re-runs the pipeline and updates composite edges in place (MERGE by source+target+kind).
+| # | Processor | Produces | Dependencies |
+|---|-----------|----------|--------------|
+| 1 | `auth_strength` | `auth_strength` node property | None |
+| 2 | `has_access_to` | `HAS_ACCESS_TO` | Raw edges |
+| 3 | `can_execute` | `CAN_EXECUTE` | Raw edges |
+| 4 | `shadows` | `SHADOWS`, `POISONS_CONTEXT` | Raw edges |
+| 5 | `poisoned_description` | `POISONED_DESCRIPTION` | Raw edges |
+| 6 | `poisoned_instructions` | `POISONED_INSTRUCTIONS` | Raw edges |
+| 7 | `taints` | `TAINTS` | `INGESTS_UNTRUSTED`, `schema_keys` |
+| 8 | `can_reach` | `CAN_REACH` | `HAS_ACCESS_TO` |
+| 9 | `cross_service_credential_chain` | `CAN_REACH` to upstream credentials, `Credential.blast_radius` | `HAS_ACCESS_TO`, `CAN_REACH`, `value_hash` |
+| 10 | `ifc_violation` | `IFC_VIOLATION` | `HAS_ACCESS_TO`, `INGESTS_UNTRUSTED` |
+| 11 | `can_exfiltrate` | `CAN_EXFILTRATE_VIA` | `CAN_REACH` |
+| 12 | `can_impersonate` | `CAN_IMPERSONATE` | Raw edges |
+| 13 | `confused_deputy` | `CONFUSED_DEPUTY` | `auth_strength`, `CAN_REACH` |
+| 14 | `cross_protocol` | Cross-protocol `CAN_REACH` | `HAS_ACCESS_TO`, `DELEGATES_TO` |
+| 15 | `risk_score` | `risk_score` node property | Prior processors |
+
+Each post-processor is idempotent. Re-ingesting a scan re-runs the pipeline and updates composite edges in place with `MERGE` by source, target, and edge kind. Stale composite-edge cleanup is scoped by `source_collector`, so partial scans refresh only the composite findings derived from collectors that ran in the current scan.

--- a/docs/operator/attack-paths.md
+++ b/docs/operator/attack-paths.md
@@ -1,6 +1,6 @@
 # Attack Path Analysis
 
-AgentHound's core contribution is surfacing attack paths that span protocol boundaries -- paths no single-protocol scanner can see. The graph combines MCP trust relationships, A2A delegation chains, network-discovered AI services, and looted credentials into a unified directed graph where Cypher queries reveal multi-hop exploitation routes.
+Once the offensive lifecycle has harvested the estate — configs, MCP/A2A enumeration, looted credentials and models — AgentHound's analysis layer turns that loot into attack paths that span protocol boundaries, paths no single-protocol scanner can see. The graph combines MCP trust relationships, A2A delegation chains, network-discovered AI services, and looted credentials into a unified directed graph where Cypher queries reveal multi-hop exploitation routes.
 
 ## 1. Credential chains via value_hash
 

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -2,10 +2,11 @@
 
 ## What AgentHound is
 
-AgentHound is a transparent, authorized-assessment tool for AI agent
-infrastructure. It enumerates configuration, queries documented
-endpoints, and builds a graph of trust relationships. Operators run it
-against systems they have been authorized to assess.
+AgentHound is a transparent, authorized-assessment offensive security
+framework for AI agent infrastructure. The collector runs recon,
+enumeration, credential looting, and reversible exploitation; the server
+builds the graph and computes attack paths. Operators run it against
+systems they have been authorized to assess.
 
 ## What AgentHound is not
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: AgentHound
-site_description: Attack-path discovery for AI agent infrastructure — BloodHound for MCP, A2A, and AI services.
+site_description: The offensive security framework for AI agent infrastructure — recon, credential looting, model exfiltration, poisoning, and attack-path analysis across MCP, A2A, and AI services. BloodHound for the agentic stack.
 site_url: https://docs.agenthound.io
 copyright: Copyright &copy; AgentHound contributors — Apache-2.0
 


### PR DESCRIPTION
## Summary

Repositions AgentHound across its public surface to a clear hierarchy:

1. **Primary** — the offensive security / AI red-team framework for agentic infrastructure (full lifecycle: recon, credential looting, model & weight exfiltration, model inversion, tool/instruction poisoning, config-implant persistence, attack-path analysis).
2. **Secondary** — "BloodHound for the agentic stack" (kept as the analogy, no longer the lead).
3. **Tertiary** — `CAN_REACH` / credential-chain is one composite edge among twelve, never framed as the hero/marquee detection.

### README
- Capabilities-first card grid (every offensive primitive), stack-coverage table, "by the numbers".
- Quick Start moved above the offensive lifecycle; lifecycle rewritten as numbered, copy-pasteable phases.
- Dropped the "not a scanner" / "what no single tool does" framing and the module-catalog table.

### Supporting docs (this push)
- **Front-door taglines:** `mkdocs.yml` `site_description`, `docs/README.md` (docs home), and `agenthound --help` (`collector/cli/root.go` Short/Long), plus `CLAUDE.md` one-liner.
- **Reframed intros:** `architecture/system-design.md`, `operator/attack-paths.md` (drop "core contribution"), `getting-started/demo-lab.md` (de-hero the credential chain), `operator/security.md` (acknowledge offensive modules).
- **Stale graph counts fixed** in the docs touched: edges 25 -> 30 (18 raw + 12 composite, added `INGESTS_UNTRUSTED` + the 4 missing composite edges), post-processors 11 -> 15.

### Repo metadata (applied directly)
- Updated the GitHub "About" description to the offensive-framework one-liner.
- Added discovery topics: `ai-security`, `llm-security`, `mcp`, `model-context-protocol`, `a2a`, `red-team`, `offensive-security`, `pentesting`, `ai-agents`, `agentic-ai`, `security-tools`, `neo4j`, `attack-paths`, `bloodhound`.

Deliberately left untouched (historical / accurate / out of scope): `CHANGELOG.md`, `adr/0001-two-binary-split.md`, `docs/plans/*` & `cfp/*` (excluded from site), `defcon_submission.md`, UI feature copy, and `graph-model.md`/`post-processors.md`/`detection-rules.md` (already canonical/correct).

## Test plan

- [x] `gofmt -l`, `go build ./collector/...`, `go vet ./collector/...` clean after the `root.go` change.
- [x] `make docs-check` (`mkdocs build --strict`) passes.
- [ ] Preview README + docs home render correctly on GitHub.
- [ ] Confirm `agenthound --help` shows the new Short/Long.