### PR TITLE
fix(collector): propagate float flags and correct MLflow probe

### DIFF
--- a/collector/cli/loot.go
+++ b/collector/cli/loot.go
@@ -328,6 +328,11 @@ func collectModuleExtras(cmd *cobra.Command, m module.Module) map[string]any {
 			if err == nil {
 				out[f.Name] = i
 			}
+		case "float64":
+			fl, err := cmd.Flags().GetFloat64(f.Name)
+			if err == nil {
+				out[f.Name] = fl
+			}
 		default:
 			out[f.Name] = live.Value.String()
 		}

--- a/collector/cli/loot_extras_test.go
+++ b/collector/cli/loot_extras_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/module"
+)
+
+// floatFlagModule is a minimal Looter that contributes a single Float64
+// per-module flag. It mirrors the real embeddinginvert extractor's
+// confidence-threshold flag so the extras path exercises float64 handling
+// exactly as a production module would drive it.
+type floatFlagModule struct{}
+
+func (*floatFlagModule) ID() string            { return "test.floatflags" }
+func (*floatFlagModule) Action() action.Action { return action.Loot }
+func (*floatFlagModule) Target() string        { return "test" }
+func (*floatFlagModule) Description() string   { return "test module with a float flag" }
+func (*floatFlagModule) Version() string       { return "0.0.0" }
+func (*floatFlagModule) IsDestructive() bool   { return false }
+func (*floatFlagModule) RegisterFlags(fs *pflag.FlagSet) {
+	fs.Float64("confidence-threshold", 3.0, "test float flag")
+}
+
+// TestCollectModuleExtras_Float64 is a direct regression guard on the
+// float64 flag propagation fix: a registered Float64 module flag must
+// reach LootOptions.Extras carrying the Go dynamic type float64 (not a
+// string), so looters can type-assert extras["flag"].(float64) without a
+// parse step.
+func TestCollectModuleExtras_Float64(t *testing.T) {
+	mod := &floatFlagModule{}
+
+	t.Run("supplied value propagates as float64", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "loot"}
+		module.RegisterFlagsFor(cmd, mod)
+		if err := cmd.ParseFlags([]string{"--confidence-threshold", "2.5"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+
+		extras := collectModuleExtras(cmd, mod)
+		raw, ok := extras["confidence-threshold"]
+		if !ok {
+			t.Fatalf("extras missing confidence-threshold: %v", extras)
+		}
+		v, ok := raw.(float64)
+		if !ok {
+			t.Fatalf("confidence-threshold dynamic type = %T, want float64", raw)
+		}
+		if v != 2.5 {
+			t.Errorf("confidence-threshold = %v, want 2.5", v)
+		}
+	})
+
+	t.Run("default value propagates as float64 when unset", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "loot"}
+		module.RegisterFlagsFor(cmd, mod)
+		if err := cmd.ParseFlags(nil); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+
+		extras := collectModuleExtras(cmd, mod)
+		v, ok := extras["confidence-threshold"].(float64)
+		if !ok {
+			t.Fatalf("default confidence-threshold dynamic type = %T, want float64", extras["confidence-threshold"])
+		}
+		if v != 3.0 {
+			t.Errorf("default confidence-threshold = %v, want 3.0", v)
+		}
+	})
+
+	t.Run("invalid value is rejected at parse time", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "loot"}
+		module.RegisterFlagsFor(cmd, mod)
+		if err := cmd.ParseFlags([]string{"--confidence-threshold", "not-a-float"}); err == nil {
+			t.Fatal("ParseFlags accepted a non-float value; want error")
+		}
+	})
+}

--- a/modules/mlflowfp/fingerprinter_test.go
+++ b/modules/mlflowfp/fingerprinter_test.go
@@ -13,8 +13,16 @@ import (
 const mlflowBody = `{"experiments":[{"experiment_id":"0","name":"Default"}]}`
 
 func TestFingerprint_MLflowHappy(t *testing.T) {
+	var gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/2.0/mlflow/experiments/search" {
+			gotQuery = r.URL.RawQuery
+			// Stock MLflow (2.22.x+) rejects bare search without max_results.
+			if !strings.Contains(r.URL.RawQuery, "max_results=") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error_code":"INVALID_PARAMETER_VALUE","message":"Missing max_results"}`))
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(mlflowBody))
 			return
@@ -37,5 +45,8 @@ func TestFingerprint_MLflowHappy(t *testing.T) {
 	}
 	if res.ServiceKind != "mlflow" {
 		t.Errorf("ServiceKind = %q, want mlflow", res.ServiceKind)
+	}
+	if !strings.Contains(gotQuery, "max_results=") {
+		t.Errorf("probe query %q missing max_results (would 400 on modern MLflow)", gotQuery)
 	}
 }

