### PR TITLE
fix(litellm): preserve gateway properties across loot publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,12 +151,11 @@ jobs:
       - name: Verify Neo4j version matrix and schema
         run: go test ./server/internal/graph -race -count=1 -run '^TestIntegrationNeo4jVersionMatrix$'
       # The ordinary integration suite runs the whole module in parallel and
-      # MUST NOT execute the destructive fresh-schema reset
-      # (TestIntegrationFreshSchemaCompleteIngestPublishes). That test does a
-      # global `MATCH (n) DETACH DELETE n` + `TRUNCATE scans, posture_state`,
-      # which would race the other DB-touching packages sharing this Neo4j /
-      # Postgres. AGENTHOUND_FRESH_DB_INTEGRATION is intentionally left unset
-      # here so the test self-skips.
+      # MUST NOT execute the destructive fresh-database integrations. Those
+      # tests globally reset Neo4j (and the ingest test also truncates
+      # PostgreSQL), which would race the other DB-touching packages sharing
+      # these services. AGENTHOUND_FRESH_DB_INTEGRATION is intentionally left
+      # unset here so those tests self-skip.
       - name: Run full test suite with DB
         run: go test ./... -race -coverprofile=coverage.out
       - name: Check coverage threshold
@@ -167,11 +166,18 @@ jobs:
             echo "::error::Coverage ${TOTAL}% is below 60% threshold"
             exit 1
           fi
+      - name: Run LiteLLM publication integrations (serialized)
+        env:
+          AGENTHOUND_FRESH_DB_INTEGRATION: "1"
+        run: |
+          go test ./server/internal/analysis/prebuilt -race -count=1 -p 1 -v \
+            -run '^TestIntegrationLiteLLM(FingerprintThenLootPreservesGatewayProperties|FirstPartyProducerSatisfiesMasterExposureQuery|QueryRejectsUnobservedMasterMaterial)$'
       # Dedicated, serialized step for the destructive fresh-schema integration.
       # It runs AFTER the ordinary suite has finished (so nothing else is
       # touching the shared DB), targets only that single test, and pins
-      # `-p 1` to forbid any parallel package execution. This is the only place
-      # the global reset opt-in is enabled.
+      # `-p 1` to forbid any parallel package execution. Together with the
+      # LiteLLM step above, these are the only places the reset opt-in is
+      # enabled.
       - name: Run destructive fresh-schema integration (serialized)
         env:
           AGENTHOUND_FRESH_DB_INTEGRATION: "1"

--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -77,7 +77,10 @@ persist canonical effective matcher definitions and every non-fatal load
 failure. Digests identify semantics but do not attest authenticity.
 Every node and edge must carry one or more `observation_domains` drawn from the
 declared coverage keys. The server never infers fact ownership from a
-single-domain report. Edge endpoint kinds are likewise explicit in v2.
+single-domain report. A node may set `property_semantics: "reference_only"` to
+assert only its ID and kinds; that mode requires an empty `properties` object.
+Omitting `property_semantics` remains an authoritative property observation.
+Edge endpoint kinds are likewise explicit in v2.
 
 Dynamic exhaustive collectors also declare `authoritative_roots`, pairing the
 stable collector-root key with the complete current child-key set. After a
@@ -147,6 +150,9 @@ Implementation details:
   publication until a complete observation replaces every active owner.
 - New facts carry length-delimited observation owner tokens. Shared facts keep
   one token per active coverage domain.
+- Reference-only node observations add ownership without merging managed
+  properties or downgrading an existing complete authoritative observation.
+  Their owner tokens are tracked as an explicit subset of node owners.
 - On merge, preserves `previous_description_hash` for rug-pull detection: `ON MATCH SET n.previous_description_hash = n.description_hash`
 - Edge writes use per-kind Cypher strings selected from the explicitly
   validated `source_kind` and `target_kind` values
@@ -162,6 +168,9 @@ prior owner token. Reconciliation removes old owner tokens, deletes unowned raw
 relationships, then deletes unowned isolated nodes. Facts with another active
 owner survive. Partial, failed, truncated, and unknown coverage performs no
 retirement.
