### PR TITLE
cleanup(ollamaloot): align flag surface with upstream Ollama API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Ollama Looter: align flag surface with upstream API
+
+Removes the experimental `--include-weights` / `--weights-dir` flags from `agenthound loot --type ollama` and cleans up the docs, tests, and node schema that surrounded them. The flags targeted `/api/blobs/<digest>` with `GET`, which sits outside Ollama's documented HTTP API surface — the upstream spec defines only `HEAD` (existence check for the create-model flow) and `POST` (upload) on that path (see the [Ollama API docs](https://github.com/ollama/ollama/blob/main/docs/api.md#check-if-a-blob-exists) and the [OpenAPI spec](https://github.com/ollama/ollama/blob/main/docs/openapi.yaml)). Raw GGUF acquisition from a compromised Ollama host remains available out-of-band via filesystem access to `~/.ollama/models/blobs/`; `agenthound extract --type embedding-invert` continues to accept any locally-available GGUF file.
+
+- **Flags removed:** `--include-weights`, `--weights-dir` (on `agenthound loot --type ollama`).
+- **Code removed:** the weight-extraction branch, `downloadBlob`, `MaxWeightBytes`, and the filename/digest helpers from `modules/ollamaloot/looter.go`; the two flag-specific tests and their stub handler from `modules/ollamaloot/looter_test.go`. Anonymous-happy-path, `--include-credential-values`, and `--include-embeddings` coverage is unchanged.
+- **Node schema:** the `weight_artifact_path` / `weight_artifact_sha256` / `weight_artifact_bytes` properties on `:AIModel` are no longer emitted.
+- **Extractor unchanged:** the GGUF parser + embedding-inversion pipeline in `modules/embeddinginvert/` is correct against any local weight file. `agenthound extract --type embedding-invert --artifact <path>` help + godoc were rewritten to make out-of-band GGUF acquisition explicit (compromised host at `~/.ollama/models/blobs/`, HuggingFace, etc.).
+- **Docs:** the README capability tile now describes the Ollama Looter's actual surface (modelfile / system prompt / fine-tune detection). `docs/operator/loot/ollama.md` replaces the Level 3 "Weight extraction" section with an "out-of-band acquisition" guide pointing at `~/.ollama/models/blobs/`. `docs/reference/cli.md`, `docs/README.md`, `docs/architecture/system-design.md`, and `docs/contributing/modules.md` track the flag removal. `docs/plans/sprint3-offensive-primitives.md` gains a dated correction block noting the `/api/blobs` GET premise sits outside upstream's API surface.
+
+Callers that pass `--include-weights` or `--weights-dir` will hit an unknown-flag error at the CLI parser rather than a silent no-op — deliberate, so a stale invocation surfaces immediately.
+
 ## v0.7.0
 
 Network `scan` / `discover` usability and hardening. Adds progress and summary output to the network verbs, fixes a `:MCPServer` duplicate-node bug at the cross-collector merge point, and adds memory-safety guards (absolute host ceiling, nested-include rejection, concurrency clamp) across the scan/discover path.
@@ -174,8 +188,8 @@ The "broaden the scan surface, harden the operations" milestone. v0.2 turned the
 
 - `agenthound loot <host> --type ollama` extracts model inventory + modelfiles via two anonymous GETs (`/api/tags`, `/api/show`). Implemented in `modules/ollamaloot/`.
 - Each emitted `:AIModel` carries `value_hash` over the modelfile content — the cross-collector merge primitive extends to model artifacts, so the same fine-tune leaked via Ollama matches the same modelfile discovered through any future collector.
-- Two flag-gated extras (default OFF, opt-in only):
-  - `--include-weights` + `--weights-dir <path>` — streams `/api/blobs/<digest>` to disk. Multi-GiB. Bandwidth-heavy. Loud. SHA-256 + bytes-written recorded on the AIModel node.
+- Two flag-gated extras (default OFF, opt-in only) — ~~`--include-weights` + `--weights-dir <path>`~~ **[removed in a follow-up; see Unreleased "Ollama Looter: align flag surface with upstream API"]** and `--include-embeddings`:
+  - ~~`--include-weights` + `--weights-dir <path>`~~ **Removed in a follow-up patch to align the Looter surface with Ollama's documented HTTP API. See the "Ollama Looter: align flag surface with upstream API" entry under Unreleased.**
   - `--include-embeddings` — single POST `/api/embeddings` to confirm the inference compute path is consumable. The Looter contract is GET-only by default; this POST is the documented exception, allowed because it is read-only-in-effect on the target. Gated because operator-billed compute is the cost.
 - GET-only contract enforced by `get_only_test.go` with an explicit allowlist for the two POST exceptions (`/api/show` is a "lookup with a body"; `/api/embeddings` per above).
 - Modelfile / template / system-prompt content NOT promoted onto the node by default — only `value_hash` + size + has-system-prompt boolean. `--include-credential-values` opts into raw modelfile content, mirroring the LiteLLM Looter.