--- a/modules/mlflowfp/fingerprinter_test.go
+++ b/modules/mlflowfp/fingerprinter_test.go
@@ -4,23 +4,44 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 )
 
 const mlflowBody = `{"experiments":[{"experiment_id":"0","name":"Default"}]}`
+
+// exactlyOneMaxResultsOne parses the probe's raw query string and reports
+// whether it carries exactly one max_results parameter whose value is "1".
+// Stock MLflow (2.22.x+) rejects experiments/search without a valid
+// max_results, so the probe contract is precise: one key, one value, "1".
+// Parsing (not substring matching) rejects max_results=0, an empty value,
+// duplicate keys, and unrelated keys that merely contain the substring
+// (e.g. max_results_extra=1).
+func exactlyOneMaxResultsOne(rawQuery string) bool {
+	q, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return false
+	}
+	vals, ok := q["max_results"]
+	if !ok || len(vals) != 1 {
+		return false
+	}
+	return vals[0] == "1"
+}
 
 func TestFingerprint_MLflowHappy(t *testing.T) {
 	var gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/2.0/mlflow/experiments/search" {
 			gotQuery = r.URL.RawQuery
-			// Stock MLflow (2.22.x+) rejects bare search without max_results.
-			if !strings.Contains(r.URL.RawQuery, "max_results=") {
+			// Modern MLflow rejects a search without a valid max_results.
+			// Only status behavior matters here, so fail generically.
+			if !exactlyOneMaxResultsOne(r.URL.RawQuery) {
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = w.Write([]byte(`{"error_code":"INVALID_PARAMETER_VALUE","message":"Missing max_results"}`))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -46,7 +67,52 @@ func TestFingerprint_MLflowHappy(t *testing.T) {
 	if res.ServiceKind != "mlflow" {
 		t.Errorf("ServiceKind = %q, want mlflow", res.ServiceKind)
 	}
-	if !strings.Contains(gotQuery, "max_results=") {
-		t.Errorf("probe query %q missing max_results (would 400 on modern MLflow)", gotQuery)
+	if !exactlyOneMaxResultsOne(gotQuery) {
+		t.Errorf("probe query %q is not exactly one max_results=1 (would 400 on modern MLflow)", gotQuery)
+	}
+
+	// The probe proves only what an anonymous experiment-search establishes
+	// about THIS instance: it answered without credentials. That scoped
+	// observation is auth_evidence=anonymous_probe_succeeded, which is what
+	// turns auth_method=none into a supported instance claim downstream
+	// (common.IsConfirmedAnonymousAccess) rather than a product-wide
+	// assertion that MLflow universally lacks authentication.
+	if len(res.IngestData.Graph.Nodes) != 1 {
+		t.Fatalf("emitted %d nodes, want 1", len(res.IngestData.Graph.Nodes))
+	}
+	props := res.IngestData.Graph.Nodes[0].Properties
+	if got := props["auth_method"]; got != string(common.AuthNone) {
+		t.Errorf("auth_method = %v, want %q", got, common.AuthNone)
+	}
+	if got := props["auth_evidence"]; got != common.AuthEvidenceAnonymousProbeSucceeded {
+		t.Errorf("auth_evidence = %v, want %q", got, common.AuthEvidenceAnonymousProbeSucceeded)
+	}
+}
+
+// TestFingerprint_MLflowMaxResultsContract locks the probe-query contract:
+// exactly one max_results=1 is accepted; the substring-adjacent and
+// malformed variants that a naive strings.Contains check would wrongly
+// accept are all rejected.
+func TestFingerprint_MLflowMaxResultsContract(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"exactly one max_results=1", "max_results=1", true},
+		{"missing", "", false},
+		{"zero", "max_results=0", false},
+		{"empty value", "max_results=", false},
+		{"duplicate same value", "max_results=1&max_results=1", false},
+		{"duplicate different value", "max_results=1&max_results=2", false},
+		{"unrelated prefixed key", "foo_max_results=1", false},
+		{"unrelated suffixed key", "max_results_extra=1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exactlyOneMaxResultsOne(tc.query); got != tc.want {
+				t.Errorf("exactlyOneMaxResultsOne(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+		})
 	}
 }

--- a/modules/mlflowfp/register.go
+++ b/modules/mlflowfp/register.go
@@ -21,7 +21,7 @@ func (*Fingerprinter) ID() string            { return "mlflow.fingerprint" }
 func (*Fingerprinter) Action() action.Action { return action.Fingerprint }
 func (*Fingerprinter) Target() string        { return "mlflow" }
 func (*Fingerprinter) Description() string {
-	return "Identify MLflow Tracking Server by GET /api/2.0/mlflow/experiments/search"
+	return "Identify MLflow Tracking Server by GET /api/2.0/mlflow/experiments/search?max_results=1"
 }
 func (*Fingerprinter) Version() string     { return "0.4.0-dev" }
 func (*Fingerprinter) IsDestructive() bool { return false }

--- a/sdk/rules/builtin/fingerprints/mlflow.yaml
+++ b/sdk/rules/builtin/fingerprints/mlflow.yaml
@@ -10,9 +10,13 @@
 # path with INVALID_PARAMETER_VALUE (HTTP 400). Match the looter and
 # the documented probe: ?max_results=1.
 #
-# Auth: MLflow has no built-in auth. Network-perimeter or a reverse
-# proxy is the deployment-time control; default deployments expose the
-# API anonymously, which is what this rule catches.
+# Auth: MLflow ships an optional built-in basic-auth plugin
+# (`mlflow server --app-name basic-auth`) that is OFF by default; a
+# reverse proxy or network perimeter is the other common control. This
+# rule does not assert MLflow universally lacks authentication — it only
+# catches an instance that served the experiment search without
+# credentials, and records that scoped observation as
+# auth_evidence=anonymous_probe_succeeded.
 id: mlflow
 name: MLflow Tracking Server
 description: 'Identifies MLflow by GET /api/2.0/mlflow/experiments/search?max_results=1 returning the canonical experiments JSON'
@@ -33,4 +37,5 @@ emit:
   properties:
     service_kind: mlflow
     auth_method: none
+    auth_evidence: anonymous_probe_succeeded
     is_anonymous_loot: "true"

--- a/sdk/rules/builtin/fingerprints/mlflow.yaml
+++ b/sdk/rules/builtin/fingerprints/mlflow.yaml
@@ -6,17 +6,21 @@
 # which on a default deployment returns:
 #   {"experiments":[...]}  (200 OK, possibly with empty list)
 #
+# max_results is required: modern MLflow (2.22.x+) rejects the bare
+# path with INVALID_PARAMETER_VALUE (HTTP 400). Match the looter and
+# the documented probe: ?max_results=1.
+#
 # Auth: MLflow has no built-in auth. Network-perimeter or a reverse
 # proxy is the deployment-time control; default deployments expose the
 # API anonymously, which is what this rule catches.
 id: mlflow
 name: MLflow Tracking Server
-description: 'Identifies MLflow by GET /api/2.0/mlflow/experiments/search returning the canonical experiments JSON'
-version: 2
+description: 'Identifies MLflow by GET /api/2.0/mlflow/experiments/search?max_results=1 returning the canonical experiments JSON'
+version: 3
 service_kind: mlflow
 probes:
   - method: GET
-    path: /api/2.0/mlflow/experiments/search
+    path: /api/2.0/mlflow/experiments/search?max_results=1
     matchers:
       - type: http_status
         status_code: 200


### PR DESCRIPTION
## Summary
- preserve `float64` module flag values when the CLI builds action extras, so flags such as `--confidence-threshold` reach extractors with their declared type
- add `max_results=1` to the MLflow experiment-search fingerprint probe for current OSS MLflow compatibility
- align MLflow module metadata and regression coverage with the corrected probe

Extracted unchanged from #88 so the offline harness PR can evaluate the collector without also modifying it.

## Test plan
- [x] `gofmt -l .` (no output)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race`