### PR TITLE
fix(collectors): correct grounded A2A/MCP/config defects + spec-compliant JWS jku verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,4 +81,4 @@ IMPORTANT: When making changes that affect any of these, update the correspondin
 
 ## Tech Stack
 
-Go 1.25.11 | cobra | chi/v5 | Neo4j 4.4+ | PostgreSQL 16 | pgx/v5 | MCP Go SDK v1.5.0 | React 18 + Vite 6 + React Flow + ELK | shadcn/ui + Zustand 5 + TanStack Query 5 | Docker Compose | GoReleaser v2 + cosign | Apache 2.0
+Go 1.25.11 | cobra | chi/v5 | Neo4j 4.4+ | PostgreSQL 16 | pgx/v5 | MCP Go SDK v1.6.1 | React 18 + Vite 6 + React Flow + ELK | shadcn/ui + Zustand 5 + TanStack Query 5 | Docker Compose | GoReleaser v2 + cosign | Apache 2.0

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -82,6 +82,8 @@ func init() {
 	scanCmd.Flags().StringSlice("discover-domain", nil, "Domains to probe for well-known agent cards")
 	scanCmd.Flags().String("targets-file", "", "File with A2A agent URLs (one per line)")
 	scanCmd.Flags().String("auth-token", "", "Bearer token for authenticated A2A agents")
+	scanCmd.Flags().Bool("no-verify-jwks", false, "Disable remote JWKS (jku) resolution during A2A signature verification (offline: inline jwks + --a2a-trusted-keys only)")
+	scanCmd.Flags().String("a2a-trusted-keys", "", "Path to a JWKS JSON file of trusted keys for A2A signature verification (offline key store)")
 
 	scanCmd.Flags().Int("scan-concurrency", 5, "Max parallel connections")
 	scanCmd.Flags().Duration("timeout", 120*time.Second, "Timeout per server/agent")
@@ -126,6 +128,8 @@ func runScan(cmd *cobra.Command, args []string) error {
 	discoverDomains, _ := cmd.Flags().GetStringSlice("discover-domain")
 	targetsFile, _ := cmd.Flags().GetString("targets-file")
 	authToken, _ := cmd.Flags().GetString("auth-token")
+	noVerifyJWKS, _ := cmd.Flags().GetBool("no-verify-jwks")
+	a2aTrustedKeys, _ := cmd.Flags().GetString("a2a-trusted-keys")
 
 	scanConcurrency, _ := cmd.Flags().GetInt("scan-concurrency")
 	cfgConcurrency := 0
@@ -181,7 +185,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 	merged, enabled, failed := collectAll(ctx, runConfig, runMCP, runA2A,
 		path, paths, projectDir, includeCredValues,
 		url, target, targets, targetsFile, authToken,
-		concurrency, timeout, insecure)
+		concurrency, timeout, insecure, noVerifyJWKS, a2aTrustedKeys)
 
 	// Default behavior: if no --output set, auto-name to scan-<scan_id>.json in CWD.
 	if output == "" {
@@ -268,7 +272,8 @@ func resolveProbeTimeout(timeout time.Duration, timeoutChanged bool) time.Durati
 func collectAll(ctx context.Context, runConfig, runMCP, runA2A bool,
 	path string, paths []string, projectDir string, includeCredValues bool,
 	url, target string, targets []string, targetsFile, authToken string,
-	concurrency int, timeout time.Duration, insecure bool) (data *ingest.IngestData, enabled, failed int) {
+	concurrency int, timeout time.Duration, insecure bool,
+	noVerifyJWKS bool, a2aTrustedKeys string) (data *ingest.IngestData, enabled, failed int) {
 
 	merged := &ingest.IngestData{
 		Meta: ingest.IngestMeta{
@@ -307,7 +312,7 @@ func collectAll(ctx context.Context, runConfig, runMCP, runA2A bool,
 
 	if runA2A {
 		enabled++
-		data, err := collectA2A(ctx, target, targets, targetsFile, authToken, concurrency, timeout, insecure)
+		data, err := collectA2A(ctx, target, targets, targetsFile, authToken, concurrency, timeout, insecure, noVerifyJWKS, a2aTrustedKeys)
 		if err != nil {
 			failed++
 			slog.Error("a2a collector failed", "error", err)
@@ -365,7 +370,8 @@ func collectMCP(ctx context.Context, url string, concurrency int, timeout time.D
 }
 
 func collectA2A(ctx context.Context, target string, targets []string, targetsFile, authToken string,
-	concurrency int, timeout time.Duration, insecure bool) (*ingest.IngestData, error) {
+	concurrency int, timeout time.Duration, insecure bool,
+	noVerifyJWKS bool, a2aTrustedKeys string) (*ingest.IngestData, error) {
 	var a2aOpts []a2acollector.Option
 	if concurrency > 0 {
 		a2aOpts = append(a2aOpts, a2acollector.WithConcurrency(concurrency))
@@ -375,6 +381,12 @@ func collectA2A(ctx context.Context, target string, targets []string, targetsFil
 	}
 	if insecure {
 		a2aOpts = append(a2aOpts, a2acollector.WithInsecure(true))
+	}
+	if noVerifyJWKS {
+		a2aOpts = append(a2aOpts, a2acollector.WithJWKSFetch(false))
+	}
+	if a2aTrustedKeys != "" {
+		a2aOpts = append(a2aOpts, a2acollector.WithTrustedKeysFile(a2aTrustedKeys))
 	}
 
 	c := a2acollector.NewA2ACollector(a2aOpts...)

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -129,7 +129,7 @@ All edges carry: `scan_id`, `last_seen`, `confidence`, `risk_weight`, `is_compos
 | Collector | Network | Input | Output Nodes | Key Signals |
 |-----------|---------|-------|-------------|-------------|
 | **Config** | None | 12 MCP client config formats (Claude Desktop, Cursor, VS Code, Windsurf, Zed, Cline, Continue, JetBrains, Kiro, Amazon Q, Augment, Claude Code) | ConfigFile, AgentInstance, MCPServer, Identity, Credential, Host, InstructionFile | Unpinned packages, high-entropy secrets, instruction poisoning |
-| **MCP** | stdio / HTTP | Live MCP servers via Go SDK v1.5.0 | MCPServer, MCPTool, MCPResource, MCPPrompt | Capability surface (8 categories), injection patterns, description hashes, cross-references |
+| **MCP** | stdio / HTTP | Live MCP servers via Go SDK v1.6.1 | MCPServer, MCPTool, MCPResource, MCPPrompt | Capability surface (8 categories), injection patterns, description hashes, cross-references |
 | **A2A** | HTTP | Agent Card JSON (v0.3.0 + v1.0) | A2AAgent, A2ASkill, Host | JWS signature verification, auth posture scoring, delegation chains |
 
 All collectors produce the same JSON ingest format. The Config and MCP collectors share

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -74,8 +74,12 @@ Read-only: calls `tools/list`, `resources/list`, `resources/templates/list`, `pr
 | `--targets-file` | | File with agent URLs (one per line). |
 | `--discover-domain` | | Domains to probe for `/.well-known/agent-card.json`. |
 | `--auth-token` | | Bearer token for authenticated agents. |
+| `--no-verify-jwks` | `false` | Disable remote JWKS (`jku`) resolution during signature verification; verify only against inline `jwks` and `--a2a-trusted-keys` (offline). |
+| `--a2a-trusted-keys` | | Path to a JWKS JSON file of trusted keys used to verify signed agent cards (offline key store). |
 
 At least one of `--target`, `--targets`, `--targets-file`, or `--discover-domain` is required with `--a2a`.
+
+Signed agent cards are verified by default: keys are resolved from the card's inline `jwks`, then `--a2a-trusted-keys`, then the JWS protected-header `jku` URL over an SSRF-hardened fetcher (loopback/RFC1918 allowed; link-local/cloud-metadata refused). `--no-verify-jwks` restricts verification to local key sources. Results are surfaced on the `A2AAgent` node via `signature_verification_status` (`verified` / `partially_verified` / `failed` / `unverifiable` / `unsigned`).
 
 #### Network Mode Flags
 
@@ -254,7 +258,7 @@ agenthound poison <host:port> --type <kind> --engagement-id <ID> [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--update-method` | `PUT` | HTTP method for the description update. |
-| `--update-path` | `/tools/{id}` | Path template; `{id}` replaced with `--target-id`. |
+| `--update-path` | `/admin/tools/{id}` | Path template; `{id}` replaced with `--target-id`. |
 | `--list-path` | `/` | JSON-RPC tools/list call path (reads original description). |
 | `--auth-token` | | Bearer token for list and update requests. |
 

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -24,11 +24,11 @@ These are the node kinds accepted in ingest input (`sdk/ingest.AllowedNodeKinds`
 | `MCPTool` | MCP | `name`, `description`, `input_schema`, `output_schema`, `annotations`, `description_hash` (SHA-256), `input_schema_hash` (SHA-256), `schema_keys[]`, `capability_surface[]`, `source_trust` (untrusted_web/email/fileshare), `has_injection_patterns`, `has_cross_references` |
 | `MCPResource` | MCP | `uri`, `name`, `mime_type`, `size`, `uri_scheme`, `sensitivity` (auto-classified) |
 | `MCPPrompt` | MCP | `name`, `description`, `arguments` |
-| `A2AAgent` | A2A | `name`, `description`, `url`, `provider`, `version`, `protocol_versions`, `capabilities`, `security_schemes`, `auth_method`, `auth_strength` (numeric, post-processor), `is_signed`, `signature_valid`, `card_hash` |
+| `A2AAgent` | A2A | `name`, `description`, `url`, `provider`, `version`, `protocol_versions`, `capabilities`, `security_schemes`, `auth_method`, `auth_posture`, `auth_strength` (numeric, post-processor), `is_https`, `is_signed`, `signature_valid`, `signature_verification_status`, `card_hash` |
 | `A2ASkill` | A2A | `id`, `name`, `description`, `input_modes`, `output_modes`, `description_hash`, `has_injection_patterns` |
 | `AgentInstance` | Config | `name`, `framework`, `config_path` |
 | `Identity` | Config + MCP | `type` (none/apiKey/oauth/bearer/mtls), `scope`, `is_static` |
-| `Credential` | Config + LiteLLM Looter | `type` (envVar/hardcoded/vaultRef/inputPrompt/master_key/apiKey/virtual_key), `name`, `source`, `is_exposed`, `high_entropy`, `value_hash` (SHA-256), `blast_radius` (distinct reachable agents, post-processor) |
+| `Credential` | Config + LiteLLM Looter | `type` (envVar/hardcoded/vaultRef/inputPrompt/master_key/apiKey/virtual_key), `name`, `source`, `is_exposed`, `high_entropy`, `format`, `value_hash` (SHA-256), `blast_radius` (distinct reachable agents, post-processor) |
 | `Host` | Config + A2A | `hostname`, `ip`, `is_local`, `is_private`, `is_public` |
 | `ConfigFile` | Config | `path`, `client`, `server_count` |
 | `InstructionFile` | Config | `path`, `type` (agents.md/claude.md/cursorrules/copilot-instructions/memory.md), `hash`, `is_suspicious` |
@@ -53,19 +53,25 @@ These labels exist in `AllNodeLabels` but NOT in `AllowedNodeKinds` — collecto
 | `ResourceGroup` | Post-processor | `type`, `sensitivity` |
 | `TrustZone` | Post-processor | `name`, `level`, `node_count` |
 
-### A2AAgent Signature Verification (`is_signed`, `signature_valid`)
+### A2AAgent Signature Verification (`is_signed`, `signature_valid`, `signature_verification_status`)
 
-`A2AAgent` carries two independent signature properties:
+`A2AAgent` carries three signature properties:
 
 - **`is_signed`** — `true` when the agent card has a non-empty `signatures[]` array, regardless of cryptographic validity.
-- **`signature_valid`** — `true` only when every signature in the card cryptographically verifies against a key in the card's inline `jwks`.
+- **`signature_valid`** — `true` when **at least one** signature cryptographically verifies against a resolvable key (any-valid semantics). Retained for backward compatibility.
+- **`signature_verification_status`** — the authoritative outcome, disambiguating the two cases `signature_valid=false` previously conflated:
+  - `unsigned` — no `signatures[]`.
+  - `verified` — every signature verified.
+  - `partially_verified` — at least one, but not all, signatures verified.
+  - `failed` — signatures were checked against resolvable keys but none verified (tampered card, wrong key, unsupported algorithm).
+  - `unverifiable` — no key could be resolved for any signature, so verification could not be attempted.
+
+**Key resolution** (per signature, in order): the card's inline `jwks`; operator-supplied trusted keys (`--a2a-trusted-keys`, a JWKS file); then — unless `--no-verify-jwks` is set — the JWS protected-header **`jku`** URL (the A2A spec §8.4 mechanism) and, as a fallback, a top-level `jwks_uri`. Remote resolution is **on by default** via an SSRF-hardened fetcher: it validates the resolved IP at dial time (refusing link-local/cloud-metadata `169.254.0.0/16`, `fe80::/10`, and unspecified addresses; loopback and RFC1918 remain allowed for internal engagements), caps redirects and response size, honors `--insecure` for TLS, and never forwards `--auth-token` to the `jku` host.
 
 The collector accepts both JWS serializations a card may use:
 
 - **Compact** — each `signatures[]` entry is a compact JWS string.
-- **Flattened JSON (object form)** — each entry is `{ "protected": "<b64url>", "signature": "<b64url>" }`, the spec-conformant A2A shape. The signed payload is the agent card with the `signatures` member removed and JCS-canonicalized (RFC 8785 key ordering, no insignificant whitespace); it is embedded base64url-encoded as the JWS payload and verified per RFC 7515. Tampering with any other card field invalidates the signature.
-
-`signature_valid` is `false` (card unverifiable, not a verification failure) when the card omits inline `jwks`. Remote `jwks_uri` fetching is not performed — a card whose keys live only behind `jwks_uri` reports `signature_valid=false`.
+- **Flattened JSON (object form)** — each entry is `{ "protected": "<b64url>", "signature": "<b64url>" }`, the spec-conformant A2A shape. The signed payload is the agent card with the `signatures` member removed and JCS-canonicalized (key ordering, no insignificant whitespace); it is embedded base64url-encoded as the JWS payload and verified per RFC 7515. Tampering with any other card field invalidates the signature.
 
 ---
 
@@ -93,7 +99,7 @@ This enables queries like `MATCH (n:AIService)` to find all AI infrastructure re
 | `DELEGATES_TO` | A2AAgent | A2AAgent | A2A | Agent delegates tasks to another agent |
 | `AUTHENTICATES_WITH` | MCPServer / A2AAgent | Identity | Config / A2A | Entity uses this auth identity |
 | `USES_CREDENTIAL` | Identity | Credential | Config | Identity backed by this credential material |
-| `RUNS_ON` | MCPServer / A2AAgent | Host | Config / A2A | Entity runs on this host |
+| `RUNS_ON` | MCPServer / A2AAgent | Host | Config / A2A / MCP | Entity runs on this host |
 | `CONFIGURED_IN` | MCPServer | ConfigFile | Config | Server defined in this config file |
 | `HAS_ENV_VAR` | MCPServer | Credential | Config | Server has access to this env var |
 | `LOADS_INSTRUCTIONS` | AgentInstance | InstructionFile | Config | Agent loads this instruction file |

--- a/modules/a2a/collector.go
+++ b/modules/a2a/collector.go
@@ -14,12 +14,16 @@ import (
 	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 	"github.com/adithyan-ak/agenthound/sdk/rules"
+	jose "github.com/go-jose/go-jose/v4"
 )
 
 type A2ACollector struct {
-	concurrency int
-	timeout     time.Duration
-	insecure    bool
+	concurrency      int
+	timeout          time.Duration
+	insecure         bool
+	jwksFetchEnabled bool
+	trustedKeysPath  string
+	trustedKeys      *jose.JSONWebKeySet
 }
 
 type Option func(*A2ACollector)
@@ -36,10 +40,24 @@ func WithInsecure(v bool) Option {
 	return func(c *A2ACollector) { c.insecure = v }
 }
 
+// WithJWKSFetch toggles spec-compliant remote JWKS (`jku`) resolution during
+// signature verification. Enabled by default; disable for a fully offline scan.
+func WithJWKSFetch(v bool) Option {
+	return func(c *A2ACollector) { c.jwksFetchEnabled = v }
+}
+
+// WithTrustedKeysFile points at a JWKS JSON file whose keys are used as an
+// out-of-band trusted key store for signature verification (the A2A spec's
+// trusted-key-store option), consulted before any network fetch.
+func WithTrustedKeysFile(path string) Option {
+	return func(c *A2ACollector) { c.trustedKeysPath = path }
+}
+
 func NewA2ACollector(opts ...Option) *A2ACollector {
 	c := &A2ACollector{
-		concurrency: 5,
-		timeout:     15 * time.Second,
+		concurrency:      5,
+		timeout:          15 * time.Second,
+		jwksFetchEnabled: true,
 	}
 	for _, o := range opts {
 		o(c)
@@ -75,6 +93,19 @@ func (c *A2ACollector) Collect(ctx context.Context, opts collector.CollectOption
 	insecure := opts.Insecure || c.insecure
 	authToken := opts.AuthToken
 
+	if c.trustedKeysPath != "" && c.trustedKeys == nil {
+		set, err := LoadJWKSFile(c.trustedKeysPath)
+		if err != nil {
+			return nil, fmt.Errorf("load a2a trusted keys %s: %w", c.trustedKeysPath, err)
+		}
+		c.trustedKeys = set
+	}
+
+	verifyOpts := VerifyOptions{TrustedKeys: c.trustedKeys}
+	if c.jwksFetchEnabled {
+		verifyOpts.Fetcher = NewJWKSFetcher(insecure, c.timeout)
+	}
+
 	type cardResult struct {
 		card *AgentCardData
 		url  string
@@ -92,14 +123,14 @@ func (c *A2ACollector) Collect(ctx context.Context, opts collector.CollectOption
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			raw, err := FetchAgentCard(ctx, tgt, authToken, insecure)
+			raw, err := FetchAgentCard(ctx, tgt, authToken, insecure, c.timeout)
 			if err != nil {
 				results[idx] = cardResult{url: tgt, err: err}
 				return
 			}
 			raw.URL = tgt
 
-			card, err := ParseAgentCard(raw, engine)
+			card, err := ParseAgentCard(ctx, raw, engine, verifyOpts)
 			if err != nil {
 				results[idx] = cardResult{url: tgt, err: err}
 				return
@@ -213,19 +244,20 @@ func buildGraph(card *AgentCardData, scanID string) ([]ingest.Node, []ingest.Edg
 	agentID := agentNodeID(card)
 
 	agentProps := map[string]any{
-		"name":              card.Name,
-		"description":       card.Description,
-		"url":               card.URL,
-		"provider":          card.Provider,
-		"version":           card.Version,
-		"protocol_versions": card.ProtocolVersions,
-		"capabilities":      card.Capabilities,
-		"auth_method":       card.AuthMethod,
-		"is_signed":         card.IsSigned,
-		"signature_valid":   card.SignatureValid,
-		"is_https":          card.IsHTTPS,
-		"card_hash":         card.CardHash,
-		"auth_posture":      AuthPostureScore(card.SecuritySchemes),
+		"name":                          card.Name,
+		"description":                   card.Description,
+		"url":                           card.URL,
+		"provider":                      card.Provider,
+		"version":                       card.Version,
+		"protocol_versions":             card.ProtocolVersions,
+		"capabilities":                  card.Capabilities,
+		"auth_method":                   card.AuthMethod,
+		"is_signed":                     card.IsSigned,
+		"signature_valid":               card.SignatureValid,
+		"signature_verification_status": card.SignatureStatus,
+		"is_https":                      card.IsHTTPS,
+		"card_hash":                     card.CardHash,
+		"auth_posture":                  AuthPostureScore(card.SecuritySchemes),
 	}
 
 	schemesData := make([]map[string]string, len(card.SecuritySchemes))

--- a/modules/a2a/collector_test.go
+++ b/modules/a2a/collector_test.go
@@ -346,6 +346,9 @@ func TestCollector_SignedCard(t *testing.T) {
 	if props["signature_valid"] != false {
 		t.Errorf("expected signature_valid=false for unverifiable card, got %v", props["signature_valid"])
 	}
+	if props["signature_verification_status"] != "unverifiable" {
+		t.Errorf("expected signature_verification_status=unverifiable, got %v", props["signature_verification_status"])
+	}
 	if props["auth_method"] != "mtls" {
 		t.Errorf("expected auth_method=mtls, got %v", props["auth_method"])
 	}
@@ -386,6 +389,9 @@ func TestCollector_SignedCard_ObjectForm_Valid(t *testing.T) {
 	}
 	if props["signature_valid"] != true {
 		t.Errorf("expected signature_valid=true for properly-signed object-form card, got %v", props["signature_valid"])
+	}
+	if props["signature_verification_status"] != "verified" {
+		t.Errorf("expected signature_verification_status=verified, got %v", props["signature_verification_status"])
 	}
 }
 

--- a/modules/a2a/fetch.go
+++ b/modules/a2a/fetch.go
@@ -26,7 +26,7 @@ const (
 	maxBodyLen = 5 * 1024 * 1024
 )
 
-func FetchAgentCard(ctx context.Context, targetURL string, authToken string, insecure bool) (*RawCard, error) {
+func FetchAgentCard(ctx context.Context, targetURL string, authToken string, insecure bool, timeout time.Duration) (*RawCard, error) {
 	base := normalizeBaseURL(targetURL)
 
 	transport := &http.Transport{}
@@ -34,9 +34,12 @@ func FetchAgentCard(ctx context.Context, targetURL string, authToken string, ins
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   15 * time.Second,
+		Timeout:   timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return fmt.Errorf("too many redirects (max 5)")

--- a/modules/a2a/fetch_test.go
+++ b/modules/a2a/fetch_test.go
@@ -31,7 +31,7 @@ func TestFetchAgentCard_V10Path(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	card, err := FetchAgentCard(context.Background(), srv.URL, "", false)
+	card, err := FetchAgentCard(context.Background(), srv.URL, "", false, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestFetchAgentCard_FallbackToV030(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	card, err := FetchAgentCard(context.Background(), srv.URL, "", false)
+	card, err := FetchAgentCard(context.Background(), srv.URL, "", false, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestFetchAgentCard_BothPathsFail(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(context.Background(), srv.URL, "", false)
+	_, err := FetchAgentCard(context.Background(), srv.URL, "", false, 0)
 	if err == nil {
 		t.Fatal("expected error when both paths return 404")
 	}
@@ -92,7 +92,7 @@ func TestFetchAgentCard_AuthHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(context.Background(), srv.URL, "test-token-123", false)
+	_, err := FetchAgentCard(context.Background(), srv.URL, "test-token-123", false, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestFetchAgentCard_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	_, err := FetchAgentCard(ctx, srv.URL, "", false)
+	_, err := FetchAgentCard(ctx, srv.URL, "", false, 0)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -124,7 +124,7 @@ func TestFetchAgentCard_InvalidJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(context.Background(), srv.URL, "", false)
+	_, err := FetchAgentCard(context.Background(), srv.URL, "", false, 0)
 	if err == nil {
 		t.Fatal("expected JSON parse error")
 	}
@@ -136,7 +136,7 @@ func TestFetchAgentCard_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := FetchAgentCard(context.Background(), srv.URL, "", false)
+	_, err := FetchAgentCard(context.Background(), srv.URL, "", false, 0)
 	if err == nil {
 		t.Fatal("expected error on 500 response")
 	}
@@ -154,7 +154,7 @@ func TestFetchAgentCard_TLSStrictDefault(t *testing.T) {
 	defer srv.Close()
 
 	// Insecure=false → TLS handshake should fail (unknown authority).
-	_, err := FetchAgentCard(context.Background(), srv.URL, "", false)
+	_, err := FetchAgentCard(context.Background(), srv.URL, "", false, 0)
 	if err == nil {
 		t.Fatal("expected TLS verification error with self-signed cert; got nil")
 	}
@@ -165,7 +165,7 @@ func TestFetchAgentCard_TLSStrictDefault(t *testing.T) {
 	}
 
 	// Insecure=true → handshake should succeed.
-	if _, err := FetchAgentCard(context.Background(), srv.URL, "", true); err != nil {
+	if _, err := FetchAgentCard(context.Background(), srv.URL, "", true, 0); err != nil {
 		t.Errorf("Insecure=true against self-signed cert: unexpected error %v", err)
 	}
 }

--- a/modules/a2a/jws.go
+++ b/modules/a2a/jws.go
@@ -2,101 +2,402 @@ package a2a
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 )
 
 var allowedAlgorithms = []jose.SignatureAlgorithm{jose.RS256, jose.ES256}
 
+// Signature verification status values emitted on A2AAgent nodes. They
+// disambiguate the outcomes that the boolean signature_valid alone conflates:
+// a card with no key to check against ("unverifiable") vs. a card whose
+// signatures were checked and none verified ("failed").
+const (
+	SigStatusUnsigned          = "unsigned"
+	SigStatusVerified          = "verified"
+	SigStatusPartiallyVerified = "partially_verified"
+	SigStatusFailed            = "failed"
+	SigStatusUnverifiable      = "unverifiable"
+)
+
+const (
+	defaultJWKSMaxBytes = 256 * 1024
+	defaultJWKSMaxKeys  = 50
+	defaultJWKSTimeout  = 10 * time.Second
+)
+
+// SignatureResult is the outcome of verifying a card's signatures.
+type SignatureResult struct {
+	Signed bool
+	Valid  bool
+	Status string
+}
+
+// VerifyOptions controls key resolution during signature verification.
+type VerifyOptions struct {
+	// Fetcher resolves keys from a signature's protected-header `jku` (and, as
+	// a fallback, a top-level `jwks_uri`). Nil disables all network resolution
+	// (offline mode); verification then relies only on inline `jwks` and
+	// TrustedKeys.
+	Fetcher *JWKSFetcher
+	// TrustedKeys is an operator-supplied out-of-band key set (the A2A spec's
+	// "trusted key store"), consulted before any network fetch.
+	TrustedKeys *jose.JSONWebKeySet
+}
+
+// VerifySignatures verifies a card's signatures OFFLINE (inline `jwks` only),
+// preserving the original two-value contract. New callers that want
+// spec-compliant `jku` resolution should use VerifySignaturesCtx.
 func VerifySignatures(cardJSON []byte, raw map[string]any) (signed bool, valid bool) {
+	res := VerifySignaturesCtx(context.Background(), cardJSON, raw, VerifyOptions{})
+	return res.Signed, res.Valid
+}
+
+// VerifySignaturesCtx verifies a card's JWS signatures and returns rich status.
+//
+// Semantics (any-valid): Valid is true when AT LEAST ONE signature verifies
+// against a resolvable key. Keys are resolved, per signature, from (in order)
+// the inline `jwks`, the operator's TrustedKeys, and — only when opts.Fetcher
+// is set — the protected-header `jku` (A2A spec §8.4) or a top-level
+// `jwks_uri`.
+func VerifySignaturesCtx(ctx context.Context, cardJSON []byte, raw map[string]any, opts VerifyOptions) SignatureResult {
 	sigs, ok := raw["signatures"]
 	if !ok {
-		return false, false
+		return SignatureResult{Status: SigStatusUnsigned}
 	}
-
 	sigArr, ok := sigs.([]any)
 	if !ok || len(sigArr) == 0 {
-		return false, false
+		return SignatureResult{Status: SigStatusUnsigned}
 	}
 
-	jwks, err := extractJWKS(raw)
+	inline, err := extractJWKS(raw)
 	if err != nil {
 		slog.Warn("jws: failed to parse inline jwks", "error", err)
-		return true, false
-	}
-	if jwks == nil {
-		if _, hasURI := raw["jwks_uri"]; hasURI {
-			slog.Warn("jws: jwks_uri present but inline jwks missing; skipping verification (fetch not supported here)")
-		} else {
-			slog.Warn("jws: no jwks or jwks_uri found; cannot verify signatures")
-		}
-		return true, false
+		inline = nil
 	}
 
 	canonical, err := canonicalSignedPayload(raw)
 	if err != nil {
 		slog.Warn("jws: failed to canonicalize signed payload", "error", err)
-		return true, false
+		return SignatureResult{Signed: true, Status: SigStatusFailed}
 	}
 
-	for i, entry := range sigArr {
-		var compact string
-		objectForm := false
-		switch e := entry.(type) {
-		case string:
-			compact = e
-		case map[string]any:
-			objectForm = true
-			compact, ok = flattenedToCompact(e, canonical)
-			if !ok {
-				slog.Warn("jws: object-form signature entry is malformed", "index", i)
-				return true, false
-			}
+	kp := &keyProvider{
+		inline:  inline,
+		trusted: opts.TrustedKeys,
+		fetcher: opts.Fetcher,
+		jwksURI: topLevelString(raw, "jwks_uri"),
+	}
+
+	var verified, failed, unresolved int
+	for _, entry := range sigArr {
+		switch verifyOneSignature(ctx, entry, cardJSON, canonical, kp) {
+		case sigVerified:
+			verified++
+		case sigFailed:
+			failed++
 		default:
-			slog.Warn("jws: signature entry is neither string nor object", "index", i)
-			return true, false
-		}
-
-		jws, err := jose.ParseSigned(compact, allowedAlgorithms)
-		if err != nil {
-			slog.Warn("jws: failed to parse signature", "index", i, "error", err)
-			return true, false
-		}
-
-		if len(jws.Signatures) == 0 {
-			slog.Warn("jws: parsed JWS has no signatures", "index", i)
-			return true, false
-		}
-
-		kid := jws.Signatures[0].Protected.KeyID
-		keys := jwks.Key(kid)
-		if len(keys) == 0 {
-			slog.Warn("jws: no key found for kid", "kid", kid, "index", i)
-			return true, false
-		}
-
-		verified := false
-		for _, key := range keys {
-			verifiedPayload, err := jws.Verify(&key)
-			if err == nil {
-				if !objectForm && cardJSON != nil && !bytes.Equal(verifiedPayload, cardJSON) {
-					slog.Warn("jws: verified payload does not match card body", "index", i)
-					return true, false
-				}
-				verified = true
-				break
-			}
-		}
-		if !verified {
-			slog.Warn("jws: signature verification failed", "kid", kid, "index", i)
-			return true, false
+			unresolved++
 		}
 	}
 
-	return true, true
+	res := SignatureResult{Signed: true}
+	switch {
+	case verified == len(sigArr):
+		res.Valid = true
+		res.Status = SigStatusVerified
+	case verified >= 1:
+		res.Valid = true
+		res.Status = SigStatusPartiallyVerified
+	case failed >= 1:
+		res.Status = SigStatusFailed
+	default:
+		res.Status = SigStatusUnverifiable
+	}
+	return res
+}
+
+type sigOutcome int
+
+const (
+	sigVerified sigOutcome = iota
+	sigFailed
+	sigUnresolved
+)
+
+// verifyOneSignature verifies a single signatures[] entry (compact string or
+// flattened {protected,signature} object) and reports whether it verified,
+// failed a resolvable-key check, or had no key to check against.
+func verifyOneSignature(ctx context.Context, entry any, cardJSON, canonical []byte, kp *keyProvider) sigOutcome {
+	var compact string
+	objectForm := false
+	switch e := entry.(type) {
+	case string:
+		compact = e
+	case map[string]any:
+		objectForm = true
+		c, ok := flattenedToCompact(e, canonical)
+		if !ok {
+			slog.Warn("jws: object-form signature entry is malformed")
+			return sigFailed
+		}
+		compact = c
+	default:
+		slog.Warn("jws: signature entry is neither string nor object")
+		return sigFailed
+	}
+
+	parsed, err := jose.ParseSigned(compact, allowedAlgorithms)
+	if err != nil {
+		slog.Warn("jws: failed to parse signature", "error", err)
+		return sigFailed
+	}
+	if len(parsed.Signatures) == 0 {
+		slog.Warn("jws: parsed JWS has no signatures")
+		return sigFailed
+	}
+
+	hdr := parsed.Signatures[0].Protected
+	kid := hdr.KeyID
+	jku := headerString(hdr, "jku")
+
+	keys := kp.keysFor(ctx, kid, jku)
+	if len(keys) == 0 {
+		slog.Warn("jws: no key resolvable for signature", "kid", kid)
+		return sigUnresolved
+	}
+
+	for i := range keys {
+		verifiedPayload, verr := parsed.Verify(&keys[i])
+		if verr != nil {
+			continue
+		}
+		if !objectForm && cardJSON != nil && !bytes.Equal(verifiedPayload, cardJSON) {
+			slog.Warn("jws: verified payload does not match card body")
+			return sigFailed
+		}
+		return sigVerified
+	}
+	slog.Warn("jws: signature verification failed", "kid", kid)
+	return sigFailed
+}
+
+// keyProvider resolves verification keys for a signature, preferring local
+// sources (inline jwks, operator trusted keys) and only reaching out over the
+// network (jku / jwks_uri) when a fetcher is configured.
+type keyProvider struct {
+	inline  *jose.JSONWebKeySet
+	trusted *jose.JSONWebKeySet
+	fetcher *JWKSFetcher
+	jwksURI string
+	cache   map[string]*jose.JSONWebKeySet
+}
+
+func (kp *keyProvider) keysFor(ctx context.Context, kid, jku string) []jose.JSONWebKey {
+	var keys []jose.JSONWebKey
+	add := func(set *jose.JSONWebKeySet) {
+		if set == nil {
+			return
+		}
+		if kid != "" {
+			keys = append(keys, set.Key(kid)...)
+		} else {
+			keys = append(keys, set.Keys...)
+		}
+	}
+
+	add(kp.inline)
+	add(kp.trusted)
+	if len(keys) > 0 || kp.fetcher == nil {
+		return keys
+	}
+
+	for _, u := range []string{jku, kp.jwksURI} {
+		if u == "" {
+			continue
+		}
+		add(kp.fetchCached(ctx, u))
+		if len(keys) > 0 {
+			break
+		}
+	}
+	return keys
+}
+
+func (kp *keyProvider) fetchCached(ctx context.Context, u string) *jose.JSONWebKeySet {
+	if kp.cache == nil {
+		kp.cache = make(map[string]*jose.JSONWebKeySet)
+	}
+	if set, ok := kp.cache[u]; ok {
+		return set
+	}
+	set, err := kp.fetcher.Fetch(ctx, u)
+	if err != nil {
+		slog.Warn("jws: jwks fetch failed", "url", u, "error", err)
+		set = nil
+	}
+	kp.cache[u] = set
+	return set
+}
+
+// JWKSFetcher fetches a JWKS over HTTP(S) with SSRF hardening. Construct with
+// NewJWKSFetcher; the zero value is not usable.
+type JWKSFetcher struct {
+	client   *http.Client
+	maxBytes int64
+	maxKeys  int
+}
+
+// NewJWKSFetcher builds an SSRF-hardened JWKS fetcher. insecure disables TLS
+// certificate verification (mirrors the collector-wide --insecure). The
+// dial-time Control hook rejects link-local/metadata and unspecified IPs on
+// the *resolved* address — this covers redirects (which re-dial) and defeats
+// DNS rebinding. Loopback and RFC1918 private ranges remain allowed so
+// operators can verify internal agents.
+func NewJWKSFetcher(insecure bool, timeout time.Duration) *JWKSFetcher {
+	if timeout <= 0 {
+		timeout = defaultJWKSTimeout
+	}
+	dialer := &net.Dialer{
+		Timeout: timeout,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return err
+			}
+			ip := net.ParseIP(host)
+			if ip == nil || isBlockedFetchIP(ip) {
+				return fmt.Errorf("jwks fetch blocked for address %s", address)
+			}
+			return nil
+		},
+	}
+	transport := &http.Transport{
+		DialContext:           dialer.DialContext,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: insecure},
+		TLSHandshakeTimeout:   timeout,
+		ResponseHeaderTimeout: timeout,
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 3 {
+				return fmt.Errorf("too many redirects (max 3)")
+			}
+			if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+				return fmt.Errorf("redirect to non-http scheme %q blocked", req.URL.Scheme)
+			}
+			return nil
+		},
+	}
+	return &JWKSFetcher{client: client, maxBytes: defaultJWKSMaxBytes, maxKeys: defaultJWKSMaxKeys}
+}
+
+// Fetch retrieves and parses a JWKS from rawURL. It never forwards any
+// credential/Authorization header to the (card-controlled) jku host.
+func (f *JWKSFetcher) Fetch(ctx context.Context, rawURL string) (*jose.JSONWebKeySet, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse jwks url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported jwks url scheme %q", u.Scheme)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch jwks: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("jwks fetch status %d", resp.StatusCode)
+	}
+	if f.maxBytes > 0 && resp.ContentLength > f.maxBytes {
+		return nil, fmt.Errorf("jwks response too large: %d bytes (max %d)", resp.ContentLength, f.maxBytes)
+	}
+
+	limit := f.maxBytes
+	if limit <= 0 {
+		limit = defaultJWKSMaxBytes
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return nil, err
+	}
+
+	var set jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, fmt.Errorf("parse jwks: %w", err)
+	}
+	if f.maxKeys > 0 && len(set.Keys) > f.maxKeys {
+		set.Keys = set.Keys[:f.maxKeys]
+	}
+	return &set, nil
+}
+
+// isBlockedFetchIP blocks link-local (169.254.0.0/16 incl. the 169.254.169.254
+// cloud-metadata endpoint, fe80::/10), link-local multicast, and unspecified
+// addresses. Loopback and RFC1918 private ranges are intentionally allowed so
+// operators can verify internal agents.
+func isBlockedFetchIP(ip net.IP) bool {
+	return ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast()
+}
+
+// LoadJWKSFile reads a JWKS JSON file (the A2A trusted-key-store escape hatch
+// backing --a2a-trusted-keys).
+func LoadJWKSFile(path string) (*jose.JSONWebKeySet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var set jose.JSONWebKeySet
+	if err := json.Unmarshal(data, &set); err != nil {
+		return nil, fmt.Errorf("parse jwks file %s: %w", path, err)
+	}
+	return &set, nil
+}
+
+func headerString(h jose.Header, key string) string {
+	if h.ExtraHeaders == nil {
+		return ""
+	}
+	if v, ok := h.ExtraHeaders[jose.HeaderKey(key)]; ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+func topLevelString(raw map[string]any, key string) string {
+	if v, ok := raw[key].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
 }
 
 // flattenedToCompact reconstructs a compact JWS string from a flattened

--- a/modules/a2a/jws_test.go
+++ b/modules/a2a/jws_test.go
@@ -1,13 +1,17 @@
 package a2a
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	jose "github.com/go-jose/go-jose/v4"
 )
@@ -246,12 +250,17 @@ func TestJWS_MultipleSignatures_OneFails(t *testing.T) {
 	}
 	raw := buildRawWithKeys(t, payload, []string{rsaCompact, ecCompact}, jwksKeys)
 
-	signed, valid := VerifySignatures(payload, raw)
-	if !signed {
+	// Any-valid semantics: one signature verifies, so the card is Valid, but
+	// the status distinguishes it from a fully-verified card.
+	res := VerifySignaturesCtx(context.Background(), payload, raw, VerifyOptions{})
+	if !res.Signed {
 		t.Error("expected signed=true")
 	}
-	if valid {
-		t.Error("expected valid=false when one signature fails")
+	if !res.Valid {
+		t.Error("expected valid=true under any-valid semantics when at least one signature verifies")
+	}
+	if res.Status != SigStatusPartiallyVerified {
+		t.Errorf("expected status partially_verified, got %q", res.Status)
 	}
 }
 
@@ -524,4 +533,116 @@ func buildRawWithKeys(t *testing.T, payload []byte, sigs []string, keys []jose.J
 	raw["jwks"] = jwksMap
 
 	return raw
+}
+
+// signPayloadWithJKU signs payload and adds a `jku` protected header pointing
+// at jwksURL, matching the A2A spec's remote-key-resolution mechanism.
+func signPayloadWithJKU(t *testing.T, key any, alg jose.SignatureAlgorithm, kid, jwksURL string, payload []byte) string {
+	t.Helper()
+	opts := (&jose.SignerOptions{}).WithHeader(jose.HeaderKey("jku"), jwksURL)
+	signingKey := jose.SigningKey{Algorithm: alg, Key: &jose.JSONWebKey{Key: key, KeyID: kid}}
+	signer, err := jose.NewSigner(signingKey, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jws, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact
+}
+
+// jwksTestServer serves the given keys as a JWKS document over loopback HTTP.
+func jwksTestServer(t *testing.T, keys []jose.JSONWebKey) *httptest.Server {
+	t.Helper()
+	body, err := json.Marshal(jose.JSONWebKeySet{Keys: keys})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestJWS_JKUFetch_Verified(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := jwksTestServer(t, []jose.JSONWebKey{{Key: &privKey.PublicKey, KeyID: "jku-key-1"}})
+
+	payload := []byte(`{"name":"jku-agent"}`)
+	compact := signPayloadWithJKU(t, privKey, jose.ES256, "jku-key-1", srv.URL, payload)
+	raw := map[string]any{"name": "jku-agent", "signatures": []any{compact}}
+
+	fetcher := NewJWKSFetcher(false, 5*time.Second)
+	res := VerifySignaturesCtx(context.Background(), payload, raw, VerifyOptions{Fetcher: fetcher})
+	if !res.Signed {
+		t.Error("expected signed=true")
+	}
+	if !res.Valid || res.Status != SigStatusVerified {
+		t.Errorf("expected verified via jku fetch, got valid=%v status=%q", res.Valid, res.Status)
+	}
+}
+
+func TestJWS_JKUOffline_Unverifiable(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := jwksTestServer(t, []jose.JSONWebKey{{Key: &privKey.PublicKey, KeyID: "jku-key-1"}})
+
+	payload := []byte(`{"name":"jku-agent"}`)
+	compact := signPayloadWithJKU(t, privKey, jose.ES256, "jku-key-1", srv.URL, payload)
+	raw := map[string]any{"name": "jku-agent", "signatures": []any{compact}}
+
+	// No fetcher: remote jku resolution is disabled (the --no-verify-jwks path).
+	res := VerifySignaturesCtx(context.Background(), payload, raw, VerifyOptions{})
+	if !res.Signed {
+		t.Error("expected signed=true")
+	}
+	if res.Valid || res.Status != SigStatusUnverifiable {
+		t.Errorf("expected unverifiable offline, got valid=%v status=%q", res.Valid, res.Status)
+	}
+}
+
+func TestJWS_TrustedKeys_Verified(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"name":"trusted-agent"}`)
+	compact := signPayload(t, privKey, jose.RS256, "trusted-1", payload)
+	raw := map[string]any{"name": "trusted-agent", "signatures": []any{compact}}
+
+	trusted := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{Key: &privKey.PublicKey, KeyID: "trusted-1"}}}
+	res := VerifySignaturesCtx(context.Background(), payload, raw, VerifyOptions{TrustedKeys: trusted})
+	if !res.Valid || res.Status != SigStatusVerified {
+		t.Errorf("expected verified via trusted keys, got valid=%v status=%q", res.Valid, res.Status)
+	}
+}
+
+func TestJWS_SSRFBlocked(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"name":"ssrf-agent"}`)
+	// jku points at the cloud-metadata / link-local endpoint; the SSRF-safe
+	// fetcher must refuse to connect, leaving the signature unverifiable.
+	compact := signPayloadWithJKU(t, privKey, jose.ES256, "k1", "http://169.254.169.254/jwks.json", payload)
+	raw := map[string]any{"name": "ssrf-agent", "signatures": []any{compact}}
+
+	fetcher := NewJWKSFetcher(false, 2*time.Second)
+	res := VerifySignaturesCtx(context.Background(), payload, raw, VerifyOptions{Fetcher: fetcher})
+	if res.Valid || res.Status != SigStatusUnverifiable {
+		t.Errorf("expected unverifiable (SSRF blocked), got valid=%v status=%q", res.Valid, res.Status)
+	}
 }

--- a/modules/a2a/parse.go
+++ b/modules/a2a/parse.go
@@ -1,6 +1,7 @@
 package a2a
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -21,6 +22,7 @@ type AgentCardData struct {
 	Skills           []SkillData
 	IsSigned         bool
 	SignatureValid   bool
+	SignatureStatus  string
 	IsHTTPS          bool
 	CardHash         string
 }
@@ -50,7 +52,7 @@ func DetectVersion(raw map[string]any) string {
 	return "v0.3.0"
 }
 
-func ParseAgentCard(raw *RawCard, engine *rules.Engine) (*AgentCardData, error) {
+func ParseAgentCard(ctx context.Context, raw *RawCard, engine *rules.Engine, verifyOpts VerifyOptions) (*AgentCardData, error) {
 	switch raw.Version {
 	case "v1.0":
 		card, err := parseV10(raw.Parsed, raw.CardHash, engine)
@@ -58,9 +60,7 @@ func ParseAgentCard(raw *RawCard, engine *rules.Engine) (*AgentCardData, error) 
 			return nil, err
 		}
 		card.IsHTTPS = strings.HasPrefix(raw.URL, "https://")
-		signed, valid := VerifySignatures(raw.Body, raw.Parsed)
-		card.IsSigned = signed
-		card.SignatureValid = valid
+		applySignatureResult(card, VerifySignaturesCtx(ctx, raw.Body, raw.Parsed, verifyOpts))
 		return card, nil
 	default:
 		card, err := parseV030(raw.Parsed, raw.CardHash, engine)
@@ -68,11 +68,15 @@ func ParseAgentCard(raw *RawCard, engine *rules.Engine) (*AgentCardData, error) 
 			return nil, err
 		}
 		card.IsHTTPS = strings.HasPrefix(raw.URL, "https://")
-		signed, valid := VerifySignatures(raw.Body, raw.Parsed)
-		card.IsSigned = signed
-		card.SignatureValid = valid
+		applySignatureResult(card, VerifySignaturesCtx(ctx, raw.Body, raw.Parsed, verifyOpts))
 		return card, nil
 	}
+}
+
+func applySignatureResult(card *AgentCardData, res SignatureResult) {
+	card.IsSigned = res.Signed
+	card.SignatureValid = res.Valid
+	card.SignatureStatus = res.Status
 }
 
 func parseV030(raw map[string]any, cardHash string, engine *rules.Engine) (*AgentCardData, error) {
@@ -120,7 +124,7 @@ func parseV030(raw map[string]any, cardHash string, engine *rules.Engine) (*Agen
 			if !ok {
 				continue
 			}
-			skill := parseSkillV030(sObj, engine)
+			skill := parseSkill(sObj, engine)
 			card.Skills = append(card.Skills, skill)
 		}
 	}
@@ -144,19 +148,24 @@ func parseV10(raw map[string]any, cardHash string, engine *rules.Engine) (*Agent
 	}
 
 	if ifaces, ok := raw["supportedInterfaces"].([]any); ok {
+		seenPV := make(map[string]bool)
 		for _, iface := range ifaces {
 			ifObj, ok := iface.(map[string]any)
 			if !ok {
 				continue
 			}
-			ifType := getString030(ifObj, "type")
-			if strings.EqualFold(ifType, "A2A") {
-				if u := getString030(ifObj, "url"); u != "" {
-					card.URL = u
-				}
-				if pv := getString030(ifObj, "protocolVersion"); pv != "" {
-					card.ProtocolVersions = append(card.ProtocolVersions, pv)
-				}
+			// The transport discriminator is protocolBinding (values JSONRPC,
+			// GRPC, HTTP+JSON per A2A v1.0 §4.4.6) — there is no "type" field.
+			// Prefer the JSONRPC interface URL; otherwise fall back to the
+			// first interface that carries a URL.
+			u := getString030(ifObj, "url")
+			binding := getString030(ifObj, "protocolBinding")
+			if u != "" && (card.URL == "" || strings.EqualFold(binding, "JSONRPC")) {
+				card.URL = u
+			}
+			if pv := getString030(ifObj, "protocolVersion"); pv != "" && !seenPV[pv] {
+				seenPV[pv] = true
+				card.ProtocolVersions = append(card.ProtocolVersions, pv)
 			}
 		}
 	}
@@ -178,7 +187,7 @@ func parseV10(raw map[string]any, cardHash string, engine *rules.Engine) (*Agent
 			if !ok {
 				continue
 			}
-			skill := parseSkillV10(sObj, engine)
+			skill := parseSkill(sObj, engine)
 			card.Skills = append(card.Skills, skill)
 		}
 	}
@@ -214,46 +223,10 @@ func getSecurityRefs(raw map[string]any) []any {
 	return sec
 }
 
-func parseSkillV030(s map[string]any, engine *rules.Engine) SkillData {
-	id := getString030(s, "id")
-	name := getString030(s, "name")
-	desc := getString030(s, "description")
-
-	var inputModes, outputModes []string
-	if is, ok := s["inputSchema"].(map[string]any); ok {
-		if t := getString030(is, "type"); t != "" {
-			inputModes = append(inputModes, "application/json")
-		}
-	}
-	if _, ok := s["outputSchema"].(map[string]any); ok {
-		outputModes = append(outputModes, "application/json")
-	}
-
-	descHash := common.DescriptionHash(name, desc, nil)
-
-	hasInj := false
-	matches := engine.EvaluateAll("a2a", map[string]string{
-		"skill.description": desc,
-	})
-	for _, m := range matches {
-		if m.Emit.FindingType == "has_injection_patterns" {
-			hasInj = true
-			break
-		}
-	}
-
-	return SkillData{
-		ID:              id,
-		Name:            name,
-		Description:     desc,
-		InputModes:      inputModes,
-		OutputModes:     outputModes,
-		DescriptionHash: descHash,
-		HasInjection:    hasInj,
-	}
-}
-
-func parseSkillV10(s map[string]any, engine *rules.Engine) SkillData {
+// parseSkill parses an A2A AgentSkill for both v0.3.0 and v1.0 cards. Media
+// types come from the spec's inputModes/outputModes string arrays; AgentSkill
+// has no inputSchema/outputSchema field in any A2A version.
+func parseSkill(s map[string]any, engine *rules.Engine) SkillData {
 	id := getString030(s, "id")
 	name := getString030(s, "name")
 	desc := getString030(s, "description")

--- a/modules/a2a/parse_test.go
+++ b/modules/a2a/parse_test.go
@@ -1,6 +1,7 @@
 package a2a
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -212,7 +213,7 @@ func TestParseAgentCard_Dispatch(t *testing.T) {
 				Version:  DetectVersion(parsed),
 				CardHash: "abc123",
 			}
-			card, err := ParseAgentCard(raw, engine)
+			card, err := ParseAgentCard(context.Background(), raw, engine, VerifyOptions{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/modules/config/instruction.go
+++ b/modules/config/instruction.go
@@ -25,7 +25,6 @@ var projectTargets = []instructionTarget{
 	{"AGENTS.md", "agents.md"},
 	{"CLAUDE.md", "claude.md"},
 	{".cursorrules", "cursorrules"},
-	{".copilot-instructions.md", "copilot-instructions"},
 	{filepath.Join(".github", "copilot-instructions.md"), "copilot-instructions"},
 }
 

--- a/modules/config/parser.go
+++ b/modules/config/parser.go
@@ -105,6 +105,72 @@ func parseMCPServersMap(data map[string]any, rootKey, urlKey string) ([]ServerDe
 	return servers, nil
 }
 
+// parseMCPServersList parses the ARRAY form of an MCP server list, where each
+// element is an object carrying its own "name" plus the same fields as the
+// keyed map form. Augment persists augment.advanced.mcpServers this way.
+func parseMCPServersList(list []any, urlKey string) []ServerDef {
+	var servers []ServerDef
+	for _, entry := range list {
+		obj, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		sd := ServerDef{Name: getString(obj, "name")}
+
+		if v, ok := obj["disabled"].(bool); ok {
+			sd.Disabled = v
+		}
+
+		if aa, ok := obj["autoApprove"].([]any); ok {
+			for _, item := range aa {
+				if s, ok := item.(string); ok {
+					sd.AutoApprove = append(sd.AutoApprove, s)
+				}
+			}
+		}
+
+		if hdrs, ok := obj["headers"].(map[string]any); ok {
+			sd.Headers = make(map[string]string, len(hdrs))
+			for k, v := range hdrs {
+				if s, ok := v.(string); ok {
+					sd.Headers[k] = s
+				}
+			}
+		}
+
+		if envObj, ok := obj["env"].(map[string]any); ok {
+			sd.Env = make(map[string]string, len(envObj))
+			for k, v := range envObj {
+				if s, ok := v.(string); ok {
+					sd.Env[k] = s
+				}
+			}
+		}
+
+		if urlVal, ok := obj[urlKey].(string); ok && urlVal != "" {
+			sd.Transport = "http"
+			sd.URL = urlVal
+		} else if cmd, ok := obj["command"].(string); ok && cmd != "" {
+			sd.Transport = "stdio"
+			sd.Command = cmd
+			if args, ok := obj["args"].([]any); ok {
+				for _, a := range args {
+					if s, ok := a.(string); ok {
+						sd.Args = append(sd.Args, s)
+					}
+				}
+			}
+		} else {
+			continue
+		}
+
+		servers = append(servers, sd)
+	}
+
+	return servers
+}
+
 func parseJSONToMap(data []byte) (map[string]any, error) {
 	data = common.StripJSONComments(data)
 	var m map[string]any

--- a/modules/config/parser_augment.go
+++ b/modules/config/parser_augment.go
@@ -26,14 +26,25 @@ func (p *AugmentParser) Parse(path string, data []byte) (*ParsedConfig, error) {
 		return nil, err
 	}
 
-	serversMap := p.extractServersMap(m)
-	if serversMap == nil {
+	advanced := p.extractServersMap(m)
+	if advanced == nil {
 		return &ParsedConfig{Client: p.ClientName(), Path: path}, nil
 	}
 
-	servers, err := parseMCPServersMap(serversMap, "mcpServers", "url")
-	if err != nil {
-		return nil, err
+	// Real Augment persists augment.advanced.mcpServers as a JSON ARRAY (each
+	// element carries its own "name"). The object-keyed form only appears in
+	// the "Import from JSON" box and the Auggie CLI settings file, so support
+	// both shapes.
+	var servers []ServerDef
+	switch raw := advanced["mcpServers"].(type) {
+	case []any:
+		servers = parseMCPServersList(raw, "url")
+	case map[string]any:
+		parsed, err := parseMCPServersMap(advanced, "mcpServers", "url")
+		if err != nil {
+			return nil, err
+		}
+		servers = parsed
 	}
 
 	return &ParsedConfig{Client: p.ClientName(), Path: path, Servers: servers}, nil

--- a/modules/config/parser_claude_desktop.go
+++ b/modules/config/parser_claude_desktop.go
@@ -14,7 +14,7 @@ func (p *ClaudeDesktopParser) ConfigPaths(homeDir string) []string {
 	case "darwin":
 		return []string{filepath.Join(homeDir, "Library", "Application Support", "Claude", "claude_desktop_config.json")}
 	case "linux":
-		return []string{filepath.Join(homeDir, ".config", "claude", "claude_desktop_config.json")}
+		return []string{filepath.Join(homeDir, ".config", "Claude", "claude_desktop_config.json")}
 	case "windows":
 		return []string{filepath.Join(homeDir, "AppData", "Roaming", "Claude", "claude_desktop_config.json")}
 	default:

--- a/modules/config/parser_cursor.go
+++ b/modules/config/parser_cursor.go
@@ -2,21 +2,20 @@ package config
 
 import (
 	"path/filepath"
-	"runtime"
 )
 
 type CursorParser struct{}
 
 func (p *CursorParser) ClientName() string { return "cursor" }
 
+// ConfigPaths returns Cursor's canonical MCP config locations: the global
+// ~/.cursor/mcp.json (all OSes) and the project-scoped .cursor/mcp.json
+// (resolved against the current working directory, like ClaudeCodeParser's
+// .mcp.json). Cursor documents no per-OS globalStorage location.
 func (p *CursorParser) ConfigPaths(homeDir string) []string {
-	switch runtime.GOOS {
-	case "darwin":
-		return []string{filepath.Join(homeDir, "Library", "Application Support", "Cursor", "User", "globalStorage", "cursor.mcp", "mcp.json")}
-	case "linux":
-		return []string{filepath.Join(homeDir, ".config", "Cursor", "User", "globalStorage", "cursor.mcp", "mcp.json")}
-	default:
-		return nil
+	return []string{
+		filepath.Join(homeDir, ".cursor", "mcp.json"),
+		filepath.Join(".cursor", "mcp.json"),
 	}
 }
 

--- a/modules/config/parser_vscode.go
+++ b/modules/config/parser_vscode.go
@@ -10,14 +10,24 @@ type VSCodeParser struct{}
 func (p *VSCodeParser) ClientName() string { return "vscode" }
 
 func (p *VSCodeParser) ConfigPaths(homeDir string) []string {
+	// The dedicated mcp.json (top-level "servers") is VS Code's documented,
+	// primary MCP location: project-scoped .vscode/mcp.json (resolved against
+	// CWD, like other project parsers) and the user-profile mcp.json. The
+	// legacy settings.json ("mcp.servers") is also scanned for older setups.
+	paths := []string{filepath.Join(".vscode", "mcp.json")}
 	switch runtime.GOOS {
 	case "darwin":
-		return []string{filepath.Join(homeDir, "Library", "Application Support", "Code", "User", "settings.json")}
+		paths = append(paths,
+			filepath.Join(homeDir, "Library", "Application Support", "Code", "User", "mcp.json"),
+			filepath.Join(homeDir, "Library", "Application Support", "Code", "User", "settings.json"),
+		)
 	case "linux":
-		return []string{filepath.Join(homeDir, ".config", "Code", "User", "settings.json")}
-	default:
-		return nil
+		paths = append(paths,
+			filepath.Join(homeDir, ".config", "Code", "User", "mcp.json"),
+			filepath.Join(homeDir, ".config", "Code", "User", "settings.json"),
+		)
 	}
+	return paths
 }
 
 func (p *VSCodeParser) Parse(path string, data []byte) (*ParsedConfig, error) {
@@ -89,14 +99,22 @@ func (p *VSCodeParser) Parse(path string, data []byte) (*ParsedConfig, error) {
 }
 
 func (p *VSCodeParser) extractServersMap(m map[string]any) map[string]any {
-	// Format 1: dotted key "mcp.servers"
+	// Format 1: top-level "servers" (the dedicated .vscode/mcp.json and
+	// user-profile mcp.json format; VS Code uses "servers", not "mcpServers")
+	if raw, ok := m["servers"]; ok {
+		if sm, ok := raw.(map[string]any); ok {
+			return sm
+		}
+	}
+
+	// Format 2: dotted key "mcp.servers"
 	if raw, ok := m["mcp.servers"]; ok {
 		if sm, ok := raw.(map[string]any); ok {
 			return sm
 		}
 	}
 
-	// Format 2: nested "mcp" -> "servers"
+	// Format 3: nested "mcp" -> "servers"
 	if mcpRaw, ok := m["mcp"]; ok {
 		if mcpObj, ok := mcpRaw.(map[string]any); ok {
 			if raw, ok := mcpObj["servers"]; ok {

--- a/modules/config/parsers_test.go
+++ b/modules/config/parsers_test.go
@@ -38,6 +38,12 @@ func TestClaudeDesktopParser(t *testing.T) {
 	if len(paths) == 0 {
 		t.Fatal("ConfigPaths returned empty")
 	}
+	if runtime.GOOS == "linux" {
+		want := filepath.Join("/home/user", ".config", "Claude", "claude_desktop_config.json")
+		if paths[0] != want {
+			t.Errorf("linux ConfigPaths[0] = %q, want %q (capital Claude, case-sensitive FS)", paths[0], want)
+		}
+	}
 
 	data := readFixture(t, "claude_desktop.json")
 	cfg, err := p.Parse("/fake/path", data)
@@ -137,6 +143,18 @@ func TestCursorParser(t *testing.T) {
 
 	if p.ClientName() != "cursor" {
 		t.Fatalf("ClientName = %q", p.ClientName())
+	}
+
+	paths := p.ConfigPaths("/home/user")
+	wantGlobal := filepath.Join("/home/user", ".cursor", "mcp.json")
+	foundGlobal := false
+	for _, pth := range paths {
+		if pth == wantGlobal {
+			foundGlobal = true
+		}
+	}
+	if !foundGlobal {
+		t.Errorf("ConfigPaths %v missing canonical global path %q", paths, wantGlobal)
 	}
 
 	data := readFixture(t, "cursor.json")
@@ -240,6 +258,40 @@ func TestVSCodeParser(t *testing.T) {
 		}
 		if sse.URL != "http://localhost:8080/sse" {
 			t.Errorf("URL = %q", sse.URL)
+		}
+	})
+
+	t.Run("mcp.json servers key", func(t *testing.T) {
+		data := readFixture(t, "vscode_mcp.json")
+		cfg, err := p.Parse("/fake/path", data)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+
+		if len(cfg.Servers) != 2 {
+			t.Fatalf("got %d servers, want 2", len(cfg.Servers))
+		}
+
+		sqlite := serverByName(cfg.Servers, "sqlite")
+		if sqlite == nil {
+			t.Fatal("server 'sqlite' not found")
+		}
+		if sqlite.Transport != "stdio" {
+			t.Errorf("transport = %q, want stdio", sqlite.Transport)
+		}
+		if sqlite.Command != "uvx" {
+			t.Errorf("command = %q, want uvx", sqlite.Command)
+		}
+
+		remote := serverByName(cfg.Servers, "remote-vscode")
+		if remote == nil {
+			t.Fatal("server 'remote-vscode' not found")
+		}
+		if remote.Transport != "http" {
+			t.Errorf("transport = %q, want http", remote.Transport)
+		}
+		if remote.URL != "http://localhost:3005/mcp" {
+			t.Errorf("URL = %q", remote.URL)
 		}
 	})
 }
@@ -570,6 +622,40 @@ func TestAugmentParser(t *testing.T) {
 		}
 		if nested.Command != "node" {
 			t.Errorf("command = %q, want node", nested.Command)
+		}
+	})
+
+	t.Run("array format", func(t *testing.T) {
+		data := readFixture(t, "augment_settings_array.json")
+		cfg, err := p.Parse("/fake/path", data)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+
+		if len(cfg.Servers) != 2 {
+			t.Fatalf("got %d servers, want 2", len(cfg.Servers))
+		}
+
+		ctx := serverByName(cfg.Servers, "augment-context")
+		if ctx == nil {
+			t.Fatal("server 'augment-context' not found")
+		}
+		if ctx.Transport != "stdio" {
+			t.Errorf("transport = %q, want stdio", ctx.Transport)
+		}
+		if ctx.Env["AUGMENT_API_KEY"] != "aug_xxxxxxxxxxxx" {
+			t.Errorf("AUGMENT_API_KEY = %q", ctx.Env["AUGMENT_API_KEY"])
+		}
+
+		remote := serverByName(cfg.Servers, "augment-remote")
+		if remote == nil {
+			t.Fatal("server 'augment-remote' not found")
+		}
+		if remote.Transport != "http" {
+			t.Errorf("transport = %q, want http", remote.Transport)
+		}
+		if remote.URL != "https://augment-mcp.example.com/v1" {
+			t.Errorf("URL = %q", remote.URL)
 		}
 	})
 }

--- a/modules/mcp/collector_test.go
+++ b/modules/mcp/collector_test.go
@@ -402,7 +402,7 @@ func claudeDesktopConfigPath(homeDir string) string {
 	case "darwin":
 		return filepath.Join(homeDir, "Library", "Application Support", "Claude", "claude_desktop_config.json")
 	case "linux":
-		return filepath.Join(homeDir, ".config", "claude", "claude_desktop_config.json")
+		return filepath.Join(homeDir, ".config", "Claude", "claude_desktop_config.json")
 	case "windows":
 		return filepath.Join(homeDir, "AppData", "Roaming", "Claude", "claude_desktop_config.json")
 	default:

--- a/modules/mcp/enumerate.go
+++ b/modules/mcp/enumerate.go
@@ -524,8 +524,25 @@ func marshalJSON(v any) string {
 func logEnumerationError(kind, serverID string, err error) {
 	msg := err.Error()
 	if strings.Contains(msg, "Method not found") || strings.Contains(msg, "method not found") {
-		slog.Debug("server does not support optional method", "method", kind+"/list", "server", serverID)
+		slog.Debug("server does not support optional method", "method", methodForKind(kind), "server", serverID)
 		return
 	}
 	log.Printf("[mcp] %s enumeration error for server %s: %v", kind, serverID, err)
+}
+
+// methodForKind maps an enumeration kind to the real MCP JSON-RPC method name
+// (e.g. "resource template" -> "resources/templates/list") for accurate logs.
+func methodForKind(kind string) string {
+	switch kind {
+	case "tool":
+		return "tools/list"
+	case "resource":
+		return "resources/list"
+	case "resource template":
+		return "resources/templates/list"
+	case "prompt":
+		return "prompts/list"
+	default:
+		return kind + "/list"
+	}
 }

--- a/testdata/a2a/agent_card_no_auth.json
+++ b/testdata/a2a/agent_card_no_auth.json
@@ -17,12 +17,7 @@
       "name": "Lookup",
       "description": "Look up public information by topic",
       "tags": ["info", "public"],
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "query": {"type": "string"}
-        }
-      }
+      "inputModes": ["application/json"]
     }
   ]
 }

--- a/testdata/a2a/agent_card_signed.json
+++ b/testdata/a2a/agent_card_signed.json
@@ -27,12 +27,7 @@
       "name": "SecureOperation",
       "description": "Perform a secure operation",
       "tags": ["security"],
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "action": {"type": "string"}
-        }
-      }
+      "inputModes": ["application/json"]
     }
   ],
   "signatures": [

--- a/testdata/a2a/agent_card_v030.json
+++ b/testdata/a2a/agent_card_v030.json
@@ -30,32 +30,16 @@
       "name": "GetWeather",
       "description": "Get current weather for a location",
       "tags": ["weather", "forecast"],
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "location": {"type": "string"}
-        }
-      },
-      "outputSchema": {
-        "type": "object",
-        "properties": {
-          "temperature": {"type": "number"},
-          "conditions": {"type": "string"}
-        }
-      }
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
     },
     {
       "id": "get-forecast",
       "name": "GetForecast",
       "description": "Get 7-day weather forecast for a location",
       "tags": ["weather", "forecast"],
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "location": {"type": "string"},
-          "days": {"type": "integer"}
-        }
-      }
+      "inputModes": ["application/json"],
+      "outputModes": ["application/json"]
     }
   ]
 }

--- a/testdata/a2a/agent_card_v10.json
+++ b/testdata/a2a/agent_card_v10.json
@@ -6,7 +6,7 @@
   },
   "supportedInterfaces": [
     {
-      "type": "A2A",
+      "protocolBinding": "JSONRPC",
       "url": "https://analyst.example.com/a2a",
       "protocolVersion": "1.0"
     }

--- a/testdata/configs/augment_settings_array.json
+++ b/testdata/configs/augment_settings_array.json
@@ -1,0 +1,19 @@
+{
+  "editor.fontSize": 14,
+  "augment.advanced": {
+    "mcpServers": [
+      {
+        "name": "augment-context",
+        "command": "npx",
+        "args": ["-y", "@augment/mcp-server"],
+        "env": {
+          "AUGMENT_API_KEY": "aug_xxxxxxxxxxxx"
+        }
+      },
+      {
+        "name": "augment-remote",
+        "url": "https://augment-mcp.example.com/v1"
+      }
+    ]
+  }
+}

--- a/testdata/configs/vscode_mcp.json
+++ b/testdata/configs/vscode_mcp.json
@@ -1,0 +1,13 @@
+{
+  "servers": {
+    "sqlite": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["mcp-server-sqlite", "--db-path", "/tmp/test.db"]
+    },
+    "remote-vscode": {
+      "type": "http",
+      "url": "http://localhost:3005/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Addresses 15 independently-validated findings where A2A / MCP / config collector code diverged from the real protocol specs and vendor config formats. Each fix is grounded to a cited spec/vendor doc; bug-encoding test fixtures were corrected in lockstep so the suite passes for the right reasons. No new node/edge kinds, no new external deps, MCPServer-ID merge invariant untouched.

**Config collector**
- **Cursor (HIGH):** read the canonical `~/.cursor/mcp.json` (+ project `.cursor/mcp.json`) instead of a fabricated `globalStorage/cursor.mcp` path that no real install uses.
- **Augment (HIGH):** parse the real `augment.advanced.mcpServers` JSON **array** (object form still supported) — previously errored out and was silently skipped.
- **Claude Desktop (MED):** fix case-sensitive Linux path `~/.config/claude` → `~/.config/Claude`.
- **VS Code (MED):** read the primary `.vscode/mcp.json` + user-profile `mcp.json` with the top-level `servers` key (legacy `settings.json`/`mcp.servers` still read).
- **Instruction files (LOW):** remove the invented root `.copilot-instructions.md` target.

**A2A collector**
- **JWS (HIGH):** resolve keys via the spec's protected-header `jku` behind an SSRF-hardened fetcher (dial-time resolved-IP validation blocking link-local/cloud-metadata/unspecified; redirect + size caps; `--insecure`-aware TLS; no auth-token forwarding). On by default with `--no-verify-jwks` and `--a2a-trusted-keys` escape hatches. Replaces all-valid with **any-valid** `signature_valid` and adds a `signature_verification_status` enum (`verified`/`partially_verified`/`failed`/`unverifiable`/`unsigned`) so "unverifiable" and "verification failed" are no longer conflated. `is_signed`/`signature_valid` retained for existing consumers.
- **v0.3.0 skills (MED):** read spec `inputModes`/`outputModes` (not the non-existent `inputSchema`/`outputSchema`).
- **v1.0 interfaces (MED):** key off `protocolBinding` instead of a fabricated `type=="A2A"` field.
- **`--timeout` (LOW):** now honored by the agent-card fetch (was hardcoded 15s).

**MCP collector**
- **Debug log (LOW):** emit real JSON-RPC method names (`tools/list`, `resources/templates/list`, …) instead of `tool/list` etc.

**Docs**
- `mcppoison --update-path` default, MCP Go SDK version (`v1.6.1`), `RUNS_ON` collector attribution (+MCP), and previously-undocumented emitted properties (`is_https`, `auth_posture`, `signature_verification_status`, `format`).

## Test plan
- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` (all packages incl. server)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `scripts/deps-check.sh` — collector deps boundary intact
- [x] `scripts/size-check.sh` — 10.08 MiB, within baseline +10%
- [x] New A2A tests cover jku fetch success, offline unverifiable, trusted-keys offline verify, and SSRF block
- [ ] `mkdocs build --strict` — not run locally (mkdocs unavailable); only existing pages edited, no new nav/links/anchors

## Notes (pre-existing, out of scope)
- `scripts/slop-check.sh` flags hardcoded `grid-cols-N` in `server/ui/**` — no UI files touched here.
- `govulncheck` flags a stdlib `crypto/tls` advisory fixed in Go 1.25.12 (`go.mod` pins 1.25.11) — a toolchain bump, pre-existing via server + `fetch.go`.

Made with [Cursor](https://cursor.com)