@@ -185,7 +199,7 @@ The "broaden the scan surface, harden the operations" milestone. v0.2 turned the
 - New `sdk/module/flags.go` declares `type FlagsModule interface { RegisterFlags(*pflag.FlagSet) }` as a pure side-interface. Modules that need per-module CLI flags add the method; modules that don't, don't.
 - `module.RegisterFlagsFor(cmd, m)` helper does the type-assert in one call so action subcommands (`agenthound loot` etc.) don't repeat the boilerplate.
 - `agenthound loot --help` lists every per-module flag from every registered Looter at command-construction time — operators discover module-specific flags without having to specify `--type` first. Per-module flag values flow into `LootOptions.Extras` (new field on the v0.2 `LootOptions` struct) at dispatch time.
-- The Ollama Looter is the first consumer (`--include-weights`, `--weights-dir`, `--include-embeddings`).
+- The Ollama Looter is the first consumer (`--include-embeddings`; `--include-weights` and `--weights-dir` were originally listed here too but were removed in a follow-up — see Unreleased).
 
 ### Rules-bundle loader and signed-tarball release
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Hand the LiteLLM looter one master key and get back every upstream provider key 
 <tr>
 <td width="50%" valign="top">
 
-🧬 **Model & weight exfiltration**<br/>
-Stream raw model weights straight off an unauthenticated Ollama to disk - alongside modelfiles, templates, and system prompts. Not metadata about the model. The model.
+🧬 **Modelfile, system-prompt & fine-tune inventory**<br/>
+Enumerate every model on an unauthenticated Ollama - names, digests, sizes, modelfiles, templates, and system prompts. Fine-tunes (SYSTEM / ADAPTER directives) get flagged; each `:AIModel` node carries `value_hash` so a leaked prompt matches across collectors.
 
 </td>
 <td width="50%" valign="top">
 
 🔬 **Model inversion / training-data residue extraction**<br/>
-A pure-Go GGUF parser runs statistical inversion on the embedding matrix to recover likely **fine-tune vocabulary tokens** - surfacing what a model was trained on as graph nodes.
+A pure-Go GGUF parser runs statistical inversion on the embedding matrix of any weight file you feed it to recover likely **fine-tune vocabulary tokens** - surfacing what a model was trained on as graph nodes.
 
 </td>
 </tr>
@@ -113,7 +113,7 @@ A new attack against a new AI service is one module away - implement an action i
 | **Agent client** | 12 MCP client configs + instruction files (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`) | `config` |
 | **Protocol** | MCP servers (stdio + HTTP/SSE), A2A agents (agent cards, JWS, delegation) | `mcp`, `a2a`, `protoscan` |
 | **Model gateway** | LiteLLM - one master key → the whole upstream provider keyring | `litellmfp`, `litellmloot` |
-| **Inference** | Ollama, vLLM - including **raw weight exfiltration** | `ollamafp`, `ollamaloot`, `vllmfp` |
+| **Inference** | Ollama, vLLM - model inventory, modelfiles, system prompts, fine-tune detection | `ollamafp`, `ollamaloot`, `vllmfp` |
 | **Vector / RAG** | Qdrant collections | `qdrantfp`, `qdrantloot` |
 | **MLOps** | MLflow experiments + runs | `mlflowfp`, `mlflowloot` |
 | **Notebook** | Jupyter sessions + notebook tree | `jupyterfp`, `jupyterloot` |
@@ -172,19 +172,19 @@ agenthound scan 10.0.0.0/24
 agenthound discover 10.0.0.0/24 --mcp --a2a
 ```
 
-**2. Loot** - pull latent credentials and model weights, read-only (GET/HEAD):
+**2. Loot** - pull latent credentials and model metadata, read-only (GET/HEAD):
 
 ```bash
 agenthound loot 10.0.0.20:4000 --type litellm --master-key sk-... --engagement-id ENG-1 --output -
-agenthound loot 10.0.0.10:11434 --type ollama --include-weights --weights-dir /tmp/loot --engagement-id ENG-1
+agenthound loot 10.0.0.10:11434 --type ollama --include-credential-values --engagement-id ENG-1
 ```
 
 Looter types: `litellm`, `ollama`, `openwebui`, `mlflow`, `qdrant`, `jupyter`.
 
-**3. Extract** - invert a looted model to recover fine-tune residue:
+**3. Extract** - invert a locally-available GGUF weight file to recover fine-tune residue:
 
 ```bash
-agenthound extract <model-id> --type embedding-invert --artifact /tmp/loot/model.bin --commit --engagement-id ENG-1
+agenthound extract <model-id> --type embedding-invert --artifact /path/to/model.gguf --commit --engagement-id ENG-1
 ```
 
 **4. Exploit + persist** - sanctioned, reversible offensive actions:

--- a/collector/cli/extract.go
+++ b/collector/cli/extract.go
@@ -24,11 +24,15 @@ import (
 var extractCmd = &cobra.Command{
 	Use:   "extract <source-node-id>",
 	Short: "Extract training signals or derived artifacts from a model (gated)",
-	Long: `Run a registered Extractor against a previously-looted artifact.
+	Long: `Run a registered Extractor against a locally-available artifact.
 
 v0.5 ships one Extractor: embedding-invert — detects fine-tune training
 signals by analyzing statistical outliers in the embedding layer of a
-GGUF weight file produced by 'agenthound loot --type ollama --include-weights'.
+GGUF weight file. Point --artifact at any GGUF the operator has already
+obtained out-of-band: a blob copied from ~/.ollama/models/blobs/ on a
+compromised host, a HuggingFace download, or any other source. The
+Ollama HTTP API does not expose a raw-weight download endpoint, so
+AgentHound cannot pull the file itself.
 
 By default --commit is OFF. Without --commit the Extractor runs end-to-
 end but does not emit ingest data (dry-run summary only).
@@ -36,7 +40,7 @@ end but does not emit ingest data (dry-run summary only).
 Example:
 
   agenthound extract <ai-model-node-id> --type embedding-invert \
-      --artifact /tmp/loot/support-agent-v3-sha256abc123.bin \
+      --artifact /path/to/support-agent-v3.gguf \
       --commit --engagement-id DC35-DEMO --output -`,
 	Args:          cobra.ExactArgs(1),
 	RunE:          runExtract,
@@ -46,7 +50,7 @@ Example:
 
 func init() {
 	extractCmd.Flags().String("type", "", "Extractor target kind (e.g. 'embedding-invert'). Required.")
-	extractCmd.Flags().String("artifact", "", "Path to the artifact file (e.g. weight file from --include-weights).")
+	extractCmd.Flags().String("artifact", "", "Path to the local artifact file (e.g. a GGUF weight file obtained out-of-band).")
 	extractCmd.Flags().Bool("commit", false, "Emit ingest data. Default: dry-run summary only.")
 	extractCmd.Flags().String("engagement-id", "", "Engagement identifier. Required.")
 	if err := extractCmd.MarkFlagRequired("type"); err != nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # AgentHound Documentation
 
-The offensive security framework for AI agent infrastructure — run the full red-team lifecycle (recon, credential looting, model & weight exfiltration, model inversion, tool/instruction poisoning, config-implant persistence, and attack-path analysis) across MCP, A2A, and AI services. [BloodHound](https://github.com/BloodHoundAD/BloodHound) for the agentic stack.
+The offensive security framework for AI agent infrastructure — run the full red-team lifecycle (recon, credential looting, model & modelfile inventory, model inversion, tool/instruction poisoning, config-implant persistence, and attack-path analysis) across MCP, A2A, and AI services. [BloodHound](https://github.com/BloodHoundAD/BloodHound) for the agentic stack.
 
 ---
 
@@ -17,7 +17,7 @@ The offensive security framework for AI agent infrastructure — run the full re
 - **[Protocol Discovery](operator/discover.md)** — Find MCP servers and A2A agents by protocol shape
 - **[Looting](operator/loot/index.md)** — Extract credentials and model artifacts from discovered services
   - [LiteLLM](operator/loot/litellm.md) — Master key → upstream provider keys
-  - [Ollama](operator/loot/ollama.md) — Model inventory, modelfiles, weight extraction
+  - [Ollama](operator/loot/ollama.md) — Model inventory, modelfiles, fine-tune detection
 - **[Offensive Actions](operator/offensive-actions.md)** — Poison tool descriptions, implant configs, revert
 - **[Attack Paths](operator/attack-paths.md)** — Credential chains, cross-protocol pivots, exfiltration routes
 - **[Deployment](operator/deployment.md)** — Production setup, reverse proxy, backups

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-AgentHound is an offensive security framework for AI agent infrastructure. It runs the full red-team lifecycle — recon, fingerprinting, credential looting, model and weight exfiltration, model inversion, tool/instruction poisoning, and config-implant persistence — then merges every fact into a Neo4j graph and computes the attack paths that tie it together. It ships as **two binaries** in the BloodHound/SharpHound mold: a lean field collector (`agenthound`) and a single-user analysis server (`agenthound-server`).
+AgentHound is an offensive security framework for AI agent infrastructure. It runs the full red-team lifecycle — recon, fingerprinting, credential looting, model and modelfile inventory, model inversion, tool/instruction poisoning, and config-implant persistence — then merges every fact into a Neo4j graph and computes the attack paths that tie it together. It ships as **two binaries** in the BloodHound/SharpHound mold: a lean field collector (`agenthound`) and a single-user analysis server (`agenthound-server`).
 
 ## Components
 

--- a/docs/contributing/modules.md
+++ b/docs/contributing/modules.md
@@ -166,8 +166,10 @@ For modules that need CLI flags beyond the standard set:
 import "github.com/spf13/pflag"
 
 func (f *YourLooter) RegisterFlags(fs *pflag.FlagSet) {
-    fs.BoolVar(&f.includeWeights, "include-weights", false, "Download model weight files")
-    fs.StringVar(&f.weightsDir, "weights-dir", "", "Directory for weight storage")
+    fs.Bool("include-embeddings", false,
+        "Issue benchmark embedding request (consumes operator-billed compute)")
+    fs.String("api-key", "",
+        "Optional service API key; enables authenticated enumeration")
 }
 ```
 

--- a/docs/operator/loot/ollama.md
+++ b/docs/operator/loot/ollama.md
@@ -1,6 +1,6 @@
 # `agenthound loot --type ollama` -- Ollama Looter
 
-Ollama is the default anonymous-loot target: no authentication by default, model inventory and modelfiles available via simple HTTP. The Looter extracts model metadata, system prompts, and (optionally) raw weights without modifying any state on the target.
+Ollama is the default anonymous-loot target: no authentication by default, model inventory and modelfiles available via simple HTTP. The Looter extracts model metadata and system prompts without modifying any state on the target.
 
 ## What it extracts
 
@@ -9,9 +9,10 @@ Ollama is the default anonymous-loot target: no authentication by default, model
 | Model inventory (names, digests, sizes) | `/api/tags` | GET | Always |
 | Modelfile, template, system prompt, family, parameters | `/api/show` | POST | Always (per model) |
 | Embedding capability confirmation | `/api/embeddings` | POST | `--include-embeddings` only |
-| Raw model weights | `/api/blobs/<digest>` | GET | `--include-weights` only |
 
 Each model emits an `:AIModel` node joined to the `:OllamaInstance` via a `PROVIDES_MODEL` edge. Fine-tunes (detected by `SYSTEM` or `ADAPTER` directives in the modelfile) are flagged with `is_finetune: true`.
+
+> **Note on raw weights.** The Ollama HTTP API does not expose a raw-weight download endpoint — `/api/blobs/<digest>` accepts only `HEAD` (existence check) and `POST` (upload for the create-model flow) per the [upstream API docs](https://github.com/ollama/ollama/blob/main/docs/api.md). Raw weight blobs live at `~/.ollama/models/blobs/sha256-<digest>` and require filesystem access on the target host to retrieve. A `--include-weights` flag was shipped in v0.3 based on a misread of that endpoint; it was withdrawn — see the CHANGELOG.
 
 ## Probe levels
 
@@ -42,22 +43,13 @@ Issues a single `POST /api/embeddings` against the first available model with a 
 
 Sets `embedding_capability_confirmed: true|false` on the `OllamaInstance` node.
 
-### Level 3: Weight extraction (`--include-weights`)
+## Getting raw weights (out-of-band)
 
-```bash
-agenthound loot 10.0.0.10:11434 --type ollama \
-    --include-weights --weights-dir ./extracted-weights \
-    --engagement-id ENG-001 --output -
-```
+The Looter no longer attempts raw weight extraction — Ollama's HTTP API does not support it. If the engagement needs the actual GGUF weight file (e.g. as input to `agenthound extract --type embedding-invert`), obtain it out-of-band:
 
-Streams `GET /api/blobs/<digest>` for each model to local disk. Multi-GiB per model. Bandwidth-heavy and highly visible in network monitoring.
-
-- `--weights-dir` is mandatory with `--include-weights`
-- Files written as `<model-name>-<digest-prefix>.bin` (mode 0600)
-- Capped at 32 GiB per blob (defensive ceiling)
-- Adds `weight_artifact_path`, `weight_artifact_sha256`, `weight_artifact_bytes` to the AIModel node
-
-Use this when the engagement requires proving model exfiltration is possible or when the fine-tune itself is the target artifact.
+- **Filesystem access to a compromised host.** Ollama stores weights as content-addressed blobs at `~/.ollama/models/blobs/sha256-<digest>`. `ollama show <model> --modelfile` on the host prints the `FROM` line with the blob's absolute path. `cp` the blob to a `.gguf` filename and any llama.cpp-compatible tool (including `agenthound extract`) loads it directly.
+- **Model registry / HuggingFace.** If the model name matches a public release, the weights are downloadable at source.
+- **Manifests as a shopping list.** `~/.ollama/models/manifests/` lists every layer digest per installed model — useful for enumerating what's on disk before physical acquisition.
 
 ## value_hash semantics
 
@@ -94,8 +86,6 @@ Expected output: two models -- `tinyllama` (stock, `is_finetune: false`) and `su
 | Flag | Default | Notes |
 |------|---------|-------|
 | `--include-embeddings` | `false` | POST exception; consumes target compute |
-| `--include-weights` | `false` | Multi-GiB downloads; requires `--weights-dir` |
-| `--weights-dir <path>` | -- | Local directory for extracted weight blobs |
 | `--include-credential-values` | `false` | Emit raw modelfile/template/system_prompt |
 | `--max-items <n>` | 1000 | Cap on models enumerated from `/api/tags` |
 | `--engagement-id <id>` | empty | Correlation key on all edges |

--- a/docs/plans/sprint3-offensive-primitives.md
+++ b/docs/plans/sprint3-offensive-primitives.md
@@ -1,5 +1,7 @@
 # Sprint 3 — Offensive primitives (network scanner + first Looter)
 
+> **2026-07-06 correction (post-v0.3, retroactive).** §2.1's bullets treating `/api/blobs/<digest>` as a GET-able weight-download channel sit outside Ollama's documented HTTP API surface. Upstream defines only `HEAD` (existence check for the create-model flow) and `POST` (upload) on that path — raw weight blobs are reachable via filesystem access to `~/.ollama/models/blobs/` on the host, not over HTTP. The Ollama Looter's `--include-weights` / `--weights-dir` surface (planned in §5) was removed in a follow-up to align with the upstream API — see the CHANGELOG entry titled "Ollama Looter: align flag surface with upstream API". Read every subsequent Ollama-loot section in this plan with that correction in mind.
+>
 > **Status:** Draft for design review (refreshed 2026-05-16).
 > **Authors:** AgentHound architect (research + plan).
 > **Date:** 2026-04-23, refreshed 2026-05-16.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -181,9 +181,9 @@ agenthound loot <host:port> --type <kind> [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--include-weights` | `false` | Extract model weights via `/api/blobs/<digest>` (multi-GiB, very loud). |
-| `--weights-dir` | | Directory for extracted weights (required with `--include-weights`). |
 | `--include-embeddings` | `false` | Issue test embedding calls via `/api/embeddings` (consumes compute). |
+
+> Ollama's HTTP API does not expose a raw-weight download endpoint. See [Ollama loot](../operator/loot/ollama.md#getting-raw-weights-out-of-band) for how to obtain the GGUF weight file out-of-band when the engagement needs it.
 
 #### Per-Module Flags: `--type openwebui`
 
@@ -398,7 +398,7 @@ agenthound extract <source-node-id> --type embedding-invert \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--type` | (required) | Extractor kind (`embedding-invert`) |
-| `--artifact` | (required) | Path to artifact file (from `--include-weights`) |
+| `--artifact` | (required) | Path to a local GGUF weight file (obtained out-of-band; see [Ollama loot](../operator/loot/ollama.md#getting-raw-weights-out-of-band)) |
 | `--commit` | `false` | Emit ingest data (default: dry-run summary) |
 | `--engagement-id` | (required) | Engagement correlation key |
 | `--confidence-threshold` | `3.0` | Z-score threshold for outlier detection |

--- a/modules/ollamaloot/helpers_test.go
+++ b/modules/ollamaloot/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 )
 
 // readAllString drains r.Body into a string. Test-only helper.
@@ -22,8 +21,4 @@ func readAllString(r *http.Request) (string, error) {
 func jsonString(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
-}
-
-func stat(path string) (os.FileInfo, error) {
-	return os.Stat(path)
 }

--- a/modules/ollamaloot/looter.go
+++ b/modules/ollamaloot/looter.go
@@ -10,12 +10,10 @@
 // Probes (GET-only by default — Looters are read-only by contract):
 //
 //	GET /api/tags                  — list installed models
-//	GET /api/show     (per model)  — modelfile, template, parameters, system prompt
+//	POST /api/show    (per model)  — modelfile, template, parameters, system prompt
+//	                                 (documented "lookup with a body" exception)
 //
 // Flag-gated extras (default OFF, opt-in only):
-//
-//	GET /api/blobs/<digest>  (--include-weights, --weights-dir <path>)
-//	    Streams model weights to disk. Multi-GiB. Bandwidth-heavy. Loud.
 //
 //	POST /api/embeddings      (--include-embeddings)
 //	    Issues a single benchmark embedding request to confirm the
@@ -24,21 +22,25 @@
 //	    allowed because it is read-only-in-effect on the target (no
 //	    state change). Gated behind explicit flag because it consumes
 //	    operator-billed compute.
+//
+// The previous v0.3 --include-weights / --weights-dir surface was
+// removed: it targeted GET /api/blobs/<digest>, an endpoint Ollama's
+// HTTP API does not implement. Only HEAD (existence check) and POST
+// (upload for the create-model flow) are defined on that path — see
+// https://github.com/ollama/ollama/blob/main/docs/api.md — so the flag
+// could never stream weights against a real Ollama. Raw weight
+// extraction from a compromised host still requires filesystem access
+// to ~/.ollama/models/blobs/, which is out of scope for a Looter.
 package ollamaloot
 
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -53,12 +55,6 @@ const (
 	DefaultPort         = 11434
 	DefaultProbeTimeout = 30 * time.Second
 	DefaultMaxItems     = 1000
-
-	// MaxWeightBytes caps a single weight blob download. Real Ollama
-	// blobs are GiB-scale; this is a defensive ceiling against an
-	// attacker-controlled response that streams forever. 32 GiB is
-	// generous for current model sizes.
-	MaxWeightBytes int64 = 32 << 30
 )
 
 // Looter is the registered module.
@@ -70,22 +66,16 @@ type Looter struct{}
 // the ollama target. Mirrors the FlagsModule sidecar pattern from
 // sdk/module/flags.go — flag values flow through LootOptions.Extras.
 func (l *Looter) RegisterFlags(fs *pflag.FlagSet) {
-	fs.Bool("include-weights", false,
-		"Extract model weights via /api/blobs/<digest> (multi-GiB, very loud).")
-	fs.String("weights-dir", "",
-		"Directory to write extracted weights into (required with --include-weights).")
 	fs.Bool("include-embeddings", false,
 		"Issue test embedding calls via /api/embeddings (consumes operator-billed compute).")
 }
 
 // Loot probes an Ollama instance, emits one :OllamaInstance node, one
 // :AIModel per /api/tags entry with PROVIDES_MODEL edges, and (when
-// flag-gated) downloads weights or issues an embedding probe.
+// flag-gated) issues an embedding probe.
 //
 // opts.Extras keys consumed by this Looter:
 //
-//	"include-weights"     bool   — gate /api/blobs/<digest> downloads
-//	"weights-dir"         string — local directory for weight artifacts
 //	"include-embeddings"  bool   — gate POST /api/embeddings probe
 func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOptions) (*action.LootResult, error) {
 	_, host, _ := action.EndpointParts(t, DefaultPort, "http")
@@ -101,14 +91,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		maxItems = DefaultMaxItems
 	}
 
-	includeWeights, _ := opts.Extras["include-weights"].(bool)
-	weightsDir, _ := opts.Extras["weights-dir"].(string)
 	includeEmbeddings, _ := opts.Extras["include-embeddings"].(bool)
-	weightsDir = strings.TrimSpace(weightsDir)
-
-	if includeWeights && weightsDir == "" {
-		return nil, errors.New("ollama loot: --include-weights requires --weights-dir <path>")
-	}
 
 	client := common.NoRedirectClient(timeout)
 
@@ -198,28 +181,6 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges,
 			providesModelEdge(ollamaID, modelID, opts.EngagementID, tag.Digest))
 		res.Summary.CredentialsFound++
-
-		// 2b. Flag-gated weight extraction.
-		if includeWeights && tag.Digest != "" {
-			path, sha, n, weightErr := downloadBlob(ctx, client, baseURL, tag.Digest, weightsDir, tag.Model)
-			res.Summary.EndpointsProbed++
-			if weightErr != nil {
-				slog.Warn("ollama loot: /api/blobs failed",
-					"model", tag.Model,
-					"digest", tag.Digest,
-					"engagement_id", opts.EngagementID,
-					"error", weightErr)
-				res.PartialErrors = append(res.PartialErrors,
-					fmt.Sprintf("api/blobs %s: %v", tag.Digest, weightErr))
-				res.Summary.PartialFailures++
-				continue
-			}
-			// Mutate the AIModel node's properties in place.
-			lastIdx := len(res.IngestData.Graph.Nodes) - 1
-			res.IngestData.Graph.Nodes[lastIdx].Properties["weight_artifact_path"] = path
-			res.IngestData.Graph.Nodes[lastIdx].Properties["weight_artifact_sha256"] = sha
-			res.IngestData.Graph.Nodes[lastIdx].Properties["weight_artifact_bytes"] = n
-		}
 	}
 
 	// 3. Flag-gated embedding probe (POST exception — see package doc).
@@ -239,7 +200,6 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		"endpoint", baseURL,
 		"engagement_id", opts.EngagementID,
 		"models_emitted", len(tags),
-		"include_weights", includeWeights,
 		"include_embeddings", includeEmbeddings,
 		"partial_failures", res.Summary.PartialFailures)
 
@@ -340,46 +300,6 @@ func fetchShow(ctx context.Context, client *http.Client, url, modelName string) 
 	return se, nil
 }
 
-// downloadBlob streams /api/blobs/<digest> to disk. Returns (path, sha,
-// bytes-written, err). The local filename is derived from the model
-// name + a sanitized digest fragment so multiple models in a single
-// loot don't collide.
-func downloadBlob(ctx context.Context, client *http.Client, baseURL, digest, weightsDir, modelName string) (string, string, int64, error) {
-	if err := os.MkdirAll(weightsDir, 0o700); err != nil {
-		return "", "", 0, fmt.Errorf("mkdir weights-dir: %w", err)
-	}
-	url := strings.TrimRight(baseURL, "/") + "/api/blobs/" + digest
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return "", "", 0, fmt.Errorf("build request: %w", err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", "", 0, fmt.Errorf("request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", "", 0, fmt.Errorf("status %d", resp.StatusCode)
-	}
-
-	safe := sanitizeFilename(modelName) + "-" + safeDigestFragment(digest) + ".bin"
-	path := filepath.Join(weightsDir, safe)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return "", "", 0, fmt.Errorf("open weights file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	hasher := sha256.New()
-	mw := io.MultiWriter(f, hasher)
-	n, err := io.Copy(mw, io.LimitReader(resp.Body, MaxWeightBytes))
-	if err != nil {
-		_ = os.Remove(path)
-		return "", "", 0, fmt.Errorf("stream blob: %w", err)
-	}
-	return path, hex.EncodeToString(hasher.Sum(nil)), n, nil
-}
-
 // probeEmbeddings issues exactly one POST /api/embeddings against the
 // first available model. Returns true on a 2xx response. The Looter's
 // GET-only contract makes this the single allowed exception — the POST
@@ -426,24 +346,6 @@ func providesModelEdge(ollamaID, modelID, engagementID, digest string) ingest.Ed
 			},
 		},
 	}
-}
-
-func sanitizeFilename(s string) string {
-	r := strings.NewReplacer(
-		"/", "_",
-		":", "_",
-		" ", "_",
-		"..", "_",
-	)
-	return r.Replace(s)
-}
-
-func safeDigestFragment(d string) string {
-	d = strings.TrimPrefix(d, "sha256:")
-	if len(d) > 12 {
-		return d[:12]
-	}
-	return d
 }
 
 var _ action.Looter = (*Looter)(nil)

--- a/modules/ollamaloot/looter_test.go
+++ b/modules/ollamaloot/looter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -36,13 +35,6 @@ func ollamaStubServer(t *testing.T, opts stubOpts) *httptest.Server {
 			} else {
 				_, _ = w.Write([]byte(`{"modelfile":` + jsonString(modelfileLlama) + `,"template":"{{ .Prompt }}","details":{"family":"llama","parameter_size":"8B","quantization_level":"Q4_0"}}`))
 			}
-		case "/api/blobs/sha256:abcdef0123456789", "/api/blobs/sha256:fedcba9876543210":
-			if !opts.allowBlobs {
-				w.WriteHeader(404)
-				return
-			}
-			// Tiny synthetic blob — the test asserts we wrote N bytes.
-			_, _ = w.Write([]byte("FAKEWEIGHTS-DO-NOT-USE-IN-PROD"))
 		case "/api/embeddings":
 			if !opts.allowEmbeddings {
 				w.WriteHeader(404)
@@ -56,7 +48,6 @@ func ollamaStubServer(t *testing.T, opts stubOpts) *httptest.Server {
 }
 
 type stubOpts struct {
-	allowBlobs      bool
 	allowEmbeddings bool
 }
 
@@ -149,68 +140,6 @@ func TestLoot_IncludeCredentialValuesEmitsModelfile(t *testing.T) {
 	}
 	if !saw {
 		t.Error("modelfile not surfaced on any AIModel node when IncludeCredentialValues=true")
-	}
-}
-
-func TestLoot_IncludeWeightsRequiresWeightsDir(t *testing.T) {
-	l := &Looter{}
-	_, err := l.Loot(context.Background(), action.Target{
-		Kind:    "host",
-		Address: "127.0.0.1:1",
-	}, action.LootOptions{
-		Extras: map[string]any{"include-weights": true},
-	})
-	if err == nil {
-		t.Fatal("expected error when --include-weights provided without --weights-dir")
-	}
-	if !strings.Contains(err.Error(), "weights-dir") {
-		t.Errorf("error = %q, want to mention weights-dir", err.Error())
-	}
-}
-
-func TestLoot_IncludeWeightsHappyPath(t *testing.T) {
-	srv := ollamaStubServer(t, stubOpts{allowBlobs: true})
-	defer srv.Close()
-
-	weightsDir := t.TempDir()
-	l := &Looter{}
-	res, err := l.Loot(context.Background(), action.Target{
-		Kind:    "host",
-		Address: strings.TrimPrefix(srv.URL, "http://"),
-	}, action.LootOptions{
-		Extras: map[string]any{
-			"include-weights": true,
-			"weights-dir":     weightsDir,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Loot: %v", err)
-	}
-	var sawArtifact bool
-	for _, n := range res.IngestData.Graph.Nodes {
-		if n.Kinds[0] != "AIModel" {
-			continue
-		}
-		if path, _ := n.Properties["weight_artifact_path"].(string); path != "" {
-			sawArtifact = true
-			if !strings.HasPrefix(path, weightsDir) {
-				t.Errorf("weight artifact path %q not under weights-dir %q", path, weightsDir)
-			}
-			if _, err := stat(path); err != nil {
-				t.Errorf("weight artifact file missing at %q: %v", path, err)
-			}
-			if sha, _ := n.Properties["weight_artifact_sha256"].(string); len(sha) != 64 {
-				t.Errorf("weight_artifact_sha256 should be 64-char hex; got %q", sha)
-			}
-		}
-	}
-	if !sawArtifact {
-		t.Error("expected at least one AIModel with weight_artifact_path populated")
-	}
-	// Ensure no leftover temp blob outside the dir.
-	matches, _ := filepath.Glob(filepath.Join(weightsDir, "*.bin"))
-	if len(matches) == 0 {
-		t.Error("expected at least one .bin in weights-dir")
 	}
 }
 

--- a/sdk/action/extractor.go
+++ b/sdk/action/extractor.go
@@ -14,9 +14,14 @@ import (
 // Poisoners.
 //
 // v0.4 ships one proof-of-concept Extractor: embedding-inversion. It
-// takes an AIModel node + extracted weights from the Ollama Looter's
-// --include-weights path and runs a local embedding-inversion algorithm
-// to produce probabilistic training-signal artifacts.
+// takes an AIModel node + a GGUF weight file the operator has already
+// obtained by other means (filesystem access to ~/.ollama/models/blobs/
+// on a compromised Ollama host, a HuggingFace download, or any other
+// out-of-band source) and runs a local embedding-inversion algorithm
+// to produce probabilistic training-signal artifacts. AgentHound does
+// not itself pull raw weight blobs over HTTP — the previous Ollama
+// Looter --include-weights path was withdrawn because the endpoint it
+// targeted (GET /api/blobs/<digest>) does not exist in the Ollama API.
 //
 // Implementations also implement sdk/module.Module.
 type Extractor interface {
@@ -30,8 +35,10 @@ type ExtractOptions struct {
 	SourceNodeID string
 
 	// ArtifactPath is the local filesystem path to an artifact the
-	// Extractor consumes (e.g. a weight file previously downloaded by
-	// `agenthound loot --type ollama --include-weights`).
+	// Extractor consumes — for embedding-invert, any GGUF weight file
+	// the operator has already obtained (e.g. copied from
+	// ~/.ollama/models/blobs/ on a compromised host, downloaded from
+	// HuggingFace, or produced by another tool).
 	ArtifactPath string
 
 	// EngagementID correlates the extraction with the engagement.

--- a/sdk/action/looter.go
+++ b/sdk/action/looter.go
@@ -55,10 +55,11 @@ type LootOptions struct {
 
 	// Extras carries per-Looter flag values populated by the CLI dispatch
 	// from the Looter's FlagsModule.RegisterFlags surface. Keys are the
-	// per-module flag names (e.g. "include-weights", "weights-dir") so
+	// per-module flag names (e.g. "include-embeddings", "master-key") so
 	// each Looter can pull its own without colliding with another's. The
-	// Ollama Looter (v0.3) is the first consumer — it reads
-	// Extras["include-weights"] (bool) and Extras["weights-dir"] (string).
+	// Ollama Looter reads Extras["include-embeddings"] (bool); the Open
+	// WebUI Looter reads Extras["api-key"] (string); LiteLLM reads its
+	// master-key sugar the same way.
 	//
 	// Generic LootOptions stays free of per-Looter fields; new Looters
 	// should add their flags to RegisterFlags and read them from Extras


### PR DESCRIPTION
## Summary

- Removes the experimental `--include-weights` / `--weights-dir` flags from `agenthound loot --type ollama`. They targeted `/api/blobs/<digest>` with `GET`, which sits outside Ollama's documented HTTP API surface — the upstream spec defines only `HEAD` (existence check for the create-model flow) and `POST` (upload) on that path per the [API docs](https://github.com/ollama/ollama/blob/main/docs/api.md#check-if-a-blob-exists) and [OpenAPI spec](https://github.com/ollama/ollama/blob/main/docs/openapi.yaml).
- Raw GGUF acquisition from a compromised Ollama host remains available out-of-band via filesystem access to `~/.ollama/models/blobs/`, and `agenthound extract --type embedding-invert` continues to accept any locally-available GGUF file. Its `--artifact` help + godoc were rewritten to make that path explicit.
- The Ollama Looter's real surface is unchanged: modelfile / system-prompt / fine-tune detection via `/api/tags` + `/api/show`, `value_hash` cross-collector merge, and the optional `POST /api/embeddings` probe.

## Scope

**Code**
- \`modules/ollamaloot/looter.go\` — remove flag registration, extras extraction, weight-extraction branch, \`downloadBlob\`, \`MaxWeightBytes\`, and filename/digest helpers. Package doc records the API-surface rationale for future contributors.
- \`modules/ollamaloot/looter_test.go\` + \`helpers_test.go\` — remove the two \`--include-weights\` tests, the stub \`/api/blobs\` handler, and the now-unused \`stat\` helper. \`TestLoot_AnonymousHappyPath\`, \`TestLoot_IncludeCredentialValuesEmitsModelfile\`, \`TestLoot_IncludeEmbeddingsProbesPOST\`, \`TestLoot_NoModels\`, redaction and get-only regression tests remain green.
- \`sdk/action/looter.go\` + \`sdk/action/extractor.go\` — godoc rewritten to drop the flag from Extras examples and rescope \`ArtifactPath\` around out-of-band GGUF acquisition.
- \`collector/cli/extract.go\` — \`Long\` help + \`--artifact\` description rewritten.

**Node schema**
- The \`weight_artifact_path\` / \`weight_artifact_sha256\` / \`weight_artifact_bytes\` properties on \`:AIModel\` are no longer emitted.

**Docs**
- \`README.md\` — capability tile refactored around modelfile / system-prompt / fine-tune inventory; Quick Start loot example updated.
- \`docs/README.md\`, \`docs/architecture/system-design.md\` — taglines refreshed.
- \`docs/operator/loot/ollama.md\` — Level 3 "Weight extraction" replaced with an "out-of-band acquisition" guide.
- \`docs/reference/cli.md\` — Ollama flag table trimmed; extract \`--artifact\` description updated with cross-reference.
- \`docs/contributing/modules.md\` — \`FlagsModule\` example switched to \`--include-embeddings\` / \`--api-key\`.
- \`docs/plans/sprint3-offensive-primitives.md\` — dated correction block explaining the \`/api/blobs\` GET premise sits outside the upstream API surface.
- \`CHANGELOG.md\` — new "Unreleased" entry documenting the flag removal; strikethroughs on the original v0.3 bullets pointing at the retraction.

## Compat

Callers passing \`--include-weights\` or \`--weights-dir\` will hit an unknown-flag error at the CLI parser rather than a silent no-op — deliberate, so a stale invocation surfaces immediately instead of producing an incomplete envelope.

## Verification

- \`gofmt -l .\` — clean
- \`go build ./...\` — clean
- \`go vet ./...\` — clean
- \`go test ./... -race\` — all packages green
- \`scripts/deps-check.sh\` — clean
- \`scripts/size-check.sh\` — collector = 10,010,808 B (baseline 9,851,064; limit 10,836,170)

## Test plan

- [x] All existing unit tests pass under \`-race\`
- [x] \`gofmt\`, \`go vet\`, \`deps-check\`, \`size-check\` green locally
- [ ] CI: \`golangci-lint\`, \`govulncheck\`, \`go-licenses\`, \`mkdocs build --strict\`

Made with [Cursor](https://cursor.com)