### PR TITLE
chore(release): prep v0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - name: Run unit tests
@@ -66,7 +66,7 @@ jobs:
       - run: mkdir -p server/internal/api/ui/dist && cp -r server/ui/dist/. server/internal/api/ui/dist/
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Build collector
         run: go build -o bin/agenthound ./collector/cmd/agenthound
       - name: Build server
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - name: Run full test suite with DB
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - run: |
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Create UI embed stub
         run: mkdir -p server/internal/api/ui/dist && echo '<!DOCTYPE html><html><body></body></html>' > server/internal/api/ui/dist/index.html
       - name: Build collector

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 
-## Unreleased
+## v0.8.0
+
+Collector-hardening and read-only loot-expansion milestone. Brings the A2A, MCP, and agent-config collectors into line with the real protocol specs and vendor config formats — most notably spec-compliant JWS `jku` signature verification behind an SSRF-hardened key fetcher — expands the read-only Looter surface with 22 verified findings and new resource-sampling flags, retires the Docker demo lab and the out-of-spec Ollama weight flags, and clears a large batch of documentation drift.
+
+### Collectors: grounded A2A / MCP / config fixes + spec-compliant JWS `jku` verification (#75)
+
+Corrects 15 validated findings where collector code diverged from the real protocol specs and vendor config formats.
+
+**A2A**
+
+- **Spec-compliant JWS key resolution.** Signed agent cards are verified by resolving keys in spec order — the card's inline `jwks`, then operator-supplied `--a2a-trusted-keys` (a JWKS file), then the JWS protected-header **`jku`** URL (A2A spec §8.4). Remote `jku` resolution is **on by default** behind an SSRF-hardened fetcher: it validates the resolved IP at dial time (refuses link-local / cloud-metadata `169.254.0.0/16` + `fe80::/10` and unspecified addresses; loopback and RFC1918 remain allowed for internal engagements), caps redirects and response size, honors `--insecure` for TLS, and never forwards `--auth-token` to the `jku` host. New escape hatches: `--no-verify-jwks` (offline: inline `jwks` + `--a2a-trusted-keys` only) and `--a2a-trusted-keys <jwks.json>`.
+- **New `signature_verification_status` enum** on `:A2AAgent` disambiguates what `signature_valid=false` previously conflated: `verified` / `partially_verified` / `failed` / `unverifiable` / `unsigned` (any-valid semantics across multiple signatures).
+- **v0.3.0 skills** read the spec's `inputModes` / `outputModes` (not `inputSchema`); **v1.0 interfaces** key off `protocolBinding` (not a fabricated `type == "A2A"`).
+- The agent-card fetch now honors `--timeout` (was hardcoded 15s).
+
+**Config**
+
+- **Cursor:** read the canonical `~/.cursor/mcp.json` (+ project `.cursor/mcp.json`) instead of a fabricated `globalStorage` path.
+- **Augment:** parse the real `augment.advanced.mcpServers` JSON array (object form still supported).
+- **Claude Desktop:** fixed the case-sensitive Linux path (`~/.config/Claude`).
+- **VS Code:** read `.vscode/mcp.json` + user `mcp.json` with the top-level `servers` key.
+- Removed the invented root `.copilot-instructions.md` instruction target.
+
+**MCP**
+
+- Enumeration debug logs now record the real JSON-RPC method names.
+
+**Docs (shipped in #75):** corrected the `mcppoison --update-path` default, the MCP Go SDK version (v1.6.1), `RUNS_ON` collector attribution, and several undocumented emitted properties; bug-encoding test fixtures corrected in lockstep.
+
+**New flags:** `agenthound scan` gains `--no-verify-jwks` (bool, default false) and `--a2a-trusted-keys` (string, path to a JWKS file).
 
 ### Looters: 22 verified findings + coverage additions across LiteLLM, MLflow, Open WebUI, Qdrant, Ollama, Jupyter (#74)
 
@@ -71,6 +100,21 @@ Removes the experimental `--include-weights` / `--weights-dir` flags from `agent
 - **Docs:** the README capability tile now describes the Ollama Looter's actual surface (modelfile / system prompt / fine-tune detection). `docs/operator/loot/ollama.md` replaces the Level 3 "Weight extraction" section with an "out-of-band acquisition" guide pointing at `~/.ollama/models/blobs/`. `docs/reference/cli.md`, `docs/README.md`, `docs/architecture/system-design.md`, and `docs/contributing/modules.md` track the flag removal. `docs/plans/sprint3-offensive-primitives.md` gains a dated correction block noting the `/api/blobs` GET premise sits outside upstream's API surface.
 
 Callers that pass `--include-weights` or `--weights-dir` will hit an unknown-flag error at the CLI parser rather than a silent no-op — deliberate, so a stale invocation surfaces immediately.
+
+### Documentation
+
+- Corrected 27 verified drift / hallucination findings across 15 files, grounded against primary Go source, YAML rules, `Makefile`, `go.mod`, and `package.json`: the API auth model (`token required` → `Origin-gated`), depth caps, the `SHADOWS` substring-match semantics, the `can_exfiltrate` capability list, the sensitivity tables, the processor registry order, and toolchain versions (Go 1.25.11, Vite 8). Pure doc corrections — no code or behavior change. (#76)
+- Reframed AgentHound as an offensive / red-team framework across the README and docs. (#69)
+- Added the Rules Bundles page to the mkdocs nav.
+
+### Release & CI tooling (#66)
+
+- CI now enforces version consistency (`scripts/version-check.sh`) and catches docs breakage pre-merge (`scripts/docs-check.sh` → `mkdocs build --strict`). `scripts/sync-version.sh` (wired as `make sync-version`) rewrites the `install.sh` / `README.md` version pins from the `CHANGELOG.md` single source of truth.
+
+### Dependencies
+
+- **Go toolchain 1.25.11 → 1.25.12** (`go.mod`) to pull in the `crypto/tls` fix for **GO-2026-5856** (Encrypted Client Hello privacy leak, flagged by `govulncheck`). With `GOTOOLCHAIN=auto` the release build and CI auto-select the patched toolchain.
+- Bumped GitHub Actions (`actions-all` group, 8 updates — incl. `actions/checkout` 6→7, `actions/cache` 4→6, `actions/setup-python` 5→6) (#70) and the UI `npm-minor-patch` group (18 Radix / TanStack / React Router / Vite-plugin updates) (#71).
 
 ## v0.7.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,4 +81,4 @@ IMPORTANT: When making changes that affect any of these, update the correspondin
 
 ## Tech Stack
 
-Go 1.25.11 | cobra | chi/v5 | Neo4j 4.4+ | PostgreSQL 16 | pgx/v5 | MCP Go SDK v1.6.1 | React 18 + Vite 8 + React Flow + ELK | shadcn/ui + Zustand 5 + TanStack Query 5 | Docker Compose | GoReleaser v2 + cosign | Apache 2.0
+Go 1.25.12 | cobra | chi/v5 | Neo4j 4.4+ | PostgreSQL 16 | pgx/v5 | MCP Go SDK v1.6.1 | React 18 + Vite 8 + React Flow + ELK | shadcn/ui + Zustand 5 + TanStack Query 5 | Docker Compose | GoReleaser v2 + cosign | Apache 2.0

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ open http://127.0.0.1:8080   # xdg-open on Linux
 Prefer a reproducible, pinned install? Every release is cosign-signed with an SBOM:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.7.0/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.8.0/install.sh | sh
 ```
 
 Also available via Homebrew (`brew install agenthound agenthound-server`), `go install`, and signed release binaries - see the [installation guide](https://docs.agenthound.io/getting-started/install/).

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -6,7 +6,7 @@ Clone to green CI in 5 minutes.
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Go | 1.25.11 | Pinned in `go.mod` |
+| Go | 1.25.12 | Pinned in `go.mod` |
 | Node.js | 20+ | UI build (Vite 8) |
 | Docker + Compose | Latest stable | Integration tests, local Neo4j/Postgres |
 | golangci-lint | v2.11+ | Linting (CI uses this exact version) |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adithyan-ak/agenthound
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/go-chi/chi/v5 v5.3.0

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # AgentHound collector installer.
 #
 # Pin to a release tag for integrity:
-#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.7.0/install.sh | sh
+#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v0.8.0/install.sh | sh
 #
 # Verifies the downloaded archive against checksums.txt before extracting,
 # and against cosign signatures if cosign is available on $PATH.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -57,13 +57,13 @@ check_go() {
     MISSING="${MISSING}go\n"
     return
   fi
-  # `go version` -> "go version go1.25.11 darwin/arm64"
+  # `go version` -> "go version go1.25.12 darwin/arm64"
   ver=$(go version 2>/dev/null | awk '{print $3}' | sed 's/^go//')
   need="${GO_MIN_MAJOR}.${GO_MIN_MINOR}"
   if ge_version "$ver" "$need"; then
     print_status OK go "$ver" "(need >= ${need})"
   else
-    print_status WARN go "$ver" "(project pins >= ${need} — CI uses 1.25.11)"
+    print_status WARN go "$ver" "(project pins >= ${need} — CI uses 1.25.12)"
     HAS_WARN=1
   fi
 }


### PR DESCRIPTION
## Summary

Release prep for **v0.8.0** (collector-hardening + read-only loot-expansion milestone).

- **CHANGELOG**: renamed `## Unreleased` → `## v0.8.0` and completed it — added the **Collectors (#75)** section (spec-compliant JWS `jku` verification behind an SSRF-hardened fetcher, new `--no-verify-jwks` / `--a2a-trusted-keys` flags, `signature_verification_status` enum, Cursor/Augment/Claude/VS Code config-parser fixes), plus **Documentation** (#76/#69), **Release & CI tooling** (#66), and **Dependencies** (#70/#71).
- **Security**: bumped the Go toolchain **1.25.11 → 1.25.12** (`go.mod`, both CI workflows, `dev-setup.md`, `CLAUDE.md`, `preflight.sh`) to pull in the `crypto/tls` fix for **GO-2026-5856** (Encrypted Client Hello privacy leak) flagged by `govulncheck`.
- **Version pins**: `install.sh` + `README.md` synced to `v0.8.0` via `make sync-version`.

## Test plan

- [x] `make prerelease` — all 13 gates pass locally (version-check, gofmt, golangci-lint 0 issues, vet, govulncheck clean, go-licenses, build, test -race -short, deps-check, size-check 9 MiB under cap, slop-check, UI build, cross-compile)
- [ ] CI green on this PR
- [ ] Tag `v0.8.0` after merge → GoReleaser publishes signed artifacts

Made with [Cursor](https://cursor.com)