+When reconciliation retires a node's last authoritative property owner but a
+reference-only owner remains, managed properties are cleared to truthful
+reference identity instead of certifying stale rich properties.
 
 Coverage keys are target/config scoped opaque hashes (for example,
 `mcp:target:sha256:...`, `a2a:target:sha256:...`, and

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -263,6 +263,9 @@ domains → post-process → freeze post-analysis totals → snapshot → publis
 `meta.collection` is required on every ingest request, and `collection` is
 required on every successful ingest result. A missing collection report is a
 validation error, not an implicit complete scan.
+Nodes may set `property_semantics: "reference_only"` only with an empty
+`properties` object. This records ID/kind ownership without authoring or
+replacing managed properties; omitted `property_semantics` is authoritative.
 Completed dynamic exhaustive runs may include `authoritative_roots`, each with
 a stable root `coverage_key` and the complete `child_coverage_keys` active set.
 The server reconciles prior children omitted from that set as complete-empty.

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -140,11 +140,14 @@ type Edge struct {
 }
 ```
 
-`Node` has the same required `observation_domains` field. In wire version 2,
-collector artifacts preserve the producing target/config scope per fact using
-opaque canonical keys such as
-`mcp:target:sha256:...`, `a2a:target:sha256:...`, and
-`config:path:sha256:...`. The server does not infer ownership.
+`Node` has the same required `observation_domains` field and an optional
+`property_semantics` field. Omitted `property_semantics` is an authoritative
+property observation. The only explicit alternative is `reference_only`,
+which asserts node ID and kinds while requiring an empty `properties` object.
+In wire version 2, collector artifacts preserve the producing target/config
+scope per fact using opaque canonical keys such as `mcp:target:sha256:...`,
+`a2a:target:sha256:...`, and `config:path:sha256:...`. The server does not
+infer ownership.
 
 ### Edge Properties (all edges carry these)
 
@@ -174,6 +177,12 @@ The writer derives internal `observation_tokens` from the validated
 retires only old tokens for that exact target/config key. A shared node or raw
 relationship remains while any owner token survives. Unknown, partial, failed,
 and truncated coverage is non-destructive.
+Node reference owners are tracked internally as a subset of
+`observation_tokens`. A `reference_only` write adds ownership without merging
+properties or lowering a complete authoritative observation. If the last
+authoritative owner retires while a reference owner remains, the writer removes
+the stale managed properties and retains only truthful node identity,
+ownership, and lifecycle metadata.
 `LOADS_INSTRUCTIONS` uses `all_dependencies`: completing either its config or
 instruction scope without re-observing the relationship retires it.
 

--- a/modules/litellmloot/looter.go
+++ b/modules/litellmloot/looter.go
@@ -62,7 +62,6 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		return nil, errors.New("litellm loot: --master-key (or --credential master_key=...) is required")
 	}
 
-	_, host, _ := action.EndpointParts(t, DefaultPort, "http")
 	baseURL := action.EndpointBaseURL(t, DefaultPort, "http")
 	gatewayObjectID := ingest.ComputeNodeID("LiteLLMGateway", baseURL)
 
@@ -81,21 +80,14 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		IngestData: &ingest.IngestData{},
 	}
 
-	// Emit the edge source in the loot artifact itself so the production CLI
-	// envelope is independently valid ingest v2. Keep this node deliberately
-	// sparse: endpoint identity is known here, while discovery and auth posture
-	// remain owned by the fingerprinter. When that richer node already exists,
-	// the shared object ID folds these identity-stable facts without replacing
-	// fingerprint-only properties.
+	// Emit a property-neutral edge-source reference so the production CLI
+	// envelope is independently valid ingest v2. The looter knows the canonical
+	// node identity and kinds, but does not own discovery or auth posture.
 	res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
-		ID:    gatewayObjectID,
-		Kinds: []string{"LiteLLMGateway", "AIService"},
-		Properties: map[string]any{
-			"objectid":     gatewayObjectID,
-			"name":         host,
-			"endpoint":     baseURL,
-			"service_kind": "litellm",
-		},
+		ID:                gatewayObjectID,
+		Kinds:             []string{"LiteLLMGateway", "AIService"},
+		Properties:        map[string]any{},
+		PropertySemantics: ingest.NodePropertySemanticsReferenceOnly,
 	})
 
 	// 1. The master-key Credential — emitted unconditionally.

--- a/modules/litellmloot/looter_test.go
+++ b/modules/litellmloot/looter_test.go
@@ -255,19 +255,11 @@ func TestLoot_GatewayMatchesFingerprintWithoutOwningPosture(t *testing.T) {
 	if !reflect.DeepEqual(gateway.Kinds, []string{"LiteLLMGateway", "AIService"}) {
 		t.Fatalf("loot gateway kinds = %v", gateway.Kinds)
 	}
-	if len(gateway.Properties) != 4 {
-		t.Fatalf("loot gateway properties = %+v, want only canonical identity facts", gateway.Properties)
+	if len(gateway.Properties) != 0 {
+		t.Fatalf("loot gateway properties = %+v, want property-neutral reference", gateway.Properties)
 	}
-	for key, value := range gateway.Properties {
-		if fingerprintValue, ok := fingerprintGateway.Properties[key]; ok &&
-			!reflect.DeepEqual(value, fingerprintValue) {
-			t.Fatalf(
-				"shared gateway property %q conflicts: loot=%v fingerprint=%v",
-				key,
-				value,
-				fingerprintValue,
-			)
-		}
+	if gateway.PropertySemantics != ingest.NodePropertySemanticsReferenceOnly {
+		t.Fatalf("loot gateway property semantics = %q, want reference_only", gateway.PropertySemantics)
 	}
 	for _, fingerprintOwned := range []string{
 		"auth_method",

--- a/sdk/ingest/model_test.go
+++ b/sdk/ingest/model_test.go
@@ -36,6 +36,30 @@ func TestNodeJSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestReferenceOnlyNodeJSONRoundTrip(t *testing.T) {
+	node := Node{
+		ID:                "sha256:reference",
+		Kinds:             []string{"LiteLLMGateway", "AIService"},
+		Properties:        map[string]any{},
+		PropertySemantics: NodePropertySemanticsReferenceOnly,
+	}
+
+	data, err := json.Marshal(node)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Node
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.PropertySemantics != NodePropertySemanticsReferenceOnly {
+		t.Errorf("PropertySemantics: got %q, want reference_only", got.PropertySemantics)
+	}
+	if got.Properties == nil || len(got.Properties) != 0 {
+		t.Errorf("Properties: got %+v, want empty object", got.Properties)
+	}
+}
+
 func TestEdgeJSONRoundTrip(t *testing.T) {
 	e := Edge{
 		Source: "sha256:aaa",

--- a/sdk/ingest/node.go
+++ b/sdk/ingest/node.go
@@ -1,8 +1,18 @@
 package ingest
 
+type NodePropertySemantics string
+
+const (
+	// NodePropertySemanticsReferenceOnly marks an ownership observation that
+	// asserts only the node's ID and kinds. It does not author or replace the
+	// node's managed properties.
+	NodePropertySemanticsReferenceOnly NodePropertySemantics = "reference_only"
+)
+
 type Node struct {
-	ID                 string         `json:"id"`
-	Kinds              []string       `json:"kinds"`
-	Properties         map[string]any `json:"properties"`
-	ObservationDomains []string       `json:"observation_domains,omitempty"`
+	ID                 string                `json:"id"`
+	Kinds              []string              `json:"kinds"`
+	Properties         map[string]any        `json:"properties"`
+	ObservationDomains []string              `json:"observation_domains,omitempty"`
+	PropertySemantics  NodePropertySemantics `json:"property_semantics,omitempty"`
 }

--- a/server/internal/analysis/prebuilt/litellm_producer_integration_test.go
+++ b/server/internal/analysis/prebuilt/litellm_producer_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/adithyan-ak/agenthound/server/internal/appdb"
 	"github.com/adithyan-ak/agenthound/server/internal/graph"
 	serveringest "github.com/adithyan-ak/agenthound/server/internal/ingest"
+	"github.com/adithyan-ak/agenthound/server/internal/projection"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -166,7 +167,7 @@ func runLiteLLMProducerQuery(
 	mutate func(*sdkingest.IngestData),
 ) []map[string]any {
 	t.Helper()
-	ctx, pipeline, db, _ := freshLiteLLMIntegrationHarness(t)
+	ctx, pipeline, db, publicationStore := freshLiteLLMIntegrationHarness(t)
 	fixture := newLiteLLMFixture(t)
 	defer fixture.Close()
 
@@ -187,9 +188,24 @@ func runLiteLLMProducerQuery(
 		t.Fatalf("validated loot output was not published: %+v", result)
 	}
 
-	rows, err := db.Query(ctx, prebuilt.CypherLitellmCredentialLeak, nil)
+	rows, identity, err := projection.GuardedRead(
+		ctx,
+		publicationStore,
+		func() ([]map[string]any, error) {
+			return db.Query(ctx, prebuilt.CypherLitellmCredentialLeak, nil)
+		},
+	)
 	if err != nil {
-		t.Fatalf("execute LiteLLM prebuilt query: %v", err)
+		t.Fatalf("execute guarded LiteLLM prebuilt query: %v", err)
+	}
+	if identity.ScanID != result.ScanID ||
+		identity.Revision != *result.PublishedRevision {
+		t.Fatalf(
+			"guarded query publication identity = %+v, want scan %q revision %d",
+			identity,
+			result.ScanID,
+			*result.PublishedRevision,
+		)
 	}
 	producedRows := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {

--- a/server/internal/analysis/prebuilt/litellm_producer_integration_test.go
+++ b/server/internal/analysis/prebuilt/litellm_producer_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -35,31 +36,116 @@ func TestLiteLLMProductionLootArtifactIsStrictV2(t *testing.T) {
 	fixture.AssertLootRequests(t)
 }
 
-func TestIntegrationLiteLLMFirstPartyProducerSatisfiesMasterExposureQuery(t *testing.T) {
-	rows := runLiteLLMProducerQuery(t, nil)
-	if len(rows) != 2 {
-		t.Fatalf("query returned %d rows, want masked apiKey and hashed virtual-key references", len(rows))
+func TestIntegrationLiteLLMFingerprintThenLootPreservesGatewayProperties(t *testing.T) {
+	ctx, pipeline, db, publicationStore := freshLiteLLMIntegrationHarness(t)
+	fixture := newLiteLLMScanFixture(t)
+	defer fixture.Close()
+
+	fingerprintData := runAgentHoundLiteLLMScan(t)
+	if err := serveringest.NewValidator().Validate(&fingerprintData); err != nil {
+		t.Fatalf("strict ingest-v2 validation rejected agenthound scan output: %v", err)
+	}
+	gatewayID := sdkingest.ComputeNodeID("LiteLLMGateway", fixture.URL)
+	fingerprintGateway := findLiteLLMGateway(t, &fingerprintData, gatewayID)
+	if fingerprintGateway.PropertySemantics != "" ||
+		fingerprintGateway.Properties["endpoint"] != fixture.URL ||
+		fingerprintGateway.Properties["auth_method"] != "master_key" ||
+		fingerprintGateway.Properties["discovered_via"] != "network_scan" {
+		t.Fatalf("scan gateway is not rich and authoritative: %+v", fingerprintGateway)
 	}
 
-	referenceStatuses := map[string]string{}
-	for _, row := range rows {
-		if row["master_material_status"] != "observed" ||
-			row["master_exposure_status"] != "exposed" ||
-			row["master_evidence"] != "observed_credential_exposure" {
-			t.Fatalf("master evidence was not preserved: %+v", row)
-		}
-		referenceType, _ := row["reference_type"].(string)
-		referenceMaterial, _ := row["reference_material_status"].(string)
-		referenceStatuses[referenceType] = referenceMaterial
-		if row["reference_exposure_status"] != "not_observed" ||
-			row["reference_contains_usable_material"] != false {
-			t.Fatalf("reference was presented as usable upstream material: %+v", row)
+	first, err := pipeline.Ingest(ctx, &fingerprintData)
+	if err != nil {
+		t.Fatalf("pipeline ingest of validated fingerprint output: %v", err)
+	}
+	if first.PublishedRevision == nil ||
+		*first.PublishedRevision != 1 ||
+		first.Outcome != sdkingest.OutcomeComplete {
+		t.Fatalf("fingerprint publication revision 1 failed: %+v", first)
+	}
+
+	lootData := runAgentHoundLiteLLMLoot(t, fixture.URL)
+	assertStrictLiteLLMArtifact(t, &lootData, fixture.URL)
+	lootGateway := findLiteLLMGateway(t, &lootData, gatewayID)
+	if lootGateway.ID != fingerprintGateway.ID ||
+		strings.Join(lootGateway.Kinds, ",") != strings.Join(fingerprintGateway.Kinds, ",") {
+		t.Fatalf(
+			"fingerprint/loot gateway identity differs: fingerprint=%+v loot=%+v",
+			fingerprintGateway,
+			lootGateway,
+		)
+	}
+
+	second, err := pipeline.Ingest(ctx, &lootData)
+	if err != nil {
+		t.Fatalf("pipeline ingest of validated loot output: %v", err)
+	}
+	if second.PublishedRevision == nil ||
+		*second.PublishedRevision != 2 ||
+		second.Outcome != sdkingest.OutcomeComplete {
+		t.Fatalf("loot publication revision 2 failed: %+v", second)
+	}
+
+	rows, err := db.Query(
+		ctx,
+		`MATCH (gateway:LiteLLMGateway {objectid: $gateway_id})
+		 RETURN labels(gateway) AS kinds,
+		        properties(gateway) AS properties,
+		        gateway.observation_tokens AS owners,
+		        gateway.observation_reference_tokens AS reference_owners`,
+		map[string]any{"gateway_id": gatewayID},
+	)
+	if err != nil {
+		t.Fatalf("query shared LiteLLM gateway: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("shared LiteLLM gateway rows = %+v, want one", rows)
+	}
+	properties, _ := rows[0]["properties"].(map[string]any)
+	if properties["endpoint"] != fixture.URL ||
+		properties["auth_method"] != "master_key" ||
+		properties["discovered_via"] != "network_scan" ||
+		properties["service_kind"] != "litellm" ||
+		properties["observation_properties_complete"] != true {
+		t.Fatalf("loot replaced or downgraded fingerprint properties: %+v", properties)
+	}
+	kinds, _ := rows[0]["kinds"].([]any)
+	if !containsValue(kinds, "LiteLLMGateway") || !containsValue(kinds, "AIService") {
+		t.Fatalf("shared gateway kinds = %v", kinds)
+	}
+	owners, _ := rows[0]["owners"].([]any)
+	referenceOwners, _ := rows[0]["reference_owners"].([]any)
+	if len(owners) != 2 || len(referenceOwners) != 1 {
+		t.Fatalf("shared gateway owners = %v, reference owners = %v", owners, referenceOwners)
+	}
+
+	projection, err := publicationStore.GetProjectionState(ctx)
+	if err != nil {
+		t.Fatalf("read publication state: %v", err)
+	}
+	if len(projection.DirtyCoverage) != 0 ||
+		projection.PublishedRevision == nil ||
+		*projection.PublishedRevision != 2 {
+		t.Fatalf("fingerprint-to-loot publication left dirty coverage: %+v", projection)
+	}
+
+	queryRows, err := db.Query(ctx, prebuilt.CypherLitellmCredentialLeak, nil)
+	if err != nil {
+		t.Fatalf("execute guarded LiteLLM prebuilt query: %v", err)
+	}
+	var produced []map[string]any
+	for _, row := range queryRows {
+		if row["gateway_id"] == gatewayID {
+			produced = append(produced, row)
 		}
 	}
-	if referenceStatuses["apiKey"] != "masked" ||
-		referenceStatuses["virtual_key"] != "hashed" {
-		t.Fatalf("reference evidence = %v", referenceStatuses)
-	}
+	assertLiteLLMReferenceRows(t, produced)
+	fixture.AssertFingerprintThenLootRequests(t)
+}
+
+func TestIntegrationLiteLLMFirstPartyProducerSatisfiesMasterExposureQuery(t *testing.T) {
+	rows := runLiteLLMProducerQuery(t, nil)
+	assertLiteLLMReferenceRows(t, rows)
 }
 
 func TestIntegrationLiteLLMQueryRejectsUnobservedMasterMaterial(t *testing.T) {
@@ -80,7 +166,7 @@ func runLiteLLMProducerQuery(
 	mutate func(*sdkingest.IngestData),
 ) []map[string]any {
 	t.Helper()
-	ctx, pipeline, db := freshLiteLLMIntegrationHarness(t)
+	ctx, pipeline, db, _ := freshLiteLLMIntegrationHarness(t)
 	fixture := newLiteLLMFixture(t)
 	defer fixture.Close()
 
@@ -114,6 +200,33 @@ func runLiteLLMProducerQuery(
 	return producedRows
 }
 
+func assertLiteLLMReferenceRows(t *testing.T, rows []map[string]any) {
+	t.Helper()
+	if len(rows) != 2 {
+		t.Fatalf("query returned %d rows, want masked apiKey and hashed virtual-key references", len(rows))
+	}
+
+	referenceStatuses := map[string]string{}
+	for _, row := range rows {
+		if row["master_material_status"] != "observed" ||
+			row["master_exposure_status"] != "exposed" ||
+			row["master_evidence"] != "observed_credential_exposure" {
+			t.Fatalf("master evidence was not preserved: %+v", row)
+		}
+		referenceType, _ := row["reference_type"].(string)
+		referenceMaterial, _ := row["reference_material_status"].(string)
+		referenceStatuses[referenceType] = referenceMaterial
+		if row["reference_exposure_status"] != "not_observed" ||
+			row["reference_contains_usable_material"] != false {
+			t.Fatalf("reference was presented as usable upstream material: %+v", row)
+		}
+	}
+	if referenceStatuses["apiKey"] != "masked" ||
+		referenceStatuses["virtual_key"] != "hashed" {
+		t.Fatalf("reference evidence = %v", referenceStatuses)
+	}
+}
+
 func assertStrictLiteLLMArtifact(
 	t *testing.T,
 	data *sdkingest.IngestData,
@@ -138,8 +251,9 @@ func assertStrictLiteLLMArtifact(
 	if len(gateway.Kinds) != 2 ||
 		gateway.Kinds[0] != "LiteLLMGateway" ||
 		gateway.Kinds[1] != "AIService" ||
-		gateway.Properties["endpoint"] != fixtureURL {
-		t.Fatalf("production loot gateway is not canonical: %+v", gateway)
+		len(gateway.Properties) != 0 ||
+		gateway.PropertySemantics != sdkingest.NodePropertySemanticsReferenceOnly {
+		t.Fatalf("production loot gateway is not a property-neutral reference: %+v", gateway)
 	}
 	for _, property := range []string{
 		"auth_method",
@@ -153,6 +267,30 @@ func assertStrictLiteLLMArtifact(
 	}
 }
 
+func findLiteLLMGateway(
+	t *testing.T,
+	data *sdkingest.IngestData,
+	gatewayID string,
+) *sdkingest.Node {
+	t.Helper()
+	for i := range data.Graph.Nodes {
+		if data.Graph.Nodes[i].ID == gatewayID {
+			return &data.Graph.Nodes[i]
+		}
+	}
+	t.Fatalf("artifact omitted LiteLLM gateway %q", gatewayID)
+	return nil
+}
+
+func containsValue(values []any, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 type liteLLMFixture struct {
 	*httptest.Server
 
@@ -164,8 +302,25 @@ type liteLLMFixture struct {
 
 func newLiteLLMFixture(t *testing.T) *liteLLMFixture {
 	t.Helper()
+	return newLiteLLMFixtureWithListener(t, nil)
+}
+
+func newLiteLLMScanFixture(t *testing.T) *liteLLMFixture {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:4000")
+	if err != nil {
+		t.Fatalf("bind first-party LiteLLM scan fixture to 127.0.0.1:4000: %v", err)
+	}
+	return newLiteLLMFixtureWithListener(t, listener)
+}
+
+func newLiteLLMFixtureWithListener(
+	t *testing.T,
+	listener net.Listener,
+) *liteLLMFixture {
+	t.Helper()
 	fixture := &liteLLMFixture{}
-	fixture.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fixture.mu.Lock()
 		switch r.URL.Path {
 		case "/model/info":
@@ -177,6 +332,10 @@ func newLiteLLMFixture(t *testing.T) *liteLLMFixture {
 		}
 		fixture.mu.Unlock()
 
+		if r.URL.Path == "/health/liveliness" {
+			_, _ = w.Write([]byte("I'm alive!"))
+			return
+		}
 		if r.Header.Get("Authorization") != "Bearer sk-integration-master-key" {
 			http.Error(w, "missing fixture master key", http.StatusUnauthorized)
 			return
@@ -203,7 +362,15 @@ func newLiteLLMFixture(t *testing.T) *liteLLMFixture {
 		default:
 			http.NotFound(w, r)
 		}
-	}))
+	})
+	if listener == nil {
+		fixture.Server = httptest.NewServer(handler)
+		return fixture
+	}
+	fixture.Server = httptest.NewUnstartedServer(handler)
+	_ = fixture.Listener.Close()
+	fixture.Listener = listener
+	fixture.Start()
 	return fixture
 }
 
@@ -223,20 +390,41 @@ func (f *liteLLMFixture) AssertLootRequests(t *testing.T) {
 	}
 }
 
+func (f *liteLLMFixture) AssertFingerprintThenLootRequests(t *testing.T) {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.healthRequests != 1 ||
+		f.modelInfoRequests != 1 ||
+		f.keyListRequests != 1 {
+		t.Fatalf(
+			"LiteLLM fixture requests: health=%d model/info=%d key/list=%d, want one each",
+			f.healthRequests,
+			f.modelInfoRequests,
+			f.keyListRequests,
+		)
+	}
+}
+
+func runAgentHoundLiteLLMScan(t *testing.T) sdkingest.IngestData {
+	t.Helper()
+	binaryPath, repositoryRoot := buildAgentHound(t)
+	command := exec.Command(
+		binaryPath,
+		"scan",
+		"127.0.0.1",
+		"--ports",
+		"4000",
+		"--scan-output",
+		"-",
+		"--quiet",
+	)
+	return runAgentHoundArtifactCommand(t, command, repositoryRoot, "scan")
+}
+
 func runAgentHoundLiteLLMLoot(t *testing.T, fixtureURL string) sdkingest.IngestData {
 	t.Helper()
-	_, currentFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("resolve integration test source path")
-	}
-	repositoryRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", "..", "..", ".."))
-	binaryPath := filepath.Join(t.TempDir(), "agenthound")
-	build := exec.Command("go", "build", "-o", binaryPath, "./collector/cmd/agenthound")
-	build.Dir = repositoryRoot
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build agenthound for production loot regression: %v\n%s", err, output)
-	}
-
+	binaryPath, repositoryRoot := buildAgentHound(t)
 	command := exec.Command(
 		binaryPath,
 		"loot",
@@ -251,20 +439,47 @@ func runAgentHoundLiteLLMLoot(t *testing.T, fixtureURL string) sdkingest.IngestD
 		"-",
 		"--quiet",
 	)
+	command.Stdin = strings.NewReader("AUTHORIZED\n")
+	return runAgentHoundArtifactCommand(t, command, repositoryRoot, "loot")
+}
+
+func buildAgentHound(t *testing.T) (string, string) {
+	t.Helper()
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve integration test source path")
+	}
+	repositoryRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", "..", "..", ".."))
+	binaryPath := filepath.Join(t.TempDir(), "agenthound")
+	build := exec.Command("go", "build", "-o", binaryPath, "./collector/cmd/agenthound")
+	build.Dir = repositoryRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build agenthound for production loot regression: %v\n%s", err, output)
+	}
+	return binaryPath, repositoryRoot
+}
+
+func runAgentHoundArtifactCommand(
+	t *testing.T,
+	command *exec.Cmd,
+	repositoryRoot string,
+	verb string,
+) sdkingest.IngestData {
+	t.Helper()
 	command.Dir = repositoryRoot
 	command.Env = integrationCommandEnv(t.TempDir())
-	command.Stdin = strings.NewReader("AUTHORIZED\n")
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 	if err := command.Run(); err != nil {
-		t.Fatalf("agenthound loot failed: %v\nstderr:\n%s", err, stderr.String())
+		t.Fatalf("agenthound %s failed: %v\nstderr:\n%s", verb, err, stderr.String())
 	}
 
 	var data sdkingest.IngestData
 	if err := sdkingest.DecodeStrict(bytes.NewReader(stdout.Bytes()), &data); err != nil {
 		t.Fatalf(
-			"strict JSON decode rejected agenthound loot output: %v\nstdout:\n%s\nstderr:\n%s",
+			"strict JSON decode rejected agenthound %s output: %v\nstdout:\n%s\nstderr:\n%s",
+			verb,
 			err,
 			stdout.String(),
 			stderr.String(),
@@ -287,7 +502,7 @@ func integrationCommandEnv(home string) []string {
 
 func freshLiteLLMIntegrationHarness(
 	t *testing.T,
-) (context.Context, *serveringest.Pipeline, *graph.DB) {
+) (context.Context, *serveringest.Pipeline, *graph.DB, *appdb.FindingStore) {
 	t.Helper()
 	if os.Getenv("AGENTHOUND_FRESH_DB_INTEGRATION") != "1" {
 		t.Skip("set AGENTHOUND_FRESH_DB_INTEGRATION=1 for destructive fresh-database integration")
@@ -354,10 +569,12 @@ func freshLiteLLMIntegrationHarness(
 		t.Fatalf("migrate PostgreSQL: %v", err)
 	}
 
+	scanStore := appdb.NewScanStore(pool)
+	findingStore := appdb.NewFindingStore(pool)
 	return ctx, serveringest.NewPipeline(
 		writer,
 		db,
-		appdb.NewScanStore(pool),
-		appdb.NewFindingStore(pool),
-	), db
+		scanStore,
+		findingStore,
+	), db, findingStore
 }

--- a/server/internal/api/handlers/openapi.yaml
+++ b/server/internal/api/handlers/openapi.yaml
@@ -342,6 +342,10 @@ components:
           minItems: 1
           uniqueItems: true
           items: { type: string }
+        property_semantics:
+          type: string
+          enum: [reference_only]
+          description: Omit for an authoritative property observation. reference_only asserts only id and kinds and requires an empty properties object.
 
     IngestEdgeV2:
       type: object

--- a/server/internal/graph/integration_test.go
+++ b/server/internal/graph/integration_test.go
@@ -729,6 +729,151 @@ func TestIntegrationCompleteObservationReplacesStaleManagedProperties(t *testing
 	}
 }
 
+func TestIntegrationReferenceOwnerPreservesThenRetiresAuthoritativeProperties(t *testing.T) {
+	ctx := testDriver(t)
+	driver, err := NewDriver(
+		os.Getenv("AGENTHOUND_NEO4J_URI"),
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+
+	writer := NewWriter(driver)
+	db := NewDB(NewReader(driver), writer)
+	const nodeID = "shared-reference-retirement"
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(
+			ctx,
+			"MATCH (n {objectid: $id}) DETACH DELETE n",
+			map[string]any{"id": nodeID},
+		)
+	}
+	cleanup()
+	defer cleanup()
+
+	authoritativeScope := "scan:network:sha256:authoritative"
+	referenceScope := "scan:loot:sha256:reference"
+	authoritative := ingest.Node{
+		ID:                 nodeID,
+		Kinds:              []string{"LiteLLMGateway", "AIService"},
+		ObservationDomains: []string{authoritativeScope},
+		Properties: map[string]any{
+			"objectid":       nodeID,
+			"endpoint":       "http://127.0.0.1:4000",
+			"auth_method":    "master_key",
+			"discovered_via": "network_scan",
+		},
+	}
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{authoritative},
+		"authoritative-scan",
+		[]string{authoritativeScope},
+	); err != nil {
+		t.Fatalf("write authoritative observation: %v", err)
+	}
+	if _, err := ReconcileObservations(
+		ctx,
+		db,
+		"authoritative-scan",
+		[]string{authoritativeScope},
+	); err != nil {
+		t.Fatalf("reconcile authoritative observation: %v", err)
+	}
+
+	reference := ingest.Node{
+		ID:                 nodeID,
+		Kinds:              []string{"LiteLLMGateway", "AIService"},
+		ObservationDomains: []string{referenceScope},
+		Properties:         map[string]any{"objectid": nodeID},
+		PropertySemantics:  ingest.NodePropertySemanticsReferenceOnly,
+	}
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{reference},
+		"reference-scan",
+		[]string{referenceScope},
+	); err != nil {
+		t.Fatalf("write reference observation: %v", err)
+	}
+	if _, err := ReconcileObservations(
+		ctx,
+		db,
+		"reference-scan",
+		[]string{referenceScope},
+	); err != nil {
+		t.Fatalf("reconcile reference observation: %v", err)
+	}
+
+	rows, err := db.Query(
+		ctx,
+		`MATCH (n:LiteLLMGateway {objectid: $id})
+		 RETURN n.endpoint AS endpoint,
+		        n.auth_method AS auth_method,
+		        n.discovered_via AS discovered_via,
+		        n.observation_tokens AS tokens,
+		        n.observation_reference_tokens AS reference_tokens,
+		        n.observation_properties_complete AS properties_complete`,
+		map[string]any{"id": nodeID},
+	)
+	if err != nil {
+		t.Fatalf("query shared-owner node: %v", err)
+	}
+	if len(rows) != 1 ||
+		rows[0]["endpoint"] != "http://127.0.0.1:4000" ||
+		rows[0]["auth_method"] != "master_key" ||
+		rows[0]["discovered_via"] != "network_scan" ||
+		rows[0]["properties_complete"] != true {
+		t.Fatalf("reference observation changed authoritative properties: %+v", rows)
+	}
+	tokens, _ := rows[0]["tokens"].([]any)
+	referenceTokens, _ := rows[0]["reference_tokens"].([]any)
+	if len(tokens) != 2 || len(referenceTokens) != 1 {
+		t.Fatalf("shared ownership tokens = %v, reference tokens = %v", tokens, referenceTokens)
+	}
+
+	if _, err := ReconcileObservations(
+		ctx,
+		db,
+		"authoritative-retired",
+		[]string{authoritativeScope},
+	); err != nil {
+		t.Fatalf("retire authoritative owner: %v", err)
+	}
+	rows, err = db.Query(
+		ctx,
+		`MATCH (n:LiteLLMGateway {objectid: $id})
+		 RETURN properties(n) AS properties`,
+		map[string]any{"id": nodeID},
+	)
+	if err != nil {
+		t.Fatalf("query reference fallback: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("reference fallback node missing: %+v", rows)
+	}
+	properties, _ := rows[0]["properties"].(map[string]any)
+	if properties["objectid"] != nodeID ||
+		properties["endpoint"] != nil ||
+		properties["auth_method"] != nil ||
+		properties["discovered_via"] != nil ||
+		properties["observation_properties_complete"] != true {
+		t.Fatalf("authoritative retirement retained stale rich properties: %+v", properties)
+	}
+	remainingTokens, _ := properties["observation_tokens"].([]any)
+	remainingReferenceTokens, _ := properties["observation_reference_tokens"].([]any)
+	if len(remainingTokens) != 1 || len(remainingReferenceTokens) != 1 {
+		t.Fatalf(
+			"reference fallback ownership tokens = %v, reference tokens = %v",
+			remainingTokens,
+			remainingReferenceTokens,
+		)
+	}
+}
+
 func TestIntegrationCompleteObservationReplacesOnlyManagedLabels(t *testing.T) {
 	ctx := testDriver(t)
 	driver, err := NewDriver(

--- a/server/internal/graph/reconciler.go
+++ b/server/internal/graph/reconciler.go
@@ -125,11 +125,43 @@ MATCH (n)
 WHERE any(label IN labels(n) WHERE label IN $public_kinds)
   AND any(token IN coalesce(n.observation_tokens, [])
           WHERE any(prefix IN $domain_prefixes WHERE token STARTS WITH prefix))
-SET n.observation_tokens = [
-  token IN coalesce(n.observation_tokens, [])
-  WHERE none(prefix IN $domain_prefixes WHERE token STARTS WITH prefix)
-     OR token IN $current_tokens
-]
+WITH n,
+     coalesce(n.observation_tokens, []) AS old_tokens,
+     coalesce(n.observation_reference_tokens, []) AS old_reference_tokens,
+     n.objectid AS objectid,
+     n.scan_id AS scan_id,
+     n.first_seen AS first_seen,
+     n.last_seen AS last_seen
+WITH n, old_tokens, old_reference_tokens,
+     objectid, scan_id, first_seen, last_seen,
+     [token IN old_tokens
+      WHERE none(prefix IN $domain_prefixes WHERE token STARTS WITH prefix)
+         OR token IN $current_tokens] AS remaining_tokens,
+     [token IN old_reference_tokens
+      WHERE none(prefix IN $domain_prefixes WHERE token STARTS WITH prefix)
+         OR token IN $current_tokens] AS remaining_reference_tokens
+WITH n, remaining_tokens, remaining_reference_tokens,
+     objectid, scan_id, first_seen, last_seen,
+     [token IN old_tokens
+      WHERE NOT token IN old_reference_tokens] AS old_authoritative_tokens,
+     [token IN remaining_tokens
+      WHERE NOT token IN remaining_reference_tokens] AS remaining_authoritative_tokens
+SET n.observation_tokens = remaining_tokens,
+    n.observation_reference_tokens = remaining_reference_tokens
+FOREACH (_ IN CASE
+  WHEN size(old_authoritative_tokens) > 0
+   AND size(remaining_authoritative_tokens) = 0
+   AND size(remaining_tokens) > 0
+  THEN [1] ELSE [] END |
+  SET n = {
+    objectid: objectid,
+    scan_id: scan_id,
+    first_seen: first_seen,
+    last_seen: last_seen,
+    observation_tokens: remaining_tokens,
+    observation_reference_tokens: remaining_reference_tokens,
+    observation_properties_complete: true
+  })
 RETURN count(n) AS retired`
 
 const deleteUnownedNodesCypher = `

--- a/server/internal/graph/reconciler_test.go
+++ b/server/internal/graph/reconciler_test.go
@@ -81,6 +81,26 @@ func TestReconcileObservationsRetiresOnlySelectedDomains(t *testing.T) {
 	if !strings.Contains(deleteQuery, "type(r) IN $raw_edge_kinds") {
 		t.Fatal("relationship retirement must remain limited to managed raw edges")
 	}
+	nodeRetireQuery, ok := calls[4].Args[0].(string)
+	if !ok {
+		t.Fatalf("node retire query type = %T", calls[4].Args[0])
+	}
+	for _, fragment := range []string{
+		"old_reference_tokens",
+		"remaining_authoritative_tokens",
+		"size(old_authoritative_tokens) > 0",
+		"size(remaining_authoritative_tokens) = 0",
+		"SET n = {",
+		"observation_properties_complete: true",
+	} {
+		if !strings.Contains(nodeRetireQuery, fragment) {
+			t.Fatalf(
+				"node retirement does not reduce stale authoritative properties on reference fallback; missing %q:\n%s",
+				fragment,
+				nodeRetireQuery,
+			)
+		}
+	}
 }
 
 func TestReconcileDependencyEdgeRetiresWhenEitherDomainChanges(t *testing.T) {

--- a/server/internal/graph/writer.go
+++ b/server/internal/graph/writer.go
@@ -112,6 +112,8 @@ func (w *Writer) writeNodesBatched(
 					"observation_tokens":          observationTokens(n.ObservationDomains, scanID),
 					"observation_domain_prefixes": observationDomainPrefixes(n.ObservationDomains),
 					"complete_domain_prefixes":    completePrefixes,
+					"reference_only": n.PropertySemantics ==
+						ingest.NodePropertySemanticsReferenceOnly,
 				}
 			}
 
@@ -144,23 +146,34 @@ WITH n, node,
      n.input_schema_hash AS old_input_schema_hash,
      n.instructions_hash AS old_instructions_hash,
      n.first_seen AS old_first_seen,
-     coalesce(n.observation_tokens, []) AS old_tokens
+     coalesce(n.observation_tokens, []) AS old_tokens,
+     coalesce(n.observation_reference_tokens, []) AS old_reference_tokens,
+     coalesce(n.observation_properties_complete, false) AS old_properties_complete
 WITH n, node, observation_created,
      old_description_hash, old_input_schema_hash, old_instructions_hash,
-     old_first_seen, old_tokens,
+     old_first_seen, old_tokens, old_reference_tokens, old_properties_complete,
+     [token IN old_tokens WHERE NOT token IN old_reference_tokens] AS old_authoritative_tokens,
      (size(node.observation_tokens) > 0
       AND all(token IN node.observation_tokens WHERE
           any(prefix IN node.complete_domain_prefixes WHERE token STARTS WITH prefix))) AS incoming_complete
 WITH n, node, observation_created,
      old_description_hash, old_input_schema_hash, old_instructions_hash,
-     old_first_seen, old_tokens, incoming_complete,
+     old_first_seen, old_tokens, old_reference_tokens, old_properties_complete,
+     old_authoritative_tokens, incoming_complete,
      (NOT observation_created
+      AND NOT node.reference_only
       AND incoming_complete
-      AND all(token IN old_tokens WHERE
+      AND all(token IN old_authoritative_tokens WHERE
           any(prefix IN node.observation_domain_prefixes WHERE token STARTS WITH prefix))) AS replace_properties
-FOREACH (_ IN CASE WHEN observation_created OR replace_properties THEN [1] ELSE [] END |
+FOREACH (_ IN CASE
+  WHEN (observation_created AND NOT node.reference_only) OR replace_properties
+  THEN [1] ELSE [] END |
   SET n = node.properties)
-FOREACH (_ IN CASE WHEN NOT observation_created AND NOT replace_properties THEN [1] ELSE [] END |
+FOREACH (_ IN CASE WHEN observation_created AND node.reference_only THEN [1] ELSE [] END |
+  SET n = {objectid: node.id})
+FOREACH (_ IN CASE
+  WHEN NOT observation_created AND NOT replace_properties AND NOT node.reference_only
+  THEN [1] ELSE [] END |
   SET n += node.properties)
 SET n.objectid = node.id,
     n.scan_id = $scan_id,
@@ -171,8 +184,20 @@ SET n.objectid = node.id,
     n.previous_instructions_hash = CASE WHEN observation_created THEN node.properties.instructions_hash ELSE old_instructions_hash END,
     n.observation_tokens = reduce(tokens = old_tokens, token IN node.observation_tokens |
       CASE WHEN token IN tokens THEN tokens ELSE tokens + token END),
+    n.observation_reference_tokens = CASE
+      WHEN node.reference_only THEN
+        reduce(tokens = old_reference_tokens, token IN node.observation_tokens |
+          CASE
+            WHEN token IN tokens OR token IN old_authoritative_tokens THEN tokens
+            ELSE tokens + token
+          END)
+      ELSE [token IN old_reference_tokens WHERE NOT token IN node.observation_tokens]
+    END,
     n.observation_properties_complete = CASE
       WHEN observation_created THEN incoming_complete
+      WHEN node.reference_only THEN
+        old_properties_complete OR
+        (incoming_complete AND size(old_authoritative_tokens) = 0)
       WHEN replace_properties THEN true
       ELSE false
     END`)
@@ -516,6 +541,7 @@ func factProperties(props map[string]any) map[string]any {
 	delete(out, "observation_dependency_tokens")
 	delete(out, "observation_semantics")
 	delete(out, "observation_properties_complete")
+	delete(out, "observation_reference_tokens")
 	delete(out, "__agenthound_observation_created")
 	return out
 }
@@ -548,6 +574,9 @@ func groupNodesByKindTuple(nodes []ingest.Node) map[string]*nodeKindTuple {
 		key := primary
 		if len(extras) > 0 {
 			key = primary + "+" + strings.Join(extras, ",")
+		}
+		if n.PropertySemantics != "" {
+			key += "\x00" + string(n.PropertySemantics)
 		}
 		group, ok := grouped[key]
 		if !ok {
@@ -588,6 +617,27 @@ func validateWriterNodes(nodes []ingest.Node) error {
 		}
 		if len(normalizedDomains(node.ObservationDomains)) == 0 {
 			return fmt.Errorf("node %d (%s) requires at least one observation domain", i, node.ID)
+		}
+		switch node.PropertySemantics {
+		case "":
+		case ingest.NodePropertySemanticsReferenceOnly:
+			for key := range node.Properties {
+				if key != "objectid" {
+					return fmt.Errorf(
+						"node %d (%s) reference-only observation cannot carry property %q",
+						i,
+						node.ID,
+						key,
+					)
+				}
+			}
+		default:
+			return fmt.Errorf(
+				"node %d (%s) has invalid property semantics %q",
+				i,
+				node.ID,
+				node.PropertySemantics,
+			)
 		}
 	}
 	return nil

--- a/server/internal/graph/writer_test.go
+++ b/server/internal/graph/writer_test.go
@@ -796,6 +796,7 @@ func TestWriterCarriesObservationOwnershipWithoutTrustingReservedProperties(t *t
 	for _, reserved := range []string{
 		"observation_tokens",
 		"observation_properties_complete",
+		"observation_reference_tokens",
 	} {
 		if _, exists := props[reserved]; exists {
 			t.Fatalf("reserved property %q was accepted from artifact", reserved)
@@ -909,6 +910,125 @@ func TestCompleteObservationReplacesManagedProperties(t *testing.T) {
 	}
 	if strings.Contains(call.Cypher, "REMOVE n:SchemaVersion") {
 		t.Fatal("managed replacement removes internal labels")
+	}
+}
+
+func TestReferenceOnlyObservationPreservesAuthoritativeProperties(t *testing.T) {
+	scope := "scan:loot:sha256:reference"
+	recorder := &recordedExec{}
+	writer := newTestWriter(recorder.exec, false)
+	node := ingest.Node{
+		ID:                 "litellm",
+		Kinds:              []string{"LiteLLMGateway", "AIService"},
+		ObservationDomains: []string{scope},
+		Properties:         map[string]any{"objectid": "litellm"},
+		PropertySemantics:  ingest.NodePropertySemanticsReferenceOnly,
+	}
+
+	if _, err := writer.WriteObservationNodes(
+		context.Background(),
+		[]ingest.Node{node},
+		"loot-scan",
+		[]string{scope},
+	); err != nil {
+		t.Fatalf("WriteObservationNodes: %v", err)
+	}
+	call := recorder.snapshot()[0]
+	row := rowsAt(t, call.Params, "nodes")[0]
+	if referenceOnly, _ := row["reference_only"].(bool); !referenceOnly {
+		t.Fatalf("writer row did not preserve reference-only semantics: %+v", row)
+	}
+	properties := propsAt(t, row, "properties")
+	if len(properties) != 1 || properties["objectid"] != "litellm" {
+		t.Fatalf("reference properties = %+v, want objectid only", properties)
+	}
+	for _, fragment := range []string{
+		"old_authoritative_tokens",
+		"AND NOT node.reference_only",
+		"old_properties_complete OR",
+		"n.observation_reference_tokens",
+		"NOT replace_properties AND NOT node.reference_only",
+	} {
+		if !strings.Contains(call.Cypher, fragment) {
+			t.Fatalf("reference-only merge query missing %q:\n%s", fragment, call.Cypher)
+		}
+	}
+}
+
+func TestWriterSeparatesAuthoritativeAndReferenceRows(t *testing.T) {
+	recorder := &recordedExec{}
+	writer := newTestWriter(recorder.exec, false)
+	nodes := []ingest.Node{
+		{
+			ID:                 "shared",
+			Kinds:              []string{"LiteLLMGateway", "AIService"},
+			ObservationDomains: []string{"scan:network:sha256:authoritative"},
+			Properties:         map[string]any{"endpoint": "http://127.0.0.1:4000"},
+		},
+		{
+			ID:                 "shared",
+			Kinds:              []string{"LiteLLMGateway", "AIService"},
+			ObservationDomains: []string{"scan:loot:sha256:reference"},
+			Properties:         map[string]any{"objectid": "shared"},
+			PropertySemantics:  ingest.NodePropertySemanticsReferenceOnly,
+		},
+	}
+
+	if _, err := writer.WriteObservationNodes(
+		context.Background(),
+		nodes,
+		"shared-owner",
+		[]string{
+			"scan:network:sha256:authoritative",
+			"scan:loot:sha256:reference",
+		},
+	); err != nil {
+		t.Fatalf("WriteObservationNodes: %v", err)
+	}
+	calls := recorder.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("mixed property semantics produced %d batches, want 2", len(calls))
+	}
+	var referenceRows, authoritativeRows int
+	for _, call := range calls {
+		for _, row := range rowsAt(t, call.Params, "nodes") {
+			if referenceOnly, _ := row["reference_only"].(bool); referenceOnly {
+				referenceRows++
+			} else {
+				authoritativeRows++
+			}
+		}
+	}
+	if referenceRows != 1 || authoritativeRows != 1 {
+		t.Fatalf(
+			"writer rows: reference=%d authoritative=%d",
+			referenceRows,
+			authoritativeRows,
+		)
+	}
+}
+
+func TestWriterRejectsPropertiesOnReferenceOnlyNode(t *testing.T) {
+	recorder := &recordedExec{}
+	writer := newTestWriter(recorder.exec, false)
+	node := ingest.Node{
+		ID:                 "litellm",
+		Kinds:              []string{"LiteLLMGateway", "AIService"},
+		ObservationDomains: []string{"scan:loot:sha256:reference"},
+		Properties:         map[string]any{"endpoint": "fabricated"},
+		PropertySemantics:  ingest.NodePropertySemanticsReferenceOnly,
+	}
+
+	if _, err := writer.WriteObservationNodes(
+		context.Background(),
+		[]ingest.Node{node},
+		"loot-scan",
+		[]string{"scan:loot:sha256:reference"},
+	); err == nil {
+		t.Fatal("writer accepted properties on a reference-only observation")
+	}
+	if calls := recorder.snapshot(); len(calls) != 0 {
+		t.Fatalf("invalid reference reached graph execution: %+v", calls)
 	}
 }
 

--- a/server/internal/ingest/lifecycle.go
+++ b/server/internal/ingest/lifecycle.go
@@ -124,7 +124,11 @@ func coalesceObservationGraph(graph sdkingest.GraphData) sdkingest.GraphData {
 	}
 	nodeIndex := make(map[string]int, len(graph.Nodes))
 	for _, node := range graph.Nodes {
-		if index, exists := nodeIndex[node.ID]; exists {
+		// Keep authoritative and reference-only observations as separate
+		// writer rows. Collapsing them would incorrectly promote the reference
+		// domains into property authors.
+		key := node.ID + "\x00" + string(node.PropertySemantics)
+		if index, exists := nodeIndex[key]; exists {
 			current := &merged.Nodes[index]
 			current.Kinds = mergeStringsPreservingOrder(current.Kinds, node.Kinds)
 			current.ObservationDomains = sdkingest.MergeObservationDomains(
@@ -141,7 +145,7 @@ func coalesceObservationGraph(graph sdkingest.GraphData) sdkingest.GraphData {
 		}
 		node.Properties = cloneProperties(node.Properties)
 		node.ObservationDomains = sdkingest.MergeObservationDomains(node.ObservationDomains)
-		nodeIndex[node.ID] = len(merged.Nodes)
+		nodeIndex[key] = len(merged.Nodes)
 		merged.Nodes = append(merged.Nodes, node)
 	}
 

--- a/server/internal/ingest/lifecycle_test.go
+++ b/server/internal/ingest/lifecycle_test.go
@@ -152,6 +152,50 @@ func TestCoalesceObservationGraphPreservesAllCurrentOwners(t *testing.T) {
 	}
 }
 
+func TestCoalesceObservationGraphKeepsReferenceOwnersPropertyNeutral(t *testing.T) {
+	authoritativeScope := sdkingest.CanonicalCoverageKey("scan", "network", "127.0.0.1")
+	referenceScope := sdkingest.CanonicalCoverageKey("scan", "loot", "litellm")
+	graph := coalesceObservationGraph(sdkingest.GraphData{
+		Nodes: []sdkingest.Node{
+			{
+				ID:                 "shared",
+				Kinds:              []string{"LiteLLMGateway", "AIService"},
+				Properties:         map[string]any{"endpoint": "http://127.0.0.1:4000"},
+				ObservationDomains: []string{authoritativeScope},
+			},
+			{
+				ID:                 "shared",
+				Kinds:              []string{"LiteLLMGateway", "AIService"},
+				Properties:         map[string]any{},
+				ObservationDomains: []string{referenceScope},
+				PropertySemantics:  sdkingest.NodePropertySemanticsReferenceOnly,
+			},
+		},
+	})
+
+	if len(graph.Nodes) != 2 {
+		t.Fatalf("coalesced mixed-semantics nodes = %+v, want two writer rows", graph.Nodes)
+	}
+	for _, node := range graph.Nodes {
+		switch node.PropertySemantics {
+		case "":
+			if len(node.ObservationDomains) != 1 ||
+				node.ObservationDomains[0] != authoritativeScope ||
+				node.Properties["endpoint"] == nil {
+				t.Fatalf("authoritative observation was changed: %+v", node)
+			}
+		case sdkingest.NodePropertySemanticsReferenceOnly:
+			if len(node.ObservationDomains) != 1 ||
+				node.ObservationDomains[0] != referenceScope ||
+				len(node.Properties) != 0 {
+				t.Fatalf("reference observation gained properties: %+v", node)
+			}
+		default:
+			t.Fatalf("unexpected property semantics %q", node.PropertySemantics)
+		}
+	}
+}
+
 func TestPrepareObservationDomainsRejectsScopeOutsideCoverage(t *testing.T) {
 	declared := sdkingest.CanonicalCoverageKey("mcp", "target", "declared")
 	unrelated := sdkingest.CanonicalCoverageKey("mcp", "target", "unrelated")

--- a/server/internal/ingest/validator.go
+++ b/server/internal/ingest/validator.go
@@ -249,6 +249,7 @@ func (v *Validator) Validate(data *ingest.IngestData) error {
 			declaredCoverage,
 			fmt.Sprintf("graph.nodes[%d].observation_domains", i),
 		)...)
+		errs = append(errs, validateNodePropertySemantics(node, i)...)
 		errs = append(errs, validateCanonicalPropertyKeys(
 			node.Properties,
 			fmt.Sprintf("graph.nodes[%d].properties", i),
@@ -257,9 +258,11 @@ func (v *Validator) Validate(data *ingest.IngestData) error {
 			node.Properties,
 			fmt.Sprintf("graph.nodes[%d].properties", i),
 		)...)
-		errs = append(errs, validateCanonicalNodeProperties(node, i)...)
-		if hasKind(node.Kinds, "Credential") {
-			errs = append(errs, validateCredentialProperties(node.Properties, i)...)
+		if node.PropertySemantics != ingest.NodePropertySemanticsReferenceOnly {
+			errs = append(errs, validateCanonicalNodeProperties(node, i)...)
+			if hasKind(node.Kinds, "Credential") {
+				errs = append(errs, validateCredentialProperties(node.Properties, i)...)
+			}
 		}
 	}
 
@@ -528,6 +531,27 @@ func validateObservationDomains(
 		}
 	}
 	return errs
+}
+
+func validateNodePropertySemantics(node ingest.Node, index int) []FieldError {
+	path := fmt.Sprintf("graph.nodes[%d].property_semantics", index)
+	switch node.PropertySemantics {
+	case "":
+		return nil
+	case ingest.NodePropertySemanticsReferenceOnly:
+		if len(node.Properties) != 0 {
+			return []FieldError{{
+				Path:    fmt.Sprintf("graph.nodes[%d].properties", index),
+				Message: "must be empty when property_semantics is reference_only",
+			}}
+		}
+		return nil
+	default:
+		return []FieldError{{
+			Path:    path,
+			Message: fmt.Sprintf("invalid node property semantics %q", node.PropertySemantics),
+		}}
+	}
 }
 
 func validateObservationSemantics(edge ingest.Edge, index int) []FieldError {

--- a/server/internal/ingest/validator_test.go
+++ b/server/internal/ingest/validator_test.go
@@ -171,6 +171,38 @@ func TestValidatorAcceptsDeclaredObservationDomains(t *testing.T) {
 	}
 }
 
+func TestValidatorAcceptsPropertyNeutralNodeReference(t *testing.T) {
+	data := validIngestData()
+	data.Graph.Nodes[0].Properties = map[string]any{}
+	data.Graph.Nodes[0].PropertySemantics = ingest.NodePropertySemanticsReferenceOnly
+
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("property-neutral node reference rejected: %v", err)
+	}
+}
+
+func TestValidatorRejectsPropertiesOnNodeReference(t *testing.T) {
+	data := validIngestData()
+	data.Graph.Nodes[0].PropertySemantics = ingest.NodePropertySemanticsReferenceOnly
+
+	assertValidationError(
+		t,
+		NewValidator().Validate(data),
+		"graph.nodes[0].properties",
+	)
+}
+
+func TestValidatorRejectsUnknownNodePropertySemantics(t *testing.T) {
+	data := validIngestData()
+	data.Graph.Nodes[0].PropertySemantics = "compatibility"
+
+	assertValidationError(
+		t,
+		NewValidator().Validate(data),
+		"graph.nodes[0].property_semantics",
+	)
+}
+
 func TestValidatorAcceptsAuthoritativeRootActiveSet(t *testing.T) {
 	data := validIngestData()
 	child := data.Meta.Collection.CoverageKeys[0]


### PR DESCRIPTION
## Summary
- add strict-v2 `reference_only` node property semantics so property-neutral owners cannot overwrite authoritative facts
- retain rich LiteLLM fingerprint properties when a later loot artifact adds shared ownership, while clearing stale rich properties if the last authoritative owner retires
- cover the real CLI fingerprint/scan → publication revision 1 → loot → publication revision 2 regression, loot-only publication/query, and writer/reconciliation behavior
- run the full fingerprint → loot → strict validation → publication → guarded query flow serially in both Neo4j 4.4 and 5.x CI matrix legs

## Test plan
- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race`
- [x] `golangci-lint run ./...`
- [x] `make deps-check size-check`
- [x] `SLOP_SKIP=hardcoded-grids make slop-check`
- [x] strict MkDocs build on the clean tracked tree
- [x] live Neo4j authoritative/reference owner retirement integration
- [x] live Neo4j/PostgreSQL LiteLLM fingerprint → loot publication and guarded-query integration

Made with [Cursor](https://cursor.com)