### PR TITLE
[Stack 4/6] Require observed authentication evidence across consumers

### DIFF
--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -173,6 +173,10 @@ replacement/reconciliation/publication for that attempt.
 
 Transformations:
 - Sets `objectid` property to match node `id`
+- Migrates only exact pre-v1 direct-URL MCP anonymous observations (MCP
+  envelope, concrete reachable HTTP server, exact raw anonymous tuple, and no
+  observed fields) into `observed_auth_*`, retaining
+  `auth_observation_compat=pre_v1_raw_mcp` provenance and a typed warning
 - Strips nil values
 - Serializes complex values (nested maps, heterogeneous arrays) to JSON strings
 - Preserves homogeneous arrays (all-string, all-number, all-bool) as native Neo4j lists
@@ -285,7 +289,8 @@ previous immutable PostgreSQL publication.
 The annotations below are each processor's declared `Dependencies() []string` return — the *processor-level* ordering contract enforced by the pipeline. Raw collector edges (`INGESTS_UNTRUSTED`, `DELEGATES_TO`, `HAS_ENV_VAR`, etc.) and pre-existing node properties (`schema_keys`, `auth_method`, …) are Cypher traversal inputs, not processor dependencies — they are present from ingest, so they do not appear here.
 
 ```
- 1. auth_strength                    (deps: none; pre-pass, sets node property)
+ 1. auth_strength                    (deps: none; pre-pass, sets paired effective
+                                     node auth + effective trust-edge assessment)
  2. has_access_to                    (deps: none)
  3. can_execute                      (deps: none)
  4. shadows                          (deps: none; also emits POISONS_CONTEXT)
@@ -293,13 +298,13 @@ The annotations below are each processor's declared `Dependencies() []string` re
  6. poisoned_instructions            (deps: none)
  7. taints                           (deps: none; runs before can_reach so its cross-tool
                                      edges influence transitive reachability)
- 8. can_reach                        (deps: has_access_to)
+ 8. can_reach                        (deps: auth_strength, has_access_to)
  9. cross_service_credential_chain   (deps: has_access_to, can_reach)
 10. ifc_violation                    (deps: has_access_to)
 11. can_exfiltrate                   (deps: can_reach)
 12. can_impersonate                  (deps: none)
 13. confused_deputy                  (deps: auth_strength, can_reach)
-14. cross_protocol                   (deps: has_access_to)
+14. cross_protocol                   (deps: auth_strength, has_access_to)
 15. risk_score                       (deps: has_access_to, can_execute, shadows,
                                      poisoned_description, poisoned_instructions,
                                      can_reach, can_exfiltrate, can_impersonate,

--- a/docs/architecture/post-processors.md
+++ b/docs/architecture/post-processors.md
@@ -7,9 +7,11 @@ All composite edges carry: `scan_id`, `last_seen`, `confidence` (0.0-1.0), `risk
 ## Dependency DAG
 
 ```
-has_access_to ─────┬─── can_reach ────┬── cross_service_credential_chain
-                   │                  └── can_exfiltrate
-                   └─── cross_protocol
+auth_strength ──┬── can_reach ─────┬── cross_service_credential_chain
+                 ├── cross_protocol      └── can_exfiltrate
+                 └── confused_deputy
+has_access_to ───┬── can_reach
+                 └── cross_protocol
 can_execute
 shadows
 poisoned_description
@@ -29,13 +31,13 @@ can_impersonate
 | 5 | poisoned_description | none |
 | 6 | poisoned_instructions | none |
 | 7 | taints | none (reads INGESTS_UNTRUSTED + schema_keys) |
-| 8 | can_reach | has_access_to |
+| 8 | can_reach | auth_strength, has_access_to |
 | 9 | cross_service_credential_chain | has_access_to, can_reach |
 | 10 | ifc_violation | has_access_to (reads INGESTS_UNTRUSTED) |
 | 11 | can_exfiltrate | can_reach |
 | 12 | can_impersonate | none |
 | 13 | confused_deputy | auth_strength, can_reach |
-| 14 | cross_protocol | has_access_to |
+| 14 | cross_protocol | auth_strength, has_access_to |
 | 15 | risk_score | all of 1-14 |
 
 ## Processor Interface
@@ -59,15 +61,42 @@ type PostProcessor interface {
 
 ## auth_strength (pre-pass)
 
-**Computes:** canonical `auth_assurance` on every assessed node and numeric `auth_strength` only for known methods (`MCPServer`, `A2AAgent`).
+**Computes:** a paired effective authentication tuple and numeric
+`auth_strength` on `MCPServer` / `A2AAgent`, plus derived effective assessment
+properties on incoming `TRUSTS_SERVER` edges.
 
-A pre-pass with no dependencies that materializes the shared SDK auth policy:
-none=100/unauthenticated, basic=85/weak, apiKey=70/weak,
+Configured `auth_method` / `auth_assurance` / `auth_evidence` and protocol
+runtime `observed_auth_*` remain immutable provenance. For MCP, a reachable
+HTTP, internally valid observed tuple with a method other than `unknown`
+becomes
+`effective_auth_method`, `effective_auth_assurance`, and
+`effective_auth_evidence`, with `effective_auth_source=observed`. An unknown,
+unavailable, partial, or contradictory observation falls back atomically to
+the configured tuple (`effective_auth_source=configured`); fields are never
+coalesced independently. A2A runtime evidence wins only for the exact bounded
+read-only observation `auth_probe_method=get_task_nonexistent`,
+`auth_probe_status=anonymous_protocol_access`, and observed
+`none/unauthenticated/anonymous_probe_succeeded`, with bounded detail
+`task_not_found_v1` or `task_not_found_v0_3`. Card retrieval, protected or
+inconclusive probe diagnostics, missing metadata, and every other A2A observed
+tuple retain configured-derived behavior.
+
+The evidence-aware policy is none=100/unauthenticated only for an
+`effective_auth_source=observed` tuple carrying
+`anonymous_probe_succeeded`, basic=85/weak, apiKey=70/weak,
 bearer=50/moderate, oauth=25/strong, oidc=20/strong, and mtls=10/strong.
-Unknown/custom methods receive `auth_assurance=unknown` and a null numeric
-property, removing any stale score. It writes only node properties — no
-composite edges — so it needs no `source_collector` and is untouched by
-composite epoch retirement.
+Unknown/custom and configured/unconfirmed-none methods receive
+`effective_auth_assurance=unknown` and a null numeric property.
+
+For each `TRUSTS_SERVER`, the pass writes `effective_risk_weight`,
+`effective_auth_assessment_complete`, and `effective_auth_source`. Exact
+reachable observed `none/unauthenticated/anonymous_probe_succeeded` sets every
+incoming trust edge to `0.1`, complete, source `observed`: anonymous runtime
+access bypasses every configured client credential. Every other runtime
+posture preserves each relationship's own configured `risk_weight` and
+`auth_assessment_complete`, source `configured`; one observed authenticated
+access path cannot rewrite unrelated configured paths. The raw fields are not
+overwritten.
 
 ---
 
@@ -152,23 +181,31 @@ The inferred transitive-access summary edge. Two passes:
 ```
 AgentInstance -[TRUSTS_SERVER]-> MCPServer -[PROVIDES_TOOL]-> MCPTool -[HAS_ACCESS_TO]-> MCPResource
 ```
-Confidence scales inversely with trust edge risk_weight (no-auth trust = 1.0, static-key = 0.8, OAuth = 0.5).
+Confidence scales inversely with the trust edge's `effective_risk_weight`
+(confirmed observed no-auth trust = 1.0, static-key = 0.8, OAuth = 0.5).
 
 **Credential chain (6 hops):**
 ```
 AgentInstance -> MCPServer(s1) -> MCPTool(file_read|credential_access)
-MCPServer(s2) -[HAS_ENV_VAR]-> Credential -> Identity -> MCPServer(s2) -> MCPTool -> MCPResource
+MCPServer(s2) -[AUTHENTICATES_WITH]-> Identity -[USES_CREDENTIAL]-> Credential
+MCPServer(s2) -> MCPTool -> MCPResource
 ```
-Requires explicit unauthenticated/weak evidence for s1. Live MCP initialize
-evidence takes precedence over configuration posture when present; missing
-auth evidence does not match. Confidence: 0.6.
+Requires `effective_auth_assurance` to be explicitly unauthenticated or weak
+for s1. Unauthenticated is eligible only when
+`effective_auth_source=observed`; configured weak authentication remains
+eligible. The paired effective tuple applies valid live MCP initialize evidence
+as described above; missing/unknown auth evidence does not match. The credential
+may come from any supported config location; it must have non-empty observed, exposed material with
+`merge_key=value_hash` and `identity_basis=value_hash`. Confidence: 0.6.
 
 When multiple credential paths connect the same `(agent, resource)`, the
 processor orders candidates by the complete stable object-ID tuple
-`(a, s1, t1, s2, c, i, t2, r)` and selects the first before `MERGE`.
+`(a, s1, t1, s2, i, c, t2, r)` and selects the first before `MERGE`.
 Neo4j relationship IDs are retained only as post-selection evidence and never
 participate in winner selection, so witness topology cannot flip with
-relationship recreation order.
+relationship recreation order. Evidence nodes follow that tuple, and evidence
+relationships follow `(TRUSTS_SERVER, PROVIDES_TOOL, AUTHENTICATES_WITH,
+USES_CREDENTIAL, PROVIDES_TOOL, HAS_ACCESS_TO)`.
 
 **Verified-reach upgrade (3rd pass):** after building the CAN_REACH edges,
 `can_reach` re-correlates any persisted per-agent raw
@@ -273,12 +310,14 @@ cannot express:
 MATCH (ext:A2AAgent)-[:DELEGATES_TO*1..3]->(int:A2AAgent)
 MATCH (int)-[:RUNS_ON]->(h:Host)<-[:RUNS_ON]-(s:MCPServer)
 MATCH (a:AgentInstance)-[:TRUSTS_SERVER]->(s)-[:PROVIDES_TOOL]->(t:MCPTool)-[:HAS_ACCESS_TO]->(r:MCPResource)
-WHERE ext.auth_assurance = 'unauthenticated'
-  AND ext.auth_evidence = 'anonymous_probe_succeeded'
+WHERE ext.effective_auth_assurance = 'unauthenticated'
+  AND ext.effective_auth_source = 'observed'
+  AND ext.effective_auth_evidence = 'anonymous_probe_succeeded'
 ```
 
-Requires explicit unauthenticated evidence for the external A2A agent; missing
-auth is unknown and does not match. The pivot is host co-location: an A2A
+Requires exact, observed unauthenticated evidence for the external A2A agent;
+configured no-auth claims and missing auth are not runtime proof and do not
+match. The pivot is host co-location: an A2A
 agent delegates to another agent recorded on the same host as an MCP server.
 The edge carries `cross_protocol=true` and confidence 0.5. Finding and pre-built
 query output label it a `shared_host` hypothesis, not proven A2A-to-MCP
@@ -288,9 +327,11 @@ invocation.
 
 **Computes:** `A2AAgent -[CONFUSED_DEPUTY]-> A2AAgent`
 
-Flags a confused-deputy escalation when an unauthenticated/weak A2A agent
-`DELEGATES_TO` a strong one. Unknown/custom methods are excluded. The low-trust
-caller effectively borrows the callee's privileges. Depends on the
+Flags a confused-deputy escalation when an unauthenticated or weak A2A agent
+`DELEGATES_TO` a strong one. Unauthenticated callers require
+`effective_auth_source=observed`; configured weak callers remain eligible.
+Unknown/custom methods are excluded. The low-trust caller effectively borrows
+the callee's privileges. Depends on the
 `auth_strength` pre-pass and `can_reach` (ordering).
 `source_collector='a2a'`; confidence 0.8, risk weight 0.3.
 

--- a/docs/operator/attack-paths.md
+++ b/docs/operator/attack-paths.md
@@ -257,18 +257,25 @@ The `can_impersonate` processor computes TF-IDF cosine similarity over A2A skill
 
 ### `CONFUSED_DEPUTY`
 
-The `auth_strength` pre-pass writes canonical categorical `auth_assurance` and,
-when supported by evidence, a numeric weakness score. An explicit
-`auth_method=none` is unauthenticated only when
-`auth_evidence=anonymous_probe_succeeded`; unknown/custom methods remain
-unknown.
+The `auth_strength` pre-pass preserves collector-owned configured and observed
+fields, then writes one paired `effective_auth_*` tuple and, when supported by
+evidence, a numeric weakness score. An effective `auth_method=none` is
+unauthenticated only when paired with
+`auth_evidence=anonymous_probe_succeeded` and
+`effective_auth_source=observed`; configured none claims and unknown/custom
+methods remain
+unknown. A2A card enumeration alone does not prove anonymous protocol access.
+Only an exact task-not-found result from the bounded read-only nonexistent-task
+lookup authors A2A observed anonymous evidence; protected and inconclusive
+outcomes retain configured card posture. This observation does not claim
+anonymous task creation or message execution.
 
 The `confused_deputy` processor emits `CONFUSED_DEPUTY` when a weakly authenticated A2A agent delegates to a strongly authenticated one:
 
 ```text
-(:A2AAgent {auth_assurance: "unauthenticated|weak"})
+(:A2AAgent {effective_auth_assurance: "unauthenticated|weak"})
   -[:CONFUSED_DEPUTY]->
-(:A2AAgent {auth_assurance: "strong"})
+(:A2AAgent {effective_auth_assurance: "strong"})
 ```
 
 This models a low-trust caller borrowing the privileges of a higher-trust callee.
@@ -324,20 +331,20 @@ Processors run in dependency order. A processor may only read edges or propertie
 
 | # | Processor | Produces | Dependencies |
 |---|-----------|----------|--------------|
-| 1 | `auth_strength` | `auth_strength` node property | None |
+| 1 | `auth_strength` | paired node `effective_auth_*`, `auth_strength`, and effective `TRUSTS_SERVER` assessment properties | None |
 | 2 | `has_access_to` | `HAS_ACCESS_TO` | Raw edges |
 | 3 | `can_execute` | `CAN_EXECUTE` | Raw edges |
 | 4 | `shadows` | `SHADOWS`, `POISONS_CONTEXT` | Raw edges |
 | 5 | `poisoned_description` | `POISONED_DESCRIPTION` | Raw edges |
 | 6 | `poisoned_instructions` | `POISONED_INSTRUCTIONS` | Raw edges |
 | 7 | `taints` | `TAINTS` | `INGESTS_UNTRUSTED`, `schema_keys` |
-| 8 | `can_reach` | `CAN_REACH` | `HAS_ACCESS_TO` |
+| 8 | `can_reach` | `CAN_REACH` | `auth_strength`, `HAS_ACCESS_TO` |
 | 9 | `cross_service_credential_chain` | `CAN_REACH` to upstream credentials, `Credential.blast_radius` | `HAS_ACCESS_TO`, `CAN_REACH`, `value_hash` |
 | 10 | `ifc_violation` | `IFC_VIOLATION` | `HAS_ACCESS_TO`, `INGESTS_UNTRUSTED` |
 | 11 | `can_exfiltrate` | `CAN_EXFILTRATE_VIA` | `CAN_REACH` |
 | 12 | `can_impersonate` | `CAN_IMPERSONATE` | Raw edges |
 | 13 | `confused_deputy` | `CONFUSED_DEPUTY` | `auth_strength`, `CAN_REACH` |
-| 14 | `cross_protocol` | Cross-protocol `CAN_REACH` | `HAS_ACCESS_TO`, `DELEGATES_TO` |
+| 14 | `cross_protocol` | Cross-protocol `CAN_REACH` | `auth_strength`, `HAS_ACCESS_TO`, `DELEGATES_TO` |
 | 15 | `risk_score` | `risk_score` node property | Prior processors |
 
 Each post-processor is idempotent. Promoting any complete raw scope retires the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -244,6 +244,15 @@ omit `observed_auth_*`; orphan positive status, partial/wrongly typed metadata,
 arbitrary status/detail, generic observed tuples, and observed fields on a
 non-positive status return `400 VALIDATION_ERROR`.
 
+Normalization preserves pre-v1 direct-URL MCP artifacts that predate the
+configured/observed split. Only an envelope with `meta.collector=mcp` and a
+concrete reachable HTTP `MCPServer` whose raw tuple is exactly
+`none/unauthenticated/anonymous_probe_succeeded` and whose three
+`observed_auth_*` fields are all absent is migrated. The tuple is copied to
+`observed_auth_*` and marked `auth_observation_compat=pre_v1_raw_mcp`; Config,
+A2A, declaration-only, unknown, unreachable, stdio, reference-only, and partial
+observed near-misses are never migrated.
+
 Campaign submissions add a scenario-specific prevalidation stage immediately
 after generic validation and before normalization, `BeginScan`, graph writes, or
 coverage reconciliation. Both positive and negative artifacts must match their
@@ -406,7 +415,12 @@ Find the bounded minimum-risk-weight path with one deployment-independent
 algorithm. APOC availability does not change results. Missing `risk_weight`
 fails the request; negative or non-finite values also fail. The response
 includes `metadata.algorithm: "bounded-min-weight"` and traversal completeness
-metadata.
+metadata. On a `TRUSTS_SERVER` hop, the returned edge `risk_weight` is the
+derived effective trust weight (falling back to the raw configured weight only
+for a pre-materialization legacy relationship), and the path `weight` sums
+that same returned value. Exact finding-detail path costs follow the same rule
+while retaining both raw `risk_weight` and `effective_risk_weight` in edge
+properties for provenance.
 
 ### Explicit topology traversal *(Origin-gated)*
 
@@ -571,6 +585,12 @@ Like findings, pre-built queries carry an optional `atlas_map` (`[]string`) of [
 `projection` is required on every result. The `shortest-to-database` result
 also requires traversal `metadata`; other pre-built results omit it. An
 unavailable or changing projection returns `409 PROJECTION_CONFLICT`.
+
+Authentication columns in `agents-shell-access`, `no-auth-servers`,
+`no-auth-a2a`, and `chokepoint-servers` are effective post-analysis values.
+Where returned, `auth_source` is `observed` or `configured`; configured and
+observed node properties remain separately available through graph endpoints
+and raw Cypher.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -145,6 +145,20 @@ retain their OR-of-AND structure and scopes; a declared scheme is inactive until
 referenced by a requirement, and `auth_method` remains `unknown` when a scalar
 method would be ambiguous.
 
+After parsing, the collector performs at most one anonymous, read-only
+nonexistent-task lookup per canonical preferred protocol endpoint. It uses v1
+`GetTask` with the advertised `A2A-Version` header or v0.3 `tasks/get`, never
+`message/send`, cancellation, or push-configuration methods. The probe sends
+neither `--auth-token` nor any other credential, rejects redirects, reads at
+most 64 KiB, and runs for at most five seconds (or the shorter collector
+timeout). A card cannot expand scan scope: the preferred interface must be a
+conformant HTTP(S) JSON-RPC URL whose exact scheme/host/effective-port origin
+matches at least one requested target and contains no userinfo, query, or
+fragment bytes. Query-bearing interfaces fail closed because even an
+innocently named parameter could carry authentication material. Aliases sharing that canonical endpoint
+reuse one result. Cross-origin, non-preferred, unsupported, malformed, or
+otherwise ambiguous interfaces remain diagnostic `unknown` observations.
+
 Only v1.0.1 cards have a defined signing algorithm. Their ProtoJSON
 presence/default rules are applied before RFC 8785 JCS and object-form JWS
 verification. Keys resolve first from `--a2a-trusted-keys`, then from the
@@ -272,6 +286,11 @@ agenthound loot <host:port> --type <kind> [flags]
 |------|---------|-------------|
 | `--include-embeddings` | `false` | Issue one test embedding call via `POST /api/embeddings` with `keep_alive: 0` (evicts the runner immediately after the probe per Ollama `server/sched.go:389-398`; consumes compute). |
 
+The Ollama Looter records verified anonymous access only after credential-free
+`GET /api/tags` returns a JSON object with a `models` array. HTTP denial,
+transport failure, malformed JSON, or a 2xx body without that array leaves only
+the neutral service identity and `loot_observed` attempt fact.
+
 > Ollama's HTTP API does not expose a raw-weight download endpoint. See [Ollama loot](../operator/loot/ollama.md#getting-raw-weights-out-of-band) for how to obtain the GGUF weight file out-of-band when the engagement needs it.
 
 #### Per-Module Flags: `--type openwebui`
@@ -288,7 +307,7 @@ agenthound loot <host:port> --type <kind> [flags]
 | `--points-per-collection` | `100` | Cap on payloads sampled per collection when `--include-points` is set. |
 | `--max-total-resources` | `5000` | Global cap on `:MCPResource` nodes emitted across all collections (prevents runaway on large deployments). |
 
-Without `--include-points` the Qdrant Looter is pure-GET (`GET /collections` + `GET /collections/{name}`), folding `collection_count`, `collections`, `total_points`, `points_count_unknown`, and `anonymous_listing` onto the `QdrantInstance` node with no Credential nodes.
+Without `--include-points` the Qdrant Looter is pure-GET (`GET /collections` + `GET /collections/{name}`), folding `collection_count`, `collections`, `total_points`, `points_count_unknown`, and `anonymous_listing` onto the `QdrantInstance` node with no Credential nodes. Those inventory and verified-anonymous properties are added only after credential-free `/collections` returns `status=ok` with a `result.collections` array; denial, transport failure, malformed JSON, and wrong-shaped 2xx responses leave a neutral attempt node.
 
 #### Per-Module Flags: `--type jupyter`
 
@@ -300,7 +319,7 @@ The Jupyter Looter is pure-GET. It first tries `GET /api/sessions` and root `GET
 
 #### `--type mlflow` — coverage note
 
-The MLflow Looter enumerates experiments + runs (paginated via `max_results` / `next_page_token` — modern MLflow rejects `experiments/search` without `max_results`) plus the Model Registry: `registered-models/search`, `model-versions/search`, and per-version `get-download-uri`. Each returned artifact URI is emitted as an `:MCPResource` joined to `MLflowServer` via `PROVIDES_RESOURCE`, with `sensitivity` auto-classified by scheme + path (see the [artifact sensitivity heuristic in graph-model.md](graph-model.md)). No new flag; the Model Registry probes are anonymous-readable on stock MLflow deployments.
+The MLflow Looter enumerates experiments + runs (paginated via `max_results` / `next_page_token` — modern MLflow rejects `experiments/search` without `max_results`) plus the Model Registry: `registered-models/search`, `model-versions/search`, and per-version `get-download-uri`. Each returned artifact URI is emitted as an `:MCPResource` joined to `MLflowServer` via `PROVIDES_RESOURCE`, with `sensitivity` auto-classified by scheme + path (see the [artifact sensitivity heuristic in graph-model.md](graph-model.md)). No new flag; the Model Registry probes are anonymous-readable on stock MLflow deployments. Verified anonymous evidence is added only after the credential-free experiments-search response contains an `experiments` array; denial, transport failure, malformed JSON, and wrong-shaped 2xx responses retain only neutral attempt facts.
 
 #### Example
 

--- a/docs/reference/detection-rules.md
+++ b/docs/reference/detection-rules.md
@@ -141,9 +141,35 @@ MCPTool:dangerous-tool has injection pattern: "ignore all previous instructions"
 **What:** Network MCP servers that accepted a probe without credentials.
 
 **How detected:** Direct probes emit canonical auth evidence. A no-auth query
-requires both `auth_method: none` and
-`auth_evidence: anonymous_probe_succeeded`; configuration with no credential,
-local stdio transport, missing evidence, and `unknown` posture do not match.
+requires the paired effective tuple
+`effective_auth_method: none`, `effective_auth_assurance: unauthenticated`,
+`effective_auth_evidence: anonymous_probe_succeeded`, and (for MCP)
+`effective_auth_source: observed`. Configuration with no credential, local
+stdio transport, missing evidence, and `unknown` posture do not match. The
+server rejects partial/mismatched observed tuples before graph writes. A
+successful MCP Initialize is anonymous evidence only when its URL has no
+userinfo/query and it used no non-empty caller-configured header. Recognized
+auth headers retain their method; every other non-empty header is fail-closed
+as unknown configured request material, including cookies, opaque session
+headers, and conventionally benign header names. No second Initialize is sent.
+
+`no-auth-a2a` is fail-closed under the same evidence rule. Card retrieval alone
+records only declared or unknown authentication posture. The collector then
+performs one bounded read-only lookup for a cryptographically random
+nonexistent task. Only the protocol's exact task-not-found result emits
+`auth_probe_method=get_task_nonexistent`,
+`auth_probe_status=anonymous_protocol_access`, and observed
+`none/unauthenticated/anonymous_probe_succeeded`, with a version-specific fixed
+task-not-found detail. The request is credential-free, redirect-free, bounded
+to 64 KiB and at most five seconds, and restricted to a preferred conformant
+HTTP(S) JSON-RPC interface on the exact origin of a requested target. Canonical
+endpoint deduplication makes aliases share one result; interface userinfo,
+query, and fragment bytes fail closed so the request cannot inherit embedded
+credentials. HTTP 401/403 and every
+inconclusive transport/protocol result omit the observed tuple and do not
+match. This proves anonymous access to the A2A protocol handler; it does not
+claim that message submission, task creation, or every advertised skill is
+anonymously executable.
 
 **Risk:** Confirmed anonymous network access removes an authentication boundary
 for reachable clients. A local stdio child process is a separate process-local
@@ -288,7 +314,13 @@ Keyword sets are kept deliberately narrow — universal taint destroys signal.
 
 **What:** A weakly-authenticated A2A agent can drive a strongly-authenticated one through delegation, borrowing its privileges.
 
-**How detected:** The `auth_strength` pre-pass materializes both canonical `auth_assurance` and a numeric weakness only for known methods. The `confused_deputy` post-processor requires an unauthenticated/weak caller and a strong callee. Unknown/custom methods have no numeric weakness and cannot satisfy either side.
+**How detected:** The `auth_strength` pre-pass preserves configured auth
+provenance and materializes a paired `effective_auth_*` tuple plus a numeric
+weakness only for supported evidence. The `confused_deputy` post-processor
+requires a strong effective callee and either a weak effective caller or an
+unauthenticated effective caller with `effective_auth_source=observed`.
+Configured no-auth claims without accepted runtime evidence, unknown methods,
+and custom methods cannot satisfy the low-trust side.
 
 **Risk:** The anonymous or low-trust caller effectively escalates to the callee's privilege level — a classic confused-deputy escalation across an agent trust boundary.
 
@@ -362,7 +394,11 @@ same host. The correlation is represented as `CAN_REACH`, but carries
 
 **What:** Servers or tools that, if compromised, would impact a disproportionately large number of agents or resources.
 
-**How detected:** The `chokepoint-servers` query finds MCP servers trusted by multiple agents. The `chokepoint-tools` query finds tools with access to many resources.
+**How detected:** The `chokepoint-servers` query finds MCP servers trusted by
+multiple agents and returns their effective auth method, assurance, evidence,
+and source so configured posture cannot mask a confirmed runtime anonymous
+observation. The `chokepoint-tools` query finds tools with access to many
+resources.
 
 **Risk:** Chokepoints are high-value targets. Compromising one chokepoint server may grant access to every agent that trusts it.
 

--- a/docs/reference/edges/can-reach.md
+++ b/docs/reference/edges/can-reach.md
@@ -16,20 +16,20 @@ Meaning: the source agent has a viable path through trusted servers and their to
 
 ## Computation
 
-The `can_reach` post-processor runs after `has_access_to` (its only dependency) and produces two variants:
+The `can_reach` post-processor runs after `auth_strength` and `has_access_to`
+and produces two variants:
 
 ### Direct Path (3 hops)
 
 ```cypher
 MATCH (a:AgentInstance)-[ts:TRUSTS_SERVER]->(s:MCPServer)
       -[:PROVIDES_TOOL]->(t:MCPTool)-[:HAS_ACCESS_TO]->(r:MCPResource)
-WHERE NOT EXISTS((a)-[:CAN_REACH]->(r))
 MERGE (a)-[e:CAN_REACH]->(r)
 SET e.hops = 3,
     e.via_server = s.name,
     e.via_tool = t.name,
-    e.confidence = CASE WHEN ts.risk_weight <= 0.1 THEN 1.0
-                        WHEN ts.risk_weight <= 0.3 THEN 0.8
+    e.confidence = CASE WHEN ts.effective_risk_weight <= 0.1 THEN 1.0
+                        WHEN ts.effective_risk_weight <= 0.3 THEN 0.8
                         ELSE 0.5 END
 ```
 
@@ -40,14 +40,29 @@ Confidence decreases as the trust edge auth strengthens — a server behind mTLS
 ```cypher
 MATCH (a:AgentInstance)-[:TRUSTS_SERVER]->(s1:MCPServer)-[:PROVIDES_TOOL]->(t1:MCPTool)
 WHERE ANY(cap IN t1.capability_surface WHERE cap IN ['file_read', 'credential_access'])
-MATCH (s2:MCPServer)-[:HAS_ENV_VAR]->(c:Credential)
-MATCH (c)<-[:USES_CREDENTIAL]-(i:Identity)<-[:AUTHENTICATES_WITH]-(s2)
+MATCH (s2:MCPServer)-[:AUTHENTICATES_WITH]->(i:Identity)-[:USES_CREDENTIAL]->(c:Credential)
 MATCH (s2)-[:PROVIDES_TOOL]->(t2:MCPTool)-[:HAS_ACCESS_TO]->(r:MCPResource)
 WHERE s1 <> s2
-      AND (s1.auth_method IS NULL OR s1.auth_method IN ['none', 'apiKey'])
+  AND (
+    (s1.effective_auth_assurance = 'unauthenticated'
+      AND s1.effective_auth_source = 'observed')
+    OR s1.effective_auth_assurance = 'weak'
+  )
+  AND c.value_hash IS NOT NULL AND c.value_hash <> ''
+  AND c.merge_key = 'value_hash'
+  AND c.identity_basis = 'value_hash'
+  AND c.material_status = 'observed'
+  AND c.exposure_status = 'exposed'
 ```
 
-This variant models: "agent has a tool that can read credentials, and those credentials authenticate to a second server with access to additional resources." Fixed confidence: 0.6.
+This variant models: "agent has a tool that can read credentials, and observed,
+exposed credential material authenticates to a second server with access to
+additional resources." The canonical identity topology applies to every config
+location; `HAS_ENV_VAR` is only optional location evidence and is not required.
+An unauthenticated first server is eligible only when its effective auth source
+is an accepted runtime observation. Configured weak authentication remains
+eligible, while a configured no-auth claim without runtime proof does not.
+Fixed confidence: 0.6.
 
 ---
 
@@ -60,10 +75,16 @@ MATCH (ext:A2AAgent)-[:DELEGATES_TO*1..3]->(int:A2AAgent)
 MATCH (int)-[:RUNS_ON]->(h:Host)<-[:RUNS_ON]-(s:MCPServer)
 MATCH (a:AgentInstance)-[:TRUSTS_SERVER]->(s)
       -[:PROVIDES_TOOL]->(t:MCPTool)-[:HAS_ACCESS_TO]->(r:MCPResource)
-WHERE (ext.auth_method = 'none' OR ext.auth_method IS NULL)
+WHERE ext.effective_auth_assurance = 'unauthenticated'
+  AND ext.effective_auth_source = 'observed'
+  AND ext.effective_auth_evidence = 'anonymous_probe_succeeded'
 ```
 
-This models an unauthenticated A2A agent delegating through a chain that lands on the same host as an MCP server — host correlation bridges the protocol boundary. This is the path class that no single-protocol scanner can find.
+This models a runtime-confirmed anonymous A2A agent delegating through a chain
+that lands on the same host as an MCP server — host correlation bridges the
+protocol boundary. A missing auth tuple or configured no-auth claim alone does
+not satisfy the correlation. This is the path class that no single-protocol
+scanner can find.
 
 ---
 
@@ -88,7 +109,8 @@ This models an unauthenticated A2A agent delegating through a chain that lands o
 ## Operator Guidance
 
 1. Sort CAN_REACH findings by target resource sensitivity (critical > high > medium).
-2. Prioritize paths where the agent's trust edge has `risk_weight <= 0.1` (no auth).
+2. Prioritize paths where the agent's trust edge has
+   `effective_risk_weight <= 0.1` (runtime-confirmed no auth).
 3. Cross-protocol paths (`cross_protocol = true`) represent novel attack surface — review host co-location.
 4. Credential chain paths indicate lateral movement potential — rotate exposed credentials.
 

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -20,29 +20,29 @@ These are the node kinds accepted in ingest input (`sdk/ingest.AllowedNodeKinds`
 
 | Label | Source | Key Properties |
 |-------|--------|----------------|
-| `MCPServer` | Config + MCP | configured `name`, live `server_name`, `endpoint`, `transport` (stdio/http), configured `auth_method`/`auth_assurance`/`auth_evidence`, live `observed_auth_method`/`observed_auth_assurance`/`observed_auth_evidence`, `auth_strength` (numeric weakness only when known, post-processor), `protocol_version`, `instructions`, `instructions_hash` (SHA-256), `capabilities`, `pinning_status`, `is_pinned` (only when known), `id_scheme`, `has_tasks_capability` |
+| `MCPServer` | Config + MCP | deterministic safe `name`, live `server_name`, `transport` (stdio/http), configured `auth_method`/`auth_assurance`/`auth_evidence`, live `observed_auth_method`/`observed_auth_assurance`/`observed_auth_evidence`, derived paired `effective_auth_method`/`effective_auth_assurance`/`effective_auth_evidence`/`effective_auth_source`, `auth_strength` (numeric weakness only when known, post-processor), `protocol_version`, `instructions`, `instructions_hash` (SHA-256), `capabilities`, `pinning_status`, `is_pinned` (only when known), `id_scheme`; stdio `command`, ordered `arg_hashes`, `arg_count`; HTTP sanitized `endpoint`, `endpoint_userinfo_redacted`, `endpoint_query_redacted`, `endpoint_fragment_redacted` when applicable; MCP-discovery `configured_names`; `has_tasks_capability` (`true` for a non-null raw tasks object, `false` when the raw key is absent, omitted when raw presence is unavailable or ambiguous) |
 | `MCPTool` | MCP | `name`, `description`, `input_schema`, `output_schema`, `annotations`, `description_hash` (SHA-256), `input_schema_hash` (SHA-256), `schema_keys[]`, `capability_surface[]`, `source_trust` (untrusted_web/email/fileshare), `has_injection_patterns`, `has_cross_references` |
-| `MCPResource` | MCP | `uri`, `name`, `mime_type`, `size`, `uri_scheme`, `sensitivity` (`critical`/`high`/`medium`/`low`/`none`/`unknown`), `sensitivity_rule_id`, `sensitivity_evidence` |
+| `MCPResource` | MCP | `uri`, `name`, `mime_type`, `size` (bytes; omitted when the SDK reports zero because its scalar model cannot distinguish an omitted size from an explicit zero), `uri_scheme`, `sensitivity` (`critical`/`high`/`medium`/`low`/`none`/`unknown`), `sensitivity_rule_id`, `sensitivity_evidence` |
 | `MCPPrompt` | MCP | `name`, `description`, `arguments` |
-| `A2AAgent` | A2A | `name`, `description`, `url`, `provider`, `version`, `card_schema_version`, `card_present_fields`, `card_conformant`, `card_conformance_errors`, ordered `interfaces`, `protocol_versions`, `capabilities`, `security_schemes`, OR-of-AND `security_requirements`, `auth_method`, `auth_assurance`, `auth_evidence`, `auth_strength` (numeric only when known), `is_https`, `is_signed`, `signature_verification_status`, `signature_key_source`, `signature_key_trust`, `card_hash` |
+| `A2AAgent` | A2A | `name`, `description`, `url`, `provider`, `version`, `card_schema_version`, `card_present_fields`, `card_conformant`, `card_conformance_errors`, ordered `interfaces`, `protocol_versions`, `capabilities`, `security_schemes`, OR-of-AND `security_requirements`, configured `auth_method`/`auth_assurance`/`auth_evidence`, bounded read-only `auth_probe_method`/`auth_probe_status`/`auth_probe_detail` diagnostics and exact-positive `observed_auth_method`/`observed_auth_assurance`/`observed_auth_evidence`, derived paired `effective_auth_method`/`effective_auth_assurance`/`effective_auth_evidence`/`effective_auth_source`, `auth_strength` (numeric only when known), `is_https`, `is_signed`, `signature_verification_status`, `signature_key_source`, `signature_key_trust`, `card_hash` |
 | `A2ASkill` | A2A | `id`, `name`, `description`, `input_modes`, `output_modes`, `security_requirements`, `conformant`, `conformance_errors`, `description_hash`, `has_injection_patterns` |
 | `AgentInstance` | Config | `name`, `framework`, `config_path` |
-| `Identity` | Config + MCP | `type` (none/apiKey/oauth/bearer/mtls), `scope`, `is_static` |
-| `Credential` | Config + LiteLLM/Open WebUI Looters | `type`, `name`, `source`, required `merge_key` (`value_hash`/`identity`), `identity_basis` (`value_hash`/`provider_name`/`metadata`/`unknown`), `material_status` (`observed`/`masked`/`hashed`/`unobserved`/`unknown`), `exposure_status` (`exposed`/`not_observed`/`unknown`), `high_entropy`, `format`, `value_hash`, `blast_radius` |
+| `Identity` | Config + MCP | `type` (none/apiKey/oauth/bearer/mtls), server-identity `scope`, `is_static` |
+| `Credential` | Config + LiteLLM/Open WebUI Looters | `type`, `name`, `source`, Config `location` (`env`, `header`, `arg:<index>`, or redacted URL component), required `merge_key` (`value_hash`/`identity`), `identity_basis` (`value_hash`/`provider_name`/`metadata`/`unknown`), `material_status` (`observed`/`masked`/`hashed`/`unobserved`/`unknown`), `exposure_status` (`exposed`/`not_observed`/`unknown`), `high_entropy`, `format`, `value_hash`, `blast_radius` |
 | `Host` | Config + A2A + MCP | `hostname`, `ip`, `scope` (`local`/`private`/`public`/`unknown`) |
 | `ConfigFile` | Config | `path`, sorted `clients`, singular `client` only for one applicable client, unique enabled `server_count` |
 | `InstructionFile` | Config | `path`, `type` (agents.md/claude.md/cursorrules/copilot-instructions/memory.md/cursor-rule), `hash`, `is_suspicious` |
-| `OllamaInstance` | Network scan + Ollama fingerprinter + Open WebUI config | `endpoint`, `version`, observed `auth_method`, `probe_status` (`configured_unverified`/`verified`/`failed`/`unknown`), `last_verified_at`, `configuration_observed`, `configured_via`, `configured_auth_method`, `is_anonymous_loot`, `discovered_via` |
+| `OllamaInstance` | Network scan + Ollama fingerprinter + Ollama Looter + Open WebUI config | `endpoint`, `version`, observed `auth_method`/`auth_assurance`/`auth_evidence`, active-probe `probe_status` (`verified`/`failed`/`unknown`), `last_verified_at`, `loot_observed`, `configuration_observed`, `configured_via`, `configured_auth_method`, `is_anonymous_loot`, active-discovery `discovered_via`. Direct loot sets `loot_observed` and does not overwrite discovery provenance; it adds verified anonymous evidence only after a credential-free `/api/tags` response contains the canonical `models` array. Open WebUI configuration references intentionally omit probe status and active-discovery provenance so a later direct Ollama observation can merge without being overwritten. |
 | `VLLMInstance` | Network scan + vLLM fingerprinter | `endpoint`, upstream `version`, `auth_method` (`unknown` from fingerprinting) |
-| `QdrantInstance` | Network scan + Qdrant fingerprinter + Qdrant Looter | `endpoint`, `version`, `collection_count`, `collections` (sorted names), `total_points`, `anonymous_listing` (Looter-enriched) |
-| `MLflowServer` | Network scan + MLflow fingerprinter | `endpoint`, `version`, `experiment_count` |
+| `QdrantInstance` | Network scan + Qdrant fingerprinter + Qdrant Looter | `endpoint`, `version`, `loot_observed`, successful-inventory `auth_method`/`auth_assurance`/`auth_evidence`, `probe_status`, `last_verified_at`, `is_anonymous_loot`, `collection_count`, `collections` (sorted names), `total_points`, `anonymous_listing`. The Looter adds the anonymous and inventory properties only after a credential-free `status=ok` response with a `result.collections` array. |
+| `MLflowServer` | Network scan + MLflow fingerprinter + MLflow Looter | `endpoint`, `version`, `loot_observed`, successful-inventory `auth_method`/`auth_assurance`/`auth_evidence`, `probe_status`, `last_verified_at`, `is_anonymous_loot`, `experiment_count`. The Looter adds the anonymous and inventory properties only after a credential-free experiments-search response with an `experiments` array. |
 | `LiteLLMGateway` | Network scan + LiteLLM fingerprinter | `endpoint`, `auth_method`, `is_anonymous_loot`, `docs_enabled` |
 | `JupyterServer` | Network scan + Jupyter fingerprinter + Jupyter Looter | `endpoint`, fingerprint-owned `version`, `status_access`, `status_anonymous_access`, `fingerprint_detector_id`, `fingerprint_detector_version`, `fingerprint_detector_source`; Looter-owned `sessions_access`, `contents_access`, `auth_required` (only when known), observed `auth_method`, `auth_assurance`, `auth_evidence`, `anonymous_access_observed`, `is_anonymous_loot` |
 | `LangServeApp` | Network scan + LangServe fingerprinter | `endpoint`, `chains` |
-| `OpenWebUIInstance` | Network scan + Open WebUI fingerprinter + Open WebUI Looter | `endpoint`, `version`, `signup_enabled`, `auth_required`, `ollama_backend_urls` (canonicalized list, Looter-enriched from admin `/ollama/config`) |
+| `OpenWebUIInstance` | Network scan + Open WebUI fingerprinter + Open WebUI Looter | `endpoint`, `version`, `loot_observed`, `signup_enabled`, `auth_required`, `ollama_backend_urls` (canonicalized list, Looter-enriched from admin `/ollama/config`). Public identity fingerprinting omits graph auth fields; only the looter's `/api/config` observation authors auth evidence. |
 | `AIService` | Multi-label umbrella (see below) | _(no unique properties — carried as companion label)_ |
-| `AIModel` | Ollama Looter | `name`, `size_bytes`, `digest`, `family`, `parameter_size`, `is_finetune`, `modified_at`, `value_hash` (when modelfile present), `has_system_prompt`, `modelfile_size_bytes` |
-| `ExtractedTrainingSignal` | Extractors | `kind`, `source_model`, `sample_count`, `confidence` |
+| `AIModel` | Ollama Looter + extractor reference endpoint | Looter observations: `name`, `size_bytes`, `digest`, `family`, `parameter_size`, `is_finetune`, `modified_at`, `value_hash` (when modelfile present), `has_system_prompt`, `modelfile_size_bytes`. Extractors may emit the canonical source `AIModel` ID as an empty `reference_only` endpoint so extraction edges remain closed without fabricating model properties. |
+| `ExtractedTrainingSignal` | Embedding inversion extractor | `token_index`, `token_string`, `magnitude`, `z_score`, `confidence`, `source_model_id`, `engagement_id`, `method`, `extracted_at` |
 
 Config collection normalizes stdio executable basenames (including
 path-qualified and Windows `.exe`/`.cmd`/`.bat` launchers) before assessing
@@ -109,6 +109,90 @@ addresses, rejects fragments, and filters explicitly expired or revoked keys.
 Each card is limited to 16 signatures and four unique remote key sources under
 one aggregate verification deadline.
 
+MCP observed authentication is an all-or-nothing tuple. If any
+`observed_auth_*` field is present, all three must be canonical and internally
+consistent. `anonymous_probe_succeeded` is accepted only with an HTTP server
+whose status is `reachable` and whose exact observed tuple is
+`none/unauthenticated/anonymous_probe_succeeded`. Unreachable servers emit
+`unknown/unknown/unknown`; successful stdio collection emits
+`unknown/unknown/local_process`; a successful request carrying configured URL
+query material or a non-empty configured header whose auth scheme cannot be
+inferred emits
+`unknown/unknown/configured_credential`. Configured method and assurance must
+also agree (`none` → unauthenticated, basic/apiKey → weak, bearer →
+moderate, oauth/oidc/mtls → strong, unknown/custom → unknown). Configured
+evidence is validated as part of the same tuple: `anonymous_probe_succeeded`
+is valid only with `none/unauthenticated`, and `local_process` only with
+`unknown/unknown`; known authenticated methods and `custom` require either
+`configured_credential` or `declared_security_scheme`. `unknown/unknown` may
+pair with `unknown`, `declared_security_scheme`, `configured_credential`, or
+`local_process` because those represent, respectively, no usable observation,
+an ambiguous card declaration, potentially credential-bearing configured
+request material whose scheme cannot be inferred, and a local stdio process.
+`none/unauthenticated` may also pair with
+`unknown` or `declared_security_scheme`, but those combinations remain
+fail-closed: neither proves anonymous runtime access.
+
+For HTTP MCP collection, every configured header is attached to Initialize on
+the target origin. Recognized `Authorization` schemes and API-key-style header
+names retain their canonical method. Any other non-empty configured header,
+including `Cookie`, `X-Session`, and conventionally benign fields such as
+`Accept` or `User-Agent`, prevents anonymous classification because an
+arbitrary server may gate on its exact value. There is no non-empty benign
+allowlist. Empty or whitespace-only values carry no credential material and
+are ignored for this decision. AgentHound does not issue a second Initialize
+without the header: that would add protocol/session side effects and still
+would not prove that the first response was independent of the configured
+value. Exact anonymous evidence therefore requires a successful HTTP
+Initialize with no URL userinfo/query and no non-empty caller-configured
+header; protocol headers generated by the MCP SDK are not caller credentials.
+
+A2A observed authentication uses a narrower all-or-nothing contract. If any
+`observed_auth_*` field is present, the tuple must be exactly
+`none/unauthenticated/anonymous_probe_succeeded` and must be paired with
+`auth_probe_method=get_task_nonexistent` plus
+`auth_probe_status=anonymous_protocol_access` and bounded
+`auth_probe_detail=task_not_found_v1|task_not_found_v0_3`. The bounded lookup
+uses a random nonexistent task and accepts only the protocol's exact not-found
+result. It targets only the preferred conformant HTTP(S) JSON-RPC interface,
+requires an exact origin match with at least one requested discovery target,
+rejects interface userinfo/query/fragment bytes, deduplicates aliases by
+canonical protocol endpoint, sends no credential,
+rejects redirects, reads at most 64 KiB, and runs for no more than five seconds
+(or the shorter collector timeout). v1 uses `GetTask` plus the advertised
+`A2A-Version` header; v0.3 uses `tasks/get`. Probe method, status, and detail are
+an atomic canonical diagnostic
+triple: `authentication_required` accepts only the fixed 401/403 details and
+`unknown` only the documented fixed failure categories. Card retrieval,
+HTTP 401/403, and inconclusive protocol/transport results must omit
+`observed_auth_*`; they fall back to configured card provenance.
+
+The canonical A2A probe-detail vocabulary is status-scoped:
+
+- `anonymous_protocol_access`: `task_not_found_v1`, `task_not_found_v0_3`
+- `authentication_required`: `http_unauthorized`, `http_forbidden`
+- `unknown`: `no_preferred_interface`,
+  `nonconformant_preferred_interface`, `unsupported_protocol_binding`,
+  `unsupported_protocol_version`, `invalid_preferred_interface_url`,
+  `query_interface_not_probeable`,
+  `cross_origin_interface`, `random_id_generation_failed`,
+  `request_encoding_failed`, `request_creation_failed`,
+  `transport_unavailable`, `timeout`, `context_canceled`, `transport_error`,
+  `redirect_response`, `unexpected_http_status`, `non_json_response`,
+  `response_too_large`, `malformed_jsonrpc_response`,
+  `unexpected_jsonrpc_response`, `response_id_mismatch`, and
+  `non_task_not_found_error`
+
+The post-processor selects effective fields as one tuple, never as independent
+fallbacks. A valid protocol-specific MCP or A2A runtime tuple wins; an
+unknown/unavailable runtime method falls back to the configured tuple. The
+configured and observed fields remain visible for provenance. A raw configured
+`none/unauthenticated/anonymous_probe_succeeded` tuple is retained as
+provenance but is not assigned unauthenticated assurance or numeric weakness;
+anonymous access requires `effective_auth_source=observed`. The bounded pre-v1
+MCP normalization described in the ingest pipeline promotes only genuine old
+direct-URL runtime observations before this selection.
+
 ---
 
 ## 2. Umbrella Labels
@@ -127,7 +211,7 @@ This enables queries like `MATCH (n:AIService)` to find all AI infrastructure re
 
 | Edge | Source | Target | Collector | Meaning |
 |------|--------|--------|-----------|---------|
-| `TRUSTS_SERVER` | AgentInstance | MCPServer | Config | Agent trusts this server to provide tools |
+| `TRUSTS_SERVER` | AgentInstance | MCPServer | Config | Agent trusts this server to provide tools; configured `risk_weight` / `auth_assessment_complete` remain raw provenance, while the auth-strength pre-pass adds derived `effective_risk_weight` / `effective_auth_assessment_complete` / `effective_auth_source`; `configured_names` preserves sorted same-identity aliases without making an alias a server identity property |
 | `PROVIDES_TOOL` | MCPServer | MCPTool | MCP | Server exposes this tool |
 | `PROVIDES_RESOURCE` | MCPServer / JupyterServer / MLflowServer / QdrantInstance | MCPResource | MCP / Jupyter Looter / MLflow Looter (Model Registry storage URIs) / Qdrant Looter (scrolled point payloads under `--include-points`) | Server exposes this resource. MLflow URIs are plain `storage_location or source` (s3://, gs://, dbfs:/, file:///), NOT presigned credentials. Qdrant point resources are per-collection payload samples. |
 | `PROVIDES_PROMPT` | MCPServer | MCPPrompt | MCP | Server exposes this prompt template |
@@ -136,7 +220,7 @@ This enables queries like `MATCH (n:AIService)` to find all AI infrastructure re
 | `AUTHENTICATES_WITH` | MCPServer / A2AAgent | Identity | Config / A2A | Entity uses this auth identity. A2A emits it only for conformant, active, scalar-unambiguous security requirements. |
 | `USES_CREDENTIAL` | Identity | Credential | Config | Identity backed by this credential material |
 | `RUNS_ON` | MCPServer / A2AAgent | Host | Config / A2A / MCP | Entity runs on this host. A2A requires a conformant preferred interface; later interfaces do not replace entry zero. |
-| `CONFIGURED_IN` | MCPServer | ConfigFile | Config | Server defined in this config file |
+| `CONFIGURED_IN` | MCPServer | ConfigFile | Config | Server defined in this config file; `configured_names` is the sorted alias set for that file |
 | `HAS_ENV_VAR` | MCPServer | Credential | Config | Server has access to this env var |
 | `LOADS_INSTRUCTIONS` | AgentInstance | InstructionFile | Future evidence-backed collectors | Agent loads this instruction file. Static path discovery does not emit this edge because path presence alone cannot prove client/scope applicability. |
 | `SAME_AUTH_DOMAIN` | A2AAgent | A2AAgent | A2A | Agents share an authentication domain |
@@ -165,11 +249,11 @@ valid per-agent campaign edge, and invalid negatives cannot retire it.
 | `POISONED_DESCRIPTION` | MCPTool | MCPTool (self-edge) | Raw edges | Tool description contains injection patterns |
 | `POISONED_INSTRUCTIONS` | InstructionFile | InstructionFile (self-edge) | Raw edges | Suspicious patterns: imperative overrides, exfiltration commands, hidden Unicode |
 | `TAINTS` | MCPTool | MCPTool | INGESTS_UNTRUSTED + `schema_keys` | Untrusted-input tool shares ≥2 schema keys with a tool on another server, so attacker data can flow between them |
-| `CAN_REACH` | AgentInstance / A2AAgent | MCPResource / Credential | HAS_ACCESS_TO and correlation joins | Inferred transitive access. Credential variants distinguish observed material from references; cross-protocol shared-host variants are 50%-confidence hypotheses, not proven invocation paths. Credential-path candidates for one `(agent, resource)` are reduced deterministically by the complete object-ID tuple `(agent, entry server, entry tool, resource server, credential, identity, resource tool, resource)`; relationship IDs never choose the witness path. When per-agent `CREDENTIAL_REACH_VERIFIED` evidence exactly re-correlates on ingest, only that source agent's credential-chain edge is upgraded in place (`reach_evidence_state=verified`, confidence 1.0), with structured verification metadata persisted on the finding. |
+| `CAN_REACH` | AgentInstance / A2AAgent | MCPResource / Credential | HAS_ACCESS_TO and correlation joins | Inferred transitive access. Credential variants distinguish observed material from references; cross-protocol shared-host variants are 50%-confidence hypotheses, not proven invocation paths. Credential-path candidates for one `(agent, resource)` are reduced deterministically by the complete object-ID tuple `(agent, entry server, entry tool, resource server, identity, credential, resource tool, resource)`; relationship IDs never choose the witness path. When per-agent `CREDENTIAL_REACH_VERIFIED` evidence exactly re-correlates on ingest, only that source agent's credential-chain edge is upgraded in place (`reach_evidence_state=verified`, confidence 1.0), with structured verification metadata persisted on the finding. |
 | `CAN_EXFILTRATE_VIA` | AgentInstance | MCPTool | CAN_REACH | Inferred sensitive-data access plus a matched output-channel capability (incl. `auto_fetch_render` / `allowlisted_proxy`); not observed exfiltration |
 | `IFC_VIOLATION` | MCPTool | MCPTool | INGESTS_UNTRUSTED + HAS_ACCESS_TO (≤3 hops) | Untrusted source shares a resource with a high-impact sink (credential_access/file_write/email_send) |
 | `CAN_IMPERSONATE` | A2AAgent | A2AAgent | Raw edges | TF-IDF cosine similarity > 0.8 on skill descriptions |
-| `CONFUSED_DEPUTY` | A2AAgent | A2AAgent | auth_strength + can_reach | Weakly-authed agent (`auth_strength` ≥ 80) delegates to a strongly-authed one (≤ 30) |
+| `CONFUSED_DEPUTY` | A2AAgent | A2AAgent | auth_strength + can_reach | Agent with observed unauthenticated auth or configured/observed weak effective auth delegates to one with strong effective assurance |
 | `POISONS_CONTEXT` | MCPTool | MCPTool | Raw edges | Injection-bearing tool can poison context driving a high-capability tool (fan-out truncated to 20 sinks per (agent, source) pair) |
 
 ### Edge Struct (Go SDK)
@@ -373,20 +457,20 @@ Processors run in strict dependency order. A processor may only read edges produ
 
 | Order | Processor | Produces | Dependencies |
 |-------|-----------|----------|--------------|
-| 1 | auth_strength | `auth_strength` node property (pre-pass) | None |
+| 1 | auth_strength | paired `effective_auth_*`, `auth_strength`, and effective TRUSTS_SERVER assessment properties (pre-pass) | None |
 | 2 | has_access_to | `HAS_ACCESS_TO` | Raw edges only |
 | 3 | can_execute | `CAN_EXECUTE` | Raw edges only |
 | 4 | shadows | `SHADOWS` + `POISONS_CONTEXT` | Raw edges only |
 | 5 | poisoned_description | `POISONED_DESCRIPTION` | Raw edges only |
 | 6 | poisoned_instructions | `POISONED_INSTRUCTIONS` | Raw edges only |
 | 7 | taints | `TAINTS` | INGESTS_UNTRUSTED + `schema_keys` |
-| 8 | can_reach | `CAN_REACH` | 2 (HAS_ACCESS_TO) |
+| 8 | can_reach | `CAN_REACH` | 1 (effective auth) + 2 (HAS_ACCESS_TO) |
 | 9 | cross_service_credential_chain | `CAN_REACH` (credential variant) + `Credential.blast_radius` | 2, 8 (joins on `Credential.value_hash`) |
 | 10 | ifc_violation | `IFC_VIOLATION` | 2 (HAS_ACCESS_TO) + INGESTS_UNTRUSTED |
 | 11 | can_exfiltrate | `CAN_EXFILTRATE_VIA` | 8 (CAN_REACH) |
 | 12 | can_impersonate | `CAN_IMPERSONATE` | Raw edges only |
 | 13 | confused_deputy | `CONFUSED_DEPUTY` | 1 (auth_strength) + 8 (can_reach) |
-| 14 | cross_protocol | `CAN_REACH` (cross-protocol) | 2 (HAS_ACCESS_TO) + DELEGATES_TO |
+| 14 | cross_protocol | `CAN_REACH` (cross-protocol) | 1 (effective auth) + 2 (HAS_ACCESS_TO) + DELEGATES_TO |
 | 15 | risk_score | Node property updates | 1–14 (all prior processors) |
 
 ---
@@ -399,11 +483,11 @@ Lower weight = easier to exploit = higher risk. Used by bounded weighted-path qu
 
 | Edge | Weight | Condition |
 |------|--------|-----------|
-| `TRUSTS_SERVER` | 0.1 | auth_method = none |
-| `TRUSTS_SERVER` | 0.3 | auth_method = apiKey |
-| `TRUSTS_SERVER` | 0.5 | auth_method = bearer |
-| `TRUSTS_SERVER` | 0.7 | auth_method = oauth |
-| `TRUSTS_SERVER` | 0.9 | auth_method = mtls |
+| `TRUSTS_SERVER` | 0.1 | configured no-auth, or exact reachable observed `none/unauthenticated/anonymous_probe_succeeded` |
+| `TRUSTS_SERVER` | 0.3 | configured auth_method = apiKey |
+| `TRUSTS_SERVER` | 0.5 | configured auth_method = bearer |
+| `TRUSTS_SERVER` | 0.7 | configured auth_method = oauth |
+| `TRUSTS_SERVER` | 0.9 | configured auth_method = mtls |
 | `PROVIDES_TOOL` | 0.1 | Always (tools are always available once trusted) |
 | `HAS_ACCESS_TO` | 0.2 | — |
 | `CAN_EXECUTE` | 0.1 | — |

--- a/docs/reference/risk-scoring.md
+++ b/docs/reference/risk-scoring.md
@@ -10,14 +10,14 @@ Lower weight = easier to exploit = attacker prefers this path.
 
 | Edge Kind | Condition | Weight |
 |-----------|-----------|--------|
-| `TRUSTS_SERVER` | `auth_method = none` with explicit `anonymous_probe_succeeded` evidence | 0.1 |
-| `TRUSTS_SERVER` | `auth_method = basic` | 0.25 |
-| `TRUSTS_SERVER` | `auth_method = apiKey` | 0.3 |
-| `TRUSTS_SERVER` | `auth_method = bearer` | 0.5 |
-| `TRUSTS_SERVER` | `auth_method = oauth` | 0.7 |
-| `TRUSTS_SERVER` | `auth_method = oidc` | 0.75 |
-| `TRUSTS_SERVER` | `auth_method = mtls` | 0.9 |
-| `TRUSTS_SERVER` | `auth_method = unknown/custom` | 0.5 (ranking only; assessment incomplete) |
+| `TRUSTS_SERVER` | effective observed `none/unauthenticated/anonymous_probe_succeeded` | 0.1 |
+| `TRUSTS_SERVER` | configured `auth_method = basic` (when no observed anonymous override exists) | 0.25 |
+| `TRUSTS_SERVER` | configured `auth_method = apiKey` (when no observed anonymous override exists) | 0.3 |
+| `TRUSTS_SERVER` | configured `auth_method = bearer` (when no observed anonymous override exists) | 0.5 |
+| `TRUSTS_SERVER` | configured `auth_method = oauth` (when no observed anonymous override exists) | 0.7 |
+| `TRUSTS_SERVER` | configured `auth_method = oidc` (when no observed anonymous override exists) | 0.75 |
+| `TRUSTS_SERVER` | configured `auth_method = mtls` (when no observed anonymous override exists) | 0.9 |
+| `TRUSTS_SERVER` | configured `auth_method = unknown/custom` (when no observed anonymous override exists) | 0.5 (ranking only; assessment incomplete) |
 | `DELEGATES_TO` | unauthenticated | 0.1 |
 | `DELEGATES_TO` | authenticated | 0.5 |
 | `PROVIDES_TOOL` | _(always)_ | 0.1 |
@@ -29,6 +29,19 @@ Lower weight = easier to exploit = attacker prefers this path.
 | `CAN_IMPERSONATE` | _(always)_ | 0.6 |
 
 Unknown edge kinds default to 0.5 (mid-range, conservative assumption).
+
+The Config Collector owns the raw `TRUSTS_SERVER.risk_weight` and
+`auth_assessment_complete`. Before other analysis, `auth_strength` derives
+`effective_risk_weight`, `effective_auth_assessment_complete`, and
+`effective_auth_source`. Exact reachable MCP runtime evidence
+`none/unauthenticated/anonymous_probe_succeeded` lowers every incoming edge to
+`0.1` and complete because the server accepted an anonymous request regardless
+of that client's configured credential. For every authenticated, unknown, or
+unavailable runtime posture, the effective fields copy that individual edge's
+configured fields. This avoids applying one observed authenticated access path
+to every agent. Weighted traversal, direct `CAN_REACH` confidence, exact
+finding-path cost, and AgentInstance auth risk consume the effective fields;
+raw configured values remain available as provenance.
 
 ### Campaign verification evidence
 
@@ -60,7 +73,7 @@ score = 0.30 * credential + 0.25 * blast_radius + 0.20 * auth_risk
 |-----------|-------------|
 | `credential` | 100 if any trusted server has high-entropy or hardcoded credentials; 60 if credentials exist but are vault-referenced; 0 otherwise |
 | `blast_radius` | `min(reachable_resource_count * 10, 100)` |
-| `auth_risk` | `(1 - avg_trust_edge_weight) * 100` (weak auth = high score) |
+| `auth_risk` | `(1 - avg_effective_trust_edge_weight) * 100` over complete effective assessments (weak auth = high score); incomplete edges contribute a bounded unknown factor |
 | `tool_surface` | `min(trusted_tool_count * 5, 100)` |
 | `poisoning` | 100 if any loaded instruction file is suspicious; 0 otherwise |
 
@@ -73,15 +86,16 @@ score = 0.30 * auth_strength + 0.30 * blast_radius + 0.25 * delegation_surface
 
 | Component | Computation |
 |-----------|-------------|
-| `auth_strength` | none=100 only with explicit anonymous-probe evidence; basic=85, apiKey=70, bearer=50, oauth=25, oidc=20, mtls=10; unknown/custom/unsupported-none have no numeric weakness |
+| `auth_strength` | From the paired `effective_auth_*` tuple: none=100 only with explicit anonymous-probe evidence and `effective_auth_source=observed`; basic=85, apiKey=70, bearer=50, oauth=25, oidc=20, mtls=10; unknown/custom/configured-or-unsupported-none have no numeric weakness |
 | `blast_radius` | `min(reachable_mcp_resource_count * 10, 100)` |
 | `delegation_surface` | `min(delegated_a2a_agent_count * 20, 100)` |
 | `impersonation` | `min(can_impersonate_peer_count * 25, 100)` |
 
-For A2A imports, `auth_method=none` without
-`auth_evidence=anonymous_probe_succeeded` contributes an incomplete 0–100 auth
-bound (`auth_evidence` is listed as unknown) instead of an exact
-unauthenticated weakness score.
+For A2A imports, `auth_method=none` without the exact validated observed probe
+tuple contributes an incomplete 0–100 auth bound instead of an exact
+unauthenticated weakness score. Missing evidence reports `auth_evidence` as
+unknown; a raw anonymous claim without observed provenance reports
+`auth_source` as unknown.
 
 ### MCPServer
 
@@ -92,7 +106,7 @@ score = 0.35 * auth_strength + 0.25 * tool_risk + 0.20 * exposure
 
 | Component | Computation |
 |-----------|-------------|
-| `auth_strength` | none=100 only with explicit anonymous-probe evidence; basic=85, apiKey=70, bearer=50, oauth=25, oidc=20, mtls=10; unknown/custom/unsupported-none have no numeric weakness |
+| `auth_strength` | From the paired `effective_auth_*` tuple: none=100 only with explicit anonymous-probe evidence and `effective_auth_source=observed`; basic=85, apiKey=70, bearer=50, oauth=25, oidc=20, mtls=10; unknown/custom/configured-or-unsupported-none have no numeric weakness |
 | `tool_risk` | max `capability_risk` across all provided tools |
 | `exposure` | public host=100, private network=50, localhost=20; unknown contributes a 0-100 bound and marks assessment incomplete |
 | `credential_handling` | Observed/exposed material only: `max(base, blast)` where `base` = 100 if high-entropy or hardcoded creds else 50, and `blast` = `min(Credential.blast_radius * 10, 100)`. Masked, hashed, unobserved, and identity-only references do not count. |

--- a/modules/a2a/auth_probe.go
+++ b/modules/a2a/auth_probe.go
@@ -1,0 +1,495 @@
+package a2a
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/sdk/common"
+)
+
+const (
+	A2AAuthProbeMethodGetTaskNonexistent      = "get_task_nonexistent"
+	A2AAuthProbeStatusAnonymousProtocolAccess = "anonymous_protocol_access"
+	A2AAuthProbeStatusAuthenticationRequired  = "authentication_required"
+	A2AAuthProbeStatusUnknown                 = "unknown"
+
+	defaultA2AAuthProbeTimeout    = 5 * time.Second
+	maxA2AAuthProbeResponseBytes  = int64(64 * 1024)
+	a2aVersionHeader              = "A2A-Version"
+	a2aTaskNotFoundCode           = -32001
+	a2aV030CompatTaskNotFoundCode = -32603
+	a2aTaskNotFoundMessage        = "Task not found"
+	a2aTaskNotFoundReason         = "TASK_NOT_FOUND"
+	a2aTaskNotFoundDomain         = "a2a-protocol.org"
+	a2aErrorInfoType              = "type.googleapis.com/google.rpc.ErrorInfo"
+)
+
+// AuthProbeResult is deliberately limited to fixed categorical values. It
+// never retains request IDs, target URLs, response bodies, or transport error
+// strings, keeping scan artifacts deterministic and safe to share.
+type AuthProbeResult struct {
+	Method string
+	Status string
+	Detail string
+}
+
+type a2aProbeDialect uint8
+
+const (
+	a2aProbeDialectUnknown a2aProbeDialect = iota
+	a2aProbeDialectV030
+	a2aProbeDialectV1
+)
+
+type a2aProbeEndpoint struct {
+	key           string
+	requestURL    string
+	origin        string
+	dialect       a2aProbeDialect
+	versionHeader string
+}
+
+type a2aAuthProbePlan struct {
+	endpoint   a2aProbeEndpoint
+	authorized bool
+	cards      []*AgentCardData
+	result     AuthProbeResult
+}
+
+type a2aJSONRPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+type a2aJSONRPCResponse struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      json.RawMessage  `json:"id"`
+	Result  json.RawMessage  `json:"result"`
+	Error   *a2aJSONRPCError `json:"error"`
+}
+
+type a2aErrorInfo struct {
+	Type   string `json:"@type"`
+	Reason string `json:"reason"`
+	Domain string `json:"domain"`
+}
+
+// applyA2AAuthProbes plans probes only after every card has been parsed. The
+// canonical protocol endpoint is the deduplication key, so multiple discovery
+// aliases for one logical endpoint receive exactly the same observation.
+//
+// A card is untrusted input. An endpoint is eligible only when at least one of
+// its discovery aliases has the exact same HTTP origin. This prevents the card
+// from expanding the operator-authorized collection scope into an SSRF probe.
+func applyA2AAuthProbes(
+	ctx context.Context,
+	results []a2aCardResult,
+	insecure bool,
+	timeout time.Duration,
+	concurrency int,
+) {
+	plansByEndpoint := make(map[string]*a2aAuthProbePlan)
+	for index := range results {
+		result := &results[index]
+		if result.err != nil || result.card == nil {
+			continue
+		}
+		endpoint, detail, ok := preferredA2AProbeEndpoint(result.card)
+		if !ok {
+			result.card.AuthProbe = unknownA2AAuthProbe(detail)
+			continue
+		}
+
+		plan := plansByEndpoint[endpoint.key]
+		if plan == nil {
+			plan = &a2aAuthProbePlan{endpoint: endpoint}
+			plansByEndpoint[endpoint.key] = plan
+		} else if preferA2AProbeEndpoint(endpoint, plan.endpoint) {
+			// Conflicting aliases for the same endpoint cannot make output depend
+			// on target order. Prefer v1, then the lexically first version header.
+			plan.endpoint = endpoint
+		}
+		plan.cards = append(plan.cards, result.card)
+		if discoveryOrigin, valid := canonicalHTTPOrigin(normalizeBaseURL(result.url)); valid && discoveryOrigin == endpoint.origin {
+			plan.authorized = true
+		}
+	}
+
+	keys := make([]string, 0, len(plansByEndpoint))
+	for key := range plansByEndpoint {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for _, key := range keys {
+		plan := plansByEndpoint[key]
+		if !plan.authorized {
+			plan.result = unknownA2AAuthProbe("cross_origin_interface")
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			plan.result = observeA2AAuth(ctx, plan.endpoint, insecure, timeout)
+		}()
+	}
+	wg.Wait()
+
+	for _, key := range keys {
+		plan := plansByEndpoint[key]
+		for _, card := range plan.cards {
+			card.AuthProbe = plan.result
+		}
+	}
+}
+
+func preferredA2AProbeEndpoint(card *AgentCardData) (a2aProbeEndpoint, string, bool) {
+	if card == nil || len(card.Interfaces) == 0 {
+		return a2aProbeEndpoint{}, "no_preferred_interface", false
+	}
+	preferred := card.Interfaces[0]
+	if !preferred.Preferred {
+		return a2aProbeEndpoint{}, "no_preferred_interface", false
+	}
+	if !preferred.Conformant {
+		return a2aProbeEndpoint{}, "nonconformant_preferred_interface", false
+	}
+	if !strings.EqualFold(strings.TrimSpace(preferred.ProtocolBinding), "JSONRPC") {
+		return a2aProbeEndpoint{}, "unsupported_protocol_binding", false
+	}
+	parsedInterface, err := url.Parse(strings.TrimSpace(preferred.URL))
+	if err == nil && (parsedInterface.RawQuery != "" || parsedInterface.ForceQuery) {
+		// Query bytes may be credentials regardless of their key name. Sending
+		// them would make the supposedly anonymous probe authenticated.
+		return a2aProbeEndpoint{}, "query_interface_not_probeable", false
+	}
+
+	dialect, versionHeader, ok := a2aAuthProbeDialect(preferred.ProtocolVersion)
+	if !ok {
+		return a2aProbeEndpoint{}, "unsupported_protocol_version", false
+	}
+	requestURL, origin, ok := canonicalHTTPProbeURL(preferred.URL)
+	if !ok {
+		return a2aProbeEndpoint{}, "invalid_preferred_interface_url", false
+	}
+	return a2aProbeEndpoint{
+		key:           requestURL,
+		requestURL:    requestURL,
+		origin:        origin,
+		dialect:       dialect,
+		versionHeader: versionHeader,
+	}, "", true
+}
+
+func a2aAuthProbeDialect(rawVersion string) (a2aProbeDialect, string, bool) {
+	version := strings.TrimSpace(strings.TrimPrefix(strings.ToLower(rawVersion), "v"))
+	switch {
+	case version == "1" || strings.HasPrefix(version, "1."):
+		return a2aProbeDialectV1, version, true
+	case version == "0.3" || strings.HasPrefix(version, "0.3."):
+		return a2aProbeDialectV030, "", true
+	default:
+		return a2aProbeDialectUnknown, "", false
+	}
+}
+
+func preferA2AProbeEndpoint(candidate, current a2aProbeEndpoint) bool {
+	if candidate.dialect != current.dialect {
+		return candidate.dialect > current.dialect
+	}
+	return candidate.versionHeader < current.versionHeader
+}
+
+func canonicalHTTPProbeURL(raw string) (string, string, bool) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || !parsed.IsAbs() || parsed.Hostname() == "" || parsed.User != nil ||
+		parsed.Fragment != "" || parsed.RawFragment != "" || parsed.RawQuery != "" ||
+		parsed.ForceQuery {
+		return "", "", false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", "", false
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return "", "", false
+	}
+	origin := scheme + "://" + net.JoinHostPort(hostname, port)
+
+	parsed.Scheme = scheme
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		if strings.Contains(hostname, ":") {
+			parsed.Host = "[" + hostname + "]"
+		} else {
+			parsed.Host = hostname
+		}
+	} else {
+		parsed.Host = net.JoinHostPort(hostname, port)
+	}
+	if parsed.Path == "" {
+		parsed.Path = "/"
+		parsed.RawPath = ""
+	}
+	return parsed.String(), origin, true
+}
+
+func canonicalHTTPOrigin(raw string) (string, bool) {
+	_, origin, ok := canonicalHTTPProbeURL(raw)
+	return origin, ok
+}
+
+func observeA2AAuth(
+	ctx context.Context,
+	endpoint a2aProbeEndpoint,
+	insecure bool,
+	timeout time.Duration,
+) AuthProbeResult {
+	requestID, err := newA2AProbeID()
+	if err != nil {
+		return unknownA2AAuthProbe("random_id_generation_failed")
+	}
+	taskID, err := newA2AProbeID()
+	if err != nil {
+		return unknownA2AAuthProbe("random_id_generation_failed")
+	}
+	method := "tasks/get"
+	if endpoint.dialect == a2aProbeDialectV1 {
+		method = "GetTask"
+	}
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      requestID,
+		"method":  method,
+		"params":  map[string]any{"id": taskID},
+	})
+	if err != nil {
+		return unknownA2AAuthProbe("request_encoding_failed")
+	}
+
+	probeTimeout := timeout
+	if probeTimeout <= 0 || probeTimeout > defaultA2AAuthProbeTimeout {
+		probeTimeout = defaultA2AAuthProbeTimeout
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		probeCtx,
+		http.MethodPost,
+		endpoint.requestURL,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return unknownA2AAuthProbe("request_creation_failed")
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	if endpoint.dialect == a2aProbeDialectV1 {
+		req.Header.Set(a2aVersionHeader, endpoint.versionHeader)
+	}
+
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return unknownA2AAuthProbe("transport_unavailable")
+	}
+	transport := baseTransport.Clone()
+	if insecure {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		} else {
+			transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   probeTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return unknownA2AAuthProbe(a2aProbeTransportDetail(probeCtx, err))
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return protectedA2AAuthProbe("http_unauthorized")
+	case http.StatusForbidden:
+		return protectedA2AAuthProbe("http_forbidden")
+	case http.StatusOK:
+		// Continue with the exact JSON-RPC witness checks below.
+	default:
+		if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+			return unknownA2AAuthProbe("redirect_response")
+		}
+		return unknownA2AAuthProbe("unexpected_http_status")
+	}
+
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		return unknownA2AAuthProbe("non_json_response")
+	}
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, maxA2AAuthProbeResponseBytes+1))
+	if err != nil {
+		return unknownA2AAuthProbe(a2aProbeTransportDetail(probeCtx, err))
+	}
+	if int64(len(responseBody)) > maxA2AAuthProbeResponseBytes {
+		return unknownA2AAuthProbe("response_too_large")
+	}
+	if err := validateRawCardJSON(responseBody); err != nil {
+		return unknownA2AAuthProbe("malformed_jsonrpc_response")
+	}
+	var rpcResponse a2aJSONRPCResponse
+	if err := json.Unmarshal(responseBody, &rpcResponse); err != nil {
+		return unknownA2AAuthProbe("malformed_jsonrpc_response")
+	}
+	if rpcResponse.JSONRPC != "2.0" || rpcResponse.Error == nil || len(rpcResponse.Result) != 0 {
+		return unknownA2AAuthProbe("unexpected_jsonrpc_response")
+	}
+	var responseID string
+	if err := json.Unmarshal(rpcResponse.ID, &responseID); err != nil || responseID != requestID {
+		return unknownA2AAuthProbe("response_id_mismatch")
+	}
+	if !isNarrowTaskNotFound(endpoint.dialect, rpcResponse.Error) {
+		return unknownA2AAuthProbe("non_task_not_found_error")
+	}
+	if endpoint.dialect == a2aProbeDialectV1 {
+		return anonymousA2AAuthProbe("task_not_found_v1")
+	}
+	return anonymousA2AAuthProbe("task_not_found_v0_3")
+}
+
+func newA2AProbeID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func isNarrowTaskNotFound(dialect a2aProbeDialect, rpcError *a2aJSONRPCError) bool {
+	if rpcError == nil || rpcError.Message != a2aTaskNotFoundMessage {
+		return false
+	}
+	if dialect == a2aProbeDialectV030 {
+		if rpcError.Code == a2aV030CompatTaskNotFoundCode && jsonNullOrAbsent(rpcError.Data) {
+			return true
+		}
+		if rpcError.Code != a2aTaskNotFoundCode {
+			return false
+		}
+		return jsonNullOrAbsent(rpcError.Data) || hasExactA2ATaskNotFoundInfo(rpcError.Data)
+	}
+	return dialect == a2aProbeDialectV1 &&
+		rpcError.Code == a2aTaskNotFoundCode &&
+		hasExactA2ATaskNotFoundInfo(rpcError.Data)
+}
+
+func hasExactA2ATaskNotFoundInfo(raw json.RawMessage) bool {
+	var details []a2aErrorInfo
+	if len(raw) == 0 || json.Unmarshal(raw, &details) != nil || len(details) == 0 {
+		return false
+	}
+	for _, detail := range details {
+		if detail.Type == a2aErrorInfoType &&
+			detail.Reason == a2aTaskNotFoundReason &&
+			detail.Domain == a2aTaskNotFoundDomain {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonNullOrAbsent(raw json.RawMessage) bool {
+	return len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+func a2aProbeTransportDetail(ctx context.Context, err error) string {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled), errors.Is(ctx.Err(), context.Canceled):
+		return "context_canceled"
+	default:
+		return "transport_error"
+	}
+}
+
+func unknownA2AAuthProbe(detail string) AuthProbeResult {
+	return AuthProbeResult{
+		Method: A2AAuthProbeMethodGetTaskNonexistent,
+		Status: A2AAuthProbeStatusUnknown,
+		Detail: detail,
+	}
+}
+
+func protectedA2AAuthProbe(detail string) AuthProbeResult {
+	return AuthProbeResult{
+		Method: A2AAuthProbeMethodGetTaskNonexistent,
+		Status: A2AAuthProbeStatusAuthenticationRequired,
+		Detail: detail,
+	}
+}
+
+func anonymousA2AAuthProbe(detail string) AuthProbeResult {
+	return AuthProbeResult{
+		Method: A2AAuthProbeMethodGetTaskNonexistent,
+		Status: A2AAuthProbeStatusAnonymousProtocolAccess,
+		Detail: detail,
+	}
+}
+
+func applyAuthProbeProperties(properties map[string]any, result AuthProbeResult) {
+	if result.Method == "" {
+		return
+	}
+	properties["auth_probe_method"] = result.Method
+	properties["auth_probe_status"] = result.Status
+	if result.Detail != "" {
+		properties["auth_probe_detail"] = result.Detail
+	}
+	if result.Method != A2AAuthProbeMethodGetTaskNonexistent ||
+		result.Status != A2AAuthProbeStatusAnonymousProtocolAccess ||
+		(result.Detail != "task_not_found_v1" && result.Detail != "task_not_found_v0_3") {
+		return
+	}
+	properties["observed_auth_method"] = string(common.AuthNone)
+	properties["observed_auth_assurance"] = string(common.AuthAssuranceUnauthenticated)
+	properties["observed_auth_evidence"] = common.AuthEvidenceAnonymousProbeSucceeded
+}

--- a/modules/a2a/auth_probe_test.go
+++ b/modules/a2a/auth_probe_test.go
@@ -1,0 +1,642 @@
+package a2a
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/sdk/collector"
+	"github.com/adithyan-ak/agenthound/sdk/common"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+)
+
+type capturedA2AProbeRequest struct {
+	Method        string
+	Authorization string
+	Cookie        string
+	APIKey        string
+	Version       string
+	JSONRPC       string
+	RequestID     string
+	RPCMethod     string
+	TaskID        string
+}
+
+func captureA2AProbeRequest(r *http.Request) (capturedA2AProbeRequest, error) {
+	var payload struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      string `json:"id"`
+		Method  string `json:"method"`
+		Params  struct {
+			ID string `json:"id"`
+		} `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		return capturedA2AProbeRequest{}, err
+	}
+	return capturedA2AProbeRequest{
+		Method:        r.Method,
+		Authorization: r.Header.Get("Authorization"),
+		Cookie:        r.Header.Get("Cookie"),
+		APIKey:        r.Header.Get("X-API-Key"),
+		Version:       r.Header.Get(a2aVersionHeader),
+		JSONRPC:       payload.JSONRPC,
+		RequestID:     payload.ID,
+		RPCMethod:     payload.Method,
+		TaskID:        payload.Params.ID,
+	}, nil
+}
+
+func writeV1TaskNotFound(w http.ResponseWriter, requestID string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      requestID,
+		"error": map[string]any{
+			"code":    a2aTaskNotFoundCode,
+			"message": a2aTaskNotFoundMessage,
+			"data": []any{map[string]any{
+				"@type":    a2aErrorInfoType,
+				"reason":   a2aTaskNotFoundReason,
+				"domain":   a2aTaskNotFoundDomain,
+				"metadata": map[string]any{},
+			}},
+		},
+	})
+}
+
+func writeV030TaskNotFound(w http.ResponseWriter, requestID string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      requestID,
+		"error": map[string]any{
+			"code":    a2aV030CompatTaskNotFoundCode,
+			"message": a2aTaskNotFoundMessage,
+			"data":    nil,
+		},
+	})
+}
+
+func testA2AProbeEndpoint(rawURL string, dialect a2aProbeDialect) a2aProbeEndpoint {
+	requestURL, origin, ok := canonicalHTTPProbeURL(rawURL)
+	if !ok {
+		panic("invalid test probe URL")
+	}
+	version := ""
+	if dialect == a2aProbeDialectV1 {
+		version = "1.0"
+	}
+	return a2aProbeEndpoint{
+		key:           requestURL,
+		requestURL:    requestURL,
+		origin:        origin,
+		dialect:       dialect,
+		versionHeader: version,
+	}
+}
+
+func TestObserveA2AAuthUsesOnlyReadOnlyV1GetTaskWithoutCredentials(t *testing.T) {
+	var captured capturedA2AProbeRequest
+	var captureErr error
+	var mutationCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, captureErr = captureA2AProbeRequest(r)
+		if captureErr != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if captured.RPCMethod != "GetTask" {
+			mutationCalls.Add(1)
+		}
+		writeV1TaskNotFound(w, captured.RequestID)
+	}))
+	t.Cleanup(server.Close)
+
+	result := observeA2AAuth(
+		context.Background(),
+		testA2AProbeEndpoint(server.URL, a2aProbeDialectV1),
+		false,
+		time.Second,
+	)
+	if captureErr != nil {
+		t.Fatalf("decode request: %v", captureErr)
+	}
+	if result != anonymousA2AAuthProbe("task_not_found_v1") {
+		t.Fatalf("result = %+v", result)
+	}
+	if captured.Method != http.MethodPost || captured.JSONRPC != "2.0" ||
+		captured.RPCMethod != "GetTask" || captured.Version != "1.0" {
+		t.Fatalf("request = %+v", captured)
+	}
+	if captured.Authorization != "" || captured.Cookie != "" || captured.APIKey != "" {
+		t.Fatalf("anonymous probe forwarded credentials: %+v", captured)
+	}
+	idPattern := regexp.MustCompile(`^[0-9a-f]{32}$`)
+	if !idPattern.MatchString(captured.RequestID) || !idPattern.MatchString(captured.TaskID) ||
+		captured.RequestID == captured.TaskID {
+		t.Fatalf("probe IDs are not independent 128-bit random values: %+v", captured)
+	}
+	if mutationCalls.Load() != 0 {
+		t.Fatalf("probe reached a mutation method %d times", mutationCalls.Load())
+	}
+}
+
+func TestObserveA2AAuthUsesV030TasksGetWithoutVersionHeader(t *testing.T) {
+	var captured capturedA2AProbeRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		captured, err = captureA2AProbeRequest(r)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		writeV030TaskNotFound(w, captured.RequestID)
+	}))
+	t.Cleanup(server.Close)
+
+	result := observeA2AAuth(
+		context.Background(),
+		testA2AProbeEndpoint(server.URL, a2aProbeDialectV030),
+		false,
+		time.Second,
+	)
+	if result != anonymousA2AAuthProbe("task_not_found_v0_3") {
+		t.Fatalf("result = %+v", result)
+	}
+	if captured.RPCMethod != "tasks/get" || captured.Version != "" {
+		t.Fatalf("v0.3 request = %+v", captured)
+	}
+}
+
+func TestObserveA2AAuthClassifiesOnlyExactTaskNotFound(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		contentType string
+		response    func(string) string
+		want        AuthProbeResult
+	}{
+		{
+			name: "unauthorized", statusCode: http.StatusUnauthorized,
+			want: protectedA2AAuthProbe("http_unauthorized"),
+		},
+		{
+			name: "forbidden", statusCode: http.StatusForbidden,
+			want: protectedA2AAuthProbe("http_forbidden"),
+		},
+		{
+			name: "mismatched response id", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(string) string {
+				return `{"jsonrpc":"2.0","id":"different","error":{"code":-32001,"message":"Task not found","data":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"TASK_NOT_FOUND","domain":"a2a-protocol.org"}]}}`
+			},
+			want: unknownA2AAuthProbe("response_id_mismatch"),
+		},
+		{
+			name: "method not found", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(id string) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"error":{"code":-32601,"message":"Method not found"}}`, id)
+			},
+			want: unknownA2AAuthProbe("non_task_not_found_error"),
+		},
+		{
+			name: "version not supported", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(id string) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"error":{"code":-32009,"message":"Version not supported"}}`, id)
+			},
+			want: unknownA2AAuthProbe("non_task_not_found_error"),
+		},
+		{
+			name: "generic internal error", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(id string) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"error":{"code":-32603,"message":"Internal error"}}`, id)
+			},
+			want: unknownA2AAuthProbe("non_task_not_found_error"),
+		},
+		{
+			name: "task code without structured reason", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(id string) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"error":{"code":-32001,"message":"Task not found","data":null}}`, id)
+			},
+			want: unknownA2AAuthProbe("non_task_not_found_error"),
+		},
+		{
+			name: "wrong structured reason", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(id string) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"error":{"code":-32001,"message":"Task not found","data":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"AUTHENTICATION_REQUIRED","domain":"a2a-protocol.org"}]}}`, id)
+			},
+			want: unknownA2AAuthProbe("non_task_not_found_error"),
+		},
+		{
+			name: "result and error", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(id string) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"result":null,"error":{"code":-32001,"message":"Task not found"}}`, id)
+			},
+			want: unknownA2AAuthProbe("unexpected_jsonrpc_response"),
+		},
+		{
+			name: "malformed json", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(string) string { return `{"jsonrpc":` },
+			want:     unknownA2AAuthProbe("malformed_jsonrpc_response"),
+		},
+		{
+			name: "duplicate response id", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(id string) string {
+				return fmt.Sprintf(`{"jsonrpc":"2.0","id":%q,"id":%q,"error":{"code":-32001,"message":"Task not found"}}`, id, id)
+			},
+			want: unknownA2AAuthProbe("malformed_jsonrpc_response"),
+		},
+		{
+			name: "html", statusCode: http.StatusOK, contentType: "text/html",
+			response: func(string) string { return `<html>Task not found</html>` },
+			want:     unknownA2AAuthProbe("non_json_response"),
+		},
+		{
+			name: "oversize", statusCode: http.StatusOK, contentType: "application/json",
+			response: func(string) string {
+				return strings.Repeat(" ", int(maxA2AAuthProbeResponseBytes)+1)
+			},
+			want: unknownA2AAuthProbe("response_too_large"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured, err := captureA2AProbeRequest(r)
+				if err != nil {
+					http.Error(w, "bad request", http.StatusBadRequest)
+					return
+				}
+				if test.contentType != "" {
+					w.Header().Set("Content-Type", test.contentType)
+				}
+				status := test.statusCode
+				if status == 0 {
+					status = http.StatusOK
+				}
+				w.WriteHeader(status)
+				if test.response != nil {
+					_, _ = w.Write([]byte(test.response(captured.RequestID)))
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			got := observeA2AAuth(
+				context.Background(),
+				testA2AProbeEndpoint(server.URL, a2aProbeDialectV1),
+				false,
+				time.Second,
+			)
+			if got != test.want {
+				t.Fatalf("result = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestObserveA2AAuthRejectsRedirectAndBoundsTimeout(t *testing.T) {
+	var redirectedCalls atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedCalls.Add(1)
+		writeV1TaskNotFound(w, "should-not-be-reached")
+	}))
+	t.Cleanup(target.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(redirector.Close)
+	got := observeA2AAuth(
+		context.Background(),
+		testA2AProbeEndpoint(redirector.URL, a2aProbeDialectV1),
+		false,
+		time.Second,
+	)
+	if got != unknownA2AAuthProbe("redirect_response") || redirectedCalls.Load() != 0 {
+		t.Fatalf("redirect result = %+v, redirected calls = %d", got, redirectedCalls.Load())
+	}
+
+	timeoutServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(timeoutServer.Close)
+	started := time.Now()
+	got = observeA2AAuth(
+		context.Background(),
+		testA2AProbeEndpoint(timeoutServer.URL, a2aProbeDialectV1),
+		false,
+		25*time.Millisecond,
+	)
+	if got != unknownA2AAuthProbe("timeout") {
+		t.Fatalf("timeout result = %+v", got)
+	}
+	if elapsed := time.Since(started); elapsed > 150*time.Millisecond {
+		t.Fatalf("probe timeout was not bounded: %v", elapsed)
+	}
+}
+
+func TestCollectorPreservesDeclaredAuthAndNeverForwardsOperatorAuthToProbe(t *testing.T) {
+	var server *httptest.Server
+	var cardAuthorization string
+	var probeAuthorization string
+	var probeCalls atomic.Int32
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			cardAuthorization = r.Header.Get("Authorization")
+			card := validV10Card()
+			card["supportedInterfaces"] = []any{map[string]any{
+				"url": server.URL, "protocolBinding": "JSONRPC", "protocolVersion": "1.0",
+			}}
+			card["securitySchemes"] = map[string]any{
+				"bearer": map[string]any{
+					"httpAuthSecurityScheme": map[string]any{"scheme": "Bearer"},
+				},
+			}
+			card["securityRequirements"] = []any{map[string]any{
+				"schemes": map[string]any{"bearer": map[string]any{"list": []any{}}},
+			}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(card)
+			return
+		}
+		probeCalls.Add(1)
+		probeAuthorization = r.Header.Get("Authorization")
+		captured, err := captureA2AProbeRequest(r)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		writeV1TaskNotFound(w, captured.RequestID)
+	}))
+	t.Cleanup(server.Close)
+
+	data, err := NewA2ACollector(WithJWKSFetch(false)).Collect(
+		context.Background(),
+		collector.CollectOptions{
+			TargetURL: server.URL,
+			AuthToken: "operator-secret",
+			ScanID:    "a2a-auth-observer",
+		},
+	)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if cardAuthorization != "Bearer operator-secret" {
+		t.Fatalf("card request Authorization = %q", cardAuthorization)
+	}
+	if probeAuthorization != "" || probeCalls.Load() != 1 {
+		t.Fatalf("probe Authorization = %q, calls = %d", probeAuthorization, probeCalls.Load())
+	}
+	agent := findA2AAgentNode(t, data)
+	props := agent.Properties
+	if props["auth_method"] != "bearer" ||
+		props["auth_assurance"] != string(common.AuthAssuranceModerate) ||
+		props["auth_evidence"] != common.AuthEvidenceDeclaredScheme {
+		t.Fatalf("declared auth provenance was overwritten: %+v", props)
+	}
+	assertAnonymousA2AProbeProperties(t, props, "task_not_found_v1")
+
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal artifact: %v", err)
+	}
+	if strings.Contains(string(encoded), "operator-secret") {
+		t.Fatal("operator credential leaked into scan artifact")
+	}
+}
+
+func TestCollectorDeduplicatesAliasProbeAndKeepsArtifactDeterministic(t *testing.T) {
+	var server *httptest.Server
+	var probeCalls atomic.Int32
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			card := validV10Card()
+			card["supportedInterfaces"] = []any{map[string]any{
+				"url": server.URL, "protocolBinding": "JSONRPC", "protocolVersion": "1.0",
+			}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(card)
+			return
+		}
+		probeCalls.Add(1)
+		captured, err := captureA2AProbeRequest(r)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		writeV1TaskNotFound(w, captured.RequestID)
+	}))
+	t.Cleanup(server.Close)
+
+	collect := func(targets []string) *ingest.IngestData {
+		t.Helper()
+		data, err := NewA2ACollector(WithJWKSFetch(false)).Collect(
+			context.Background(),
+			collector.CollectOptions{TargetURLs: targets, ScanID: "stable-a2a-probe"},
+		)
+		if err != nil {
+			t.Fatalf("Collect: %v", err)
+		}
+		return data
+	}
+	forwardTargets := []string{server.URL + "/alias-b", server.URL + "/alias-a"}
+	forward := collect(forwardTargets)
+	if probeCalls.Load() != 1 {
+		t.Fatalf("same protocol endpoint probed %d times, want 1", probeCalls.Load())
+	}
+	reversed := collect([]string{forwardTargets[1], forwardTargets[0]})
+	if probeCalls.Load() != 2 {
+		t.Fatalf("second collection did not issue exactly one probe: %d", probeCalls.Load())
+	}
+
+	for _, data := range []*ingest.IngestData{forward, reversed} {
+		var agentProperties []map[string]any
+		for _, node := range data.Graph.Nodes {
+			if ingest.ConcreteNodeKind(node.Kinds) == "A2AAgent" {
+				agentProperties = append(agentProperties, node.Properties)
+			}
+		}
+		if len(agentProperties) != 2 || !reflect.DeepEqual(agentProperties[0], agentProperties[1]) {
+			t.Fatalf("alias contributions disagree: %#v", agentProperties)
+		}
+		assertAnonymousA2AProbeProperties(t, agentProperties[0], "task_not_found_v1")
+	}
+	scrubA2AArtifactVolatile(forward)
+	scrubA2AArtifactVolatile(reversed)
+	if !reflect.DeepEqual(forward, reversed) {
+		forwardJSON, _ := json.MarshalIndent(forward, "", "  ")
+		reversedJSON, _ := json.MarshalIndent(reversed, "", "  ")
+		t.Fatalf("random probe IDs or target order changed artifact:\n%s\n%s", forwardJSON, reversedJSON)
+	}
+}
+
+func TestCollectorDoesNotProbeCrossOriginCardInterface(t *testing.T) {
+	var crossOriginCalls atomic.Int32
+	probeTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		crossOriginCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(probeTarget.Close)
+	cardServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		card := validV10Card()
+		card["supportedInterfaces"] = []any{map[string]any{
+			"url": probeTarget.URL, "protocolBinding": "JSONRPC", "protocolVersion": "1.0",
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(card)
+	}))
+	t.Cleanup(cardServer.Close)
+
+	data, err := NewA2ACollector(WithJWKSFetch(false)).Collect(
+		context.Background(),
+		collector.CollectOptions{TargetURL: cardServer.URL, ScanID: "cross-origin-card"},
+	)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if crossOriginCalls.Load() != 0 {
+		t.Fatalf("untrusted cross-origin endpoint received %d probe(s)", crossOriginCalls.Load())
+	}
+	props := findA2AAgentNode(t, data).Properties
+	if props["auth_probe_method"] != A2AAuthProbeMethodGetTaskNonexistent ||
+		props["auth_probe_status"] != A2AAuthProbeStatusUnknown ||
+		props["auth_probe_detail"] != "cross_origin_interface" {
+		t.Fatalf("cross-origin diagnostics = %+v", props)
+	}
+	assertNoObservedA2AAuth(t, props)
+}
+
+func TestCollectorDoesNotProbePreferredInterfaceWithQueryBytes(t *testing.T) {
+	for _, suffix := range []string{"?tenant=one", "?"} {
+		suffix := suffix
+		t.Run(suffix, func(t *testing.T) {
+			var server *httptest.Server
+			var protocolCalls atomic.Int32
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					protocolCalls.Add(1)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				card := validV10Card()
+				card["supportedInterfaces"] = []any{map[string]any{
+					"url": server.URL + suffix, "protocolBinding": "JSONRPC", "protocolVersion": "1.0",
+				}}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(card)
+			}))
+			t.Cleanup(server.Close)
+
+			data, err := NewA2ACollector(WithJWKSFetch(false)).Collect(
+				context.Background(),
+				collector.CollectOptions{TargetURL: server.URL, ScanID: "query-interface"},
+			)
+			if err != nil {
+				t.Fatalf("Collect: %v", err)
+			}
+			if protocolCalls.Load() != 0 {
+				t.Fatalf("query-bearing interface %q received %d probe(s)", suffix, protocolCalls.Load())
+			}
+			props := findA2AAgentNode(t, data).Properties
+			if props["auth_probe_status"] != A2AAuthProbeStatusUnknown ||
+				props["auth_probe_detail"] != "query_interface_not_probeable" {
+				t.Fatalf("query-interface diagnostics for %q = %+v", suffix, props)
+			}
+			assertNoObservedA2AAuth(t, props)
+		})
+	}
+}
+
+func TestApplyAuthProbePropertiesOmitsObservedTupleForNonPositiveResults(t *testing.T) {
+	for _, result := range []AuthProbeResult{
+		protectedA2AAuthProbe("http_unauthorized"),
+		unknownA2AAuthProbe("timeout"),
+		{
+			Method: A2AAuthProbeMethodGetTaskNonexistent,
+			Status: A2AAuthProbeStatusAnonymousProtocolAccess,
+			Detail: "non_task_not_found_error",
+		},
+	} {
+		props := map[string]any{
+			"auth_method":    "bearer",
+			"auth_assurance": string(common.AuthAssuranceModerate),
+			"auth_evidence":  common.AuthEvidenceDeclaredScheme,
+		}
+		applyAuthProbeProperties(props, result)
+		assertNoObservedA2AAuth(t, props)
+		if props["auth_method"] != "bearer" || props["auth_evidence"] != common.AuthEvidenceDeclaredScheme {
+			t.Fatalf("raw declared tuple changed for %+v: %+v", result, props)
+		}
+	}
+}
+
+func TestCanonicalA2AProbeURLSafetyAndOrigin(t *testing.T) {
+	canonical, origin, ok := canonicalHTTPProbeURL("HTTPS://EXAMPLE.test:443/a2a")
+	if !ok || canonical != "https://example.test/a2a" ||
+		origin != "https://example.test:443" {
+		t.Fatalf("canonical URL = %q, origin = %q, ok = %v", canonical, origin, ok)
+	}
+	for _, raw := range []string{
+		"https://user:secret@example.test/a2a",
+		"https://example.test/a2a?tenant=one",
+		"https://example.test/a2a#fragment",
+		"ws://example.test/a2a",
+		"https://example.test:not-a-port/a2a",
+		"/relative/a2a",
+	} {
+		if _, _, ok := canonicalHTTPProbeURL(raw); ok {
+			t.Fatalf("unsafe probe URL accepted: %q", raw)
+		}
+	}
+}
+
+func findA2AAgentNode(t *testing.T, data *ingest.IngestData) ingest.Node {
+	t.Helper()
+	for _, node := range data.Graph.Nodes {
+		if ingest.ConcreteNodeKind(node.Kinds) == "A2AAgent" {
+			return node
+		}
+	}
+	t.Fatal("A2AAgent node not found")
+	return ingest.Node{}
+}
+
+func assertAnonymousA2AProbeProperties(t *testing.T, props map[string]any, detail string) {
+	t.Helper()
+	if props["auth_probe_method"] != A2AAuthProbeMethodGetTaskNonexistent ||
+		props["auth_probe_status"] != A2AAuthProbeStatusAnonymousProtocolAccess ||
+		props["auth_probe_detail"] != detail ||
+		props["observed_auth_method"] != string(common.AuthNone) ||
+		props["observed_auth_assurance"] != string(common.AuthAssuranceUnauthenticated) ||
+		props["observed_auth_evidence"] != common.AuthEvidenceAnonymousProbeSucceeded {
+		t.Fatalf("anonymous probe properties = %+v", props)
+	}
+}
+
+func assertNoObservedA2AAuth(t *testing.T, props map[string]any) {
+	t.Helper()
+	for _, key := range []string{
+		"observed_auth_method", "observed_auth_assurance", "observed_auth_evidence",
+	} {
+		if _, present := props[key]; present {
+			t.Fatalf("non-positive probe emitted %s: %+v", key, props)
+		}
+	}
+}
+
+func scrubA2AArtifactVolatile(data *ingest.IngestData) {
+	data.Meta.Timestamp = ""
+	for index := range data.Graph.Edges {
+		delete(data.Graph.Edges[index].Properties, "last_seen")
+	}
+}

--- a/modules/a2a/collector.go
+++ b/modules/a2a/collector.go
@@ -27,6 +27,12 @@ type A2ACollector struct {
 	trustedKeys      *jose.JSONWebKeySet
 }
 
+type a2aCardResult struct {
+	card *AgentCardData
+	url  string
+	err  error
+}
+
 type Option func(*A2ACollector)
 
 func WithConcurrency(n int) Option {
@@ -107,13 +113,7 @@ func (c *A2ACollector) Collect(ctx context.Context, opts collector.CollectOption
 		verifyOpts.Fetcher = NewJWKSFetcher(c.timeout)
 	}
 
-	type cardResult struct {
-		card *AgentCardData
-		url  string
-		err  error
-	}
-
-	results := make([]cardResult, len(targets))
+	results := make([]a2aCardResult, len(targets))
 	sem := make(chan struct{}, c.concurrency)
 	var wg sync.WaitGroup
 
@@ -126,19 +126,19 @@ func (c *A2ACollector) Collect(ctx context.Context, opts collector.CollectOption
 
 			raw, err := FetchAgentCard(ctx, tgt, authToken, insecure, c.timeout)
 			if err != nil {
-				results[idx] = cardResult{url: tgt, err: err}
+				results[idx] = a2aCardResult{url: tgt, err: err}
 				return
 			}
 			card, err := ParseAgentCard(ctx, raw, engine, verifyOpts)
 			if err != nil {
-				results[idx] = cardResult{url: tgt, err: err}
+				results[idx] = a2aCardResult{url: tgt, err: err}
 				return
 			}
 			if card.URL == "" {
 				card.URL = normalizeBaseURL(tgt)
 			}
 
-			results[idx] = cardResult{card: card, url: tgt}
+			results[idx] = a2aCardResult{card: card, url: tgt}
 		}(i, target)
 	}
 	wg.Wait()
@@ -150,6 +150,7 @@ func (c *A2ACollector) Collect(ctx context.Context, opts collector.CollectOption
 		}
 		return leftScope < rightScope
 	})
+	applyA2AAuthProbes(ctx, results, insecure, c.timeout, c.concurrency)
 
 	data := common.NewIngestData("a2a", scanID)
 	data.Meta.Origin = opts.Origin
@@ -452,6 +453,7 @@ func buildGraph(card *AgentCardData, scanID string) ([]ingest.Node, []ingest.Edg
 	}
 	agentProps["security_schemes"] = schemesData
 	agentProps["security_requirements"] = securityRequirementsProperty(card.SecurityRequirements)
+	applyAuthProbeProperties(agentProps, card.AuthProbe)
 
 	nodes = append(nodes, common.NewNode(agentID, []string{"A2AAgent"}, agentProps))
 

--- a/modules/a2a/parse.go
+++ b/modules/a2a/parse.go
@@ -36,6 +36,7 @@ type AgentCardData struct {
 	SignatureKeyTrust    string
 	IsHTTPS              bool
 	CardHash             string
+	AuthProbe            AuthProbeResult
 }
 
 type SkillData struct {

--- a/modules/litellmloot/looter.go
+++ b/modules/litellmloot/looter.go
@@ -58,7 +58,7 @@ type Looter struct{}
 // aborting on the first 401.
 func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOptions) (*action.LootResult, error) {
 	masterKey := opts.Credentials["master_key"]
-	if masterKey == "" {
+	if strings.TrimSpace(masterKey) == "" {
 		return nil, errors.New("litellm loot: --master-key (or --credential master_key=...) is required")
 	}
 

--- a/modules/litellmloot/looter_test.go
+++ b/modules/litellmloot/looter_test.go
@@ -364,6 +364,27 @@ func TestLoot_RequiresMasterKey(t *testing.T) {
 	}
 }
 
+func TestLoot_RejectsWhitespaceOnlyMasterKeyBeforeProbing(t *testing.T) {
+	s := newStub(t)
+	srv := httptest.NewServer(s.handler())
+	defer srv.Close()
+
+	res, err := (&Looter{}).Loot(context.Background(), action.Target{
+		Address: strings.TrimPrefix(srv.URL, "http://"),
+	}, action.LootOptions{
+		Credentials: map[string]string{"master_key": " \t\n "},
+	})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only master_key")
+	}
+	if res != nil {
+		t.Fatalf("result = %+v, want nil before graph construction", res)
+	}
+	if len(s.seenMethods) != 0 {
+		t.Fatalf("requests = %v, want none for invalid credential input", s.seenMethods)
+	}
+}
+
 func TestLoot_IncludeCredentialValues(t *testing.T) {
 	// When the operator opts in, the master Credential carries the raw
 	// value too. The merge-primitive value_hash is unchanged.

--- a/modules/mlflowloot/looter.go
+++ b/modules/mlflowloot/looter.go
@@ -30,6 +30,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -82,13 +83,11 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		ID:    mlflowID,
 		Kinds: []string{"MLflowServer", "AIService"},
 		Properties: map[string]any{
-			"objectid":          mlflowID,
-			"endpoint":          baseURL,
-			"name":              host,
-			"discovered_via":    "mlflow_loot",
-			"service_kind":      "mlflow",
-			"auth_method":       "none",
-			"is_anonymous_loot": "true",
+			"objectid":      mlflowID,
+			"endpoint":      baseURL,
+			"name":          host,
+			"loot_observed": true,
+			"service_kind":  "mlflow",
 		},
 	})
 	res.Summary.EndpointsProbed++
@@ -101,7 +100,9 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		res.PartialErrors = append(res.PartialErrors, fmt.Sprintf("experiments/search: %v", err))
 		res.Summary.PartialFailures++
 	} else {
-		res.IngestData.Graph.Nodes[0].Properties["experiment_count"] = len(experiments)
+		props := res.IngestData.Graph.Nodes[0].Properties
+		props["experiment_count"] = len(experiments)
+		markAnonymousInventorySuccess(props)
 	}
 
 	// 2. /runs/search per experiment (paginated).
@@ -242,14 +243,22 @@ func fetchExperiments(ctx context.Context, client *http.Client, baseURL string, 
 			return out, fmt.Errorf("page: %w", err)
 		}
 		var parsed struct {
-			Experiments   []experiment `json:"experiments"`
-			NextPageToken string       `json:"next_page_token"`
+			Experiments   json.RawMessage `json:"experiments"`
+			NextPageToken string          `json:"next_page_token"`
 		}
 		if err := json.Unmarshal(body, &parsed); err != nil {
 			return nil, fmt.Errorf("decode experiments: %w", err)
 		}
-		out = append(out, parsed.Experiments...)
-		if parsed.NextPageToken == "" || len(parsed.Experiments) == 0 {
+		experimentsJSON := bytes.TrimSpace(parsed.Experiments)
+		if len(experimentsJSON) == 0 || experimentsJSON[0] != '[' {
+			return nil, errors.New("decode experiments: expected an experiments array")
+		}
+		var pageExperiments []experiment
+		if err := json.Unmarshal(experimentsJSON, &pageExperiments); err != nil {
+			return nil, fmt.Errorf("decode experiments array: %w", err)
+		}
+		out = append(out, pageExperiments...)
+		if parsed.NextPageToken == "" || len(pageExperiments) == 0 {
 			break
 		}
 		pageToken = parsed.NextPageToken
@@ -258,6 +267,15 @@ func fetchExperiments(ctx context.Context, client *http.Client, baseURL string, 
 		out = out[:maxItems]
 	}
 	return out, nil
+}
+
+func markAnonymousInventorySuccess(props map[string]any) {
+	props["auth_method"] = string(common.AuthNone)
+	props["auth_assurance"] = string(common.AuthAssuranceUnauthenticated)
+	props["auth_evidence"] = common.AuthEvidenceAnonymousProbeSucceeded
+	props["probe_status"] = string(common.VerificationVerified)
+	props["last_verified_at"] = time.Now().UTC().Format(time.RFC3339)
+	props["is_anonymous_loot"] = "true"
 }
 
 type run struct {

--- a/modules/mlflowloot/looter_test.go
+++ b/modules/mlflowloot/looter_test.go
@@ -7,11 +7,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/adithyan-ak/agenthound/modules/mlflowfp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 )
 
 const experimentsBody = `{"experiments":[{"experiment_id":"0","name":"Default"},{"experiment_id":"1","name":"Fine-tune-v3"}],"next_page_token":""}`
@@ -36,6 +39,40 @@ func mlflowStub(t *testing.T) *httptest.Server {
 	}))
 }
 
+func TestFingerprintAndLootPropertiesComposeOnSameEndpoint(t *testing.T) {
+	srv := mlflowStub(t)
+	defer srv.Close()
+	target := action.Target{Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://")}
+
+	fingerprinter, err := mlflowfp.New()
+	if err != nil {
+		t.Fatalf("new fingerprinter: %v", err)
+	}
+	fingerprint, err := fingerprinter.Fingerprint(context.Background(), target)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	loot, err := (&Looter{}).Loot(context.Background(), target, action.LootOptions{})
+	if err != nil {
+		t.Fatalf("loot: %v", err)
+	}
+	fingerprintNode := fingerprint.IngestData.Graph.Nodes[0]
+	lootNode := loot.IngestData.Graph.Nodes[0]
+	if fingerprintNode.ID != lootNode.ID {
+		t.Fatalf("same endpoint IDs differ: %q != %q", fingerprintNode.ID, lootNode.ID)
+	}
+	for key, fingerprintValue := range fingerprintNode.Properties {
+		if lootValue, shared := lootNode.Properties[key]; shared &&
+			!reflect.DeepEqual(fingerprintValue, lootValue) {
+			t.Errorf("shared property %q conflicts: fingerprint=%#v loot=%#v", key, fingerprintValue, lootValue)
+		}
+	}
+	if fingerprintNode.Properties["discovered_via"] != "network_scan" ||
+		lootNode.Properties["loot_observed"] != true {
+		t.Errorf("action provenance not separated: fingerprint=%+v loot=%+v", fingerprintNode.Properties, lootNode.Properties)
+	}
+}
+
 func TestLoot_MLflowHappy(t *testing.T) {
 	srv := mlflowStub(t)
 	defer srv.Close()
@@ -55,6 +92,12 @@ func TestLoot_MLflowHappy(t *testing.T) {
 	if node.Kinds[0] != "MLflowServer" {
 		t.Errorf("kind = %v, want MLflowServer", node.Kinds)
 	}
+	if node.Properties["loot_observed"] != true {
+		t.Errorf("MLflowServer missing loot_observed: %+v", node.Properties)
+	}
+	if _, exists := node.Properties["discovered_via"]; exists {
+		t.Errorf("direct loot claimed discovery provenance: %+v", node.Properties)
+	}
 	if ec, _ := node.Properties["experiment_count"].(int); ec != 2 {
 		t.Errorf("experiment_count = %v, want 2", node.Properties["experiment_count"])
 	}
@@ -71,6 +114,7 @@ func TestLoot_MLflowHappy(t *testing.T) {
 	if res.Summary.CredentialsFound != 0 {
 		t.Errorf("CredentialsFound = %d, want 0 for metadata-only discoveries", res.Summary.CredentialsFound)
 	}
+	assertAnonymousInventoryClaim(t, node.Properties)
 }
 
 func TestLoot_MLflow_FetchRunsUsesPOST(t *testing.T) {
@@ -139,6 +183,65 @@ func TestLoot_MLflow_ExperimentsFail(t *testing.T) {
 	// registered-models, model-versions).
 	if res.Summary.PartialFailures < 1 {
 		t.Errorf("partial failures: got %d, want at least 1", res.Summary.PartialFailures)
+	}
+	assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+}
+
+func TestLoot_MLflow_ExperimentsMalformedOrUnavailableDoesNotClaimAnonymousAccess(t *testing.T) {
+	t.Run("malformed success shape", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		res, err := (&Looter{}).Loot(context.Background(), action.Target{
+			Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://"),
+		}, action.LootOptions{})
+		if err != nil {
+			t.Fatalf("Loot: %v", err)
+		}
+		assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+	})
+
+	t.Run("transport failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.NotFoundHandler())
+		address := strings.TrimPrefix(srv.URL, "http://")
+		srv.Close()
+
+		res, err := (&Looter{}).Loot(context.Background(), action.Target{
+			Kind: "host", Address: address,
+		}, action.LootOptions{})
+		if err != nil {
+			t.Fatalf("Loot: %v", err)
+		}
+		assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+	})
+}
+
+func assertAnonymousInventoryClaim(t *testing.T, props map[string]any) {
+	t.Helper()
+	if props["auth_method"] != string(common.AuthNone) ||
+		props["auth_assurance"] != string(common.AuthAssuranceUnauthenticated) ||
+		props["auth_evidence"] != common.AuthEvidenceAnonymousProbeSucceeded ||
+		props["probe_status"] != string(common.VerificationVerified) ||
+		props["is_anonymous_loot"] != "true" {
+		t.Fatalf("anonymous inventory evidence = %+v", props)
+	}
+	if _, ok := props["last_verified_at"].(string); !ok {
+		t.Fatalf("last_verified_at missing from anonymous inventory evidence: %+v", props)
+	}
+}
+
+func assertNoAnonymousInventoryClaim(t *testing.T, props map[string]any) {
+	t.Helper()
+	for _, key := range []string{
+		"auth_method", "auth_assurance", "auth_evidence", "probe_status",
+		"last_verified_at", "is_anonymous_loot",
+	} {
+		if value, present := props[key]; present {
+			t.Errorf("failed inventory fabricated %s=%v: %+v", key, value, props)
+		}
 	}
 }
 

--- a/modules/ollamaloot/looter.go
+++ b/modules/ollamaloot/looter.go
@@ -52,6 +52,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -120,17 +121,11 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		ID:    ollamaID,
 		Kinds: []string{"OllamaInstance", "AIService"},
 		Properties: map[string]any{
-			"objectid":          ollamaID,
-			"endpoint":          baseURL,
-			"name":              host,
-			"discovered_via":    "ollama_loot",
-			"service_kind":      "ollama",
-			"auth_method":       "none",
-			"auth_assurance":    string(common.AuthAssuranceUnauthenticated),
-			"auth_evidence":     common.AuthEvidenceAnonymousProbeSucceeded,
-			"probe_status":      string(common.VerificationVerified),
-			"last_verified_at":  time.Now().UTC().Format(time.RFC3339),
-			"is_anonymous_loot": "true",
+			"objectid":      ollamaID,
+			"endpoint":      baseURL,
+			"name":          host,
+			"loot_observed": true,
+			"service_kind":  "ollama",
 		},
 	})
 	res.Summary.EndpointsProbed++
@@ -148,6 +143,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		return res, nil
 	}
 	res.Summary.EndpointsProbed++
+	markAnonymousInventorySuccess(res.IngestData.Graph.Nodes[0].Properties)
 
 	for _, tag := range tags {
 		showURL := strings.TrimRight(baseURL, "/") + "/api/show"
@@ -240,13 +236,20 @@ func fetchTags(ctx context.Context, client *http.Client, url string, maxItems in
 		return nil, err
 	}
 	type rawResp struct {
-		Models []tagEntry `json:"models"`
+		Models json.RawMessage `json:"models"`
 	}
 	var parsed rawResp
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, fmt.Errorf("decode /api/tags: %w", err)
 	}
-	out := parsed.Models
+	modelsJSON := bytes.TrimSpace(parsed.Models)
+	if len(modelsJSON) == 0 || modelsJSON[0] != '[' {
+		return nil, errors.New("decode /api/tags: expected a models array")
+	}
+	var out []tagEntry
+	if err := json.Unmarshal(modelsJSON, &out); err != nil {
+		return nil, fmt.Errorf("decode /api/tags models: %w", err)
+	}
 	for i := range out {
 		if out[i].Model == "" {
 			out[i].Model = out[i].Name
@@ -256,6 +259,15 @@ func fetchTags(ctx context.Context, client *http.Client, url string, maxItems in
 		out = out[:maxItems]
 	}
 	return out, nil
+}
+
+func markAnonymousInventorySuccess(props map[string]any) {
+	props["auth_method"] = string(common.AuthNone)
+	props["auth_assurance"] = string(common.AuthAssuranceUnauthenticated)
+	props["auth_evidence"] = common.AuthEvidenceAnonymousProbeSucceeded
+	props["probe_status"] = string(common.VerificationVerified)
+	props["last_verified_at"] = time.Now().UTC().Format(time.RFC3339)
+	props["is_anonymous_loot"] = "true"
 }
 
 // showEntry captures the slice of /api/show that we promote onto the

--- a/modules/ollamaloot/looter_test.go
+++ b/modules/ollamaloot/looter_test.go
@@ -6,11 +6,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/adithyan-ak/agenthound/modules/ollamafp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 )
 
 const tagsBody = `{
@@ -28,6 +31,8 @@ func ollamaStubServer(t *testing.T, opts stubOpts) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
+		case "/api/version":
+			_, _ = w.Write([]byte(`{"version":"0.5.1"}`))
 		case "/api/tags":
 			_, _ = w.Write([]byte(tagsBody))
 		case "/api/show":
@@ -48,6 +53,43 @@ func ollamaStubServer(t *testing.T, opts stubOpts) *httptest.Server {
 			w.WriteHeader(404)
 		}
 	}))
+}
+
+func TestFingerprintAndLootPropertiesComposeOnSameEndpoint(t *testing.T) {
+	srv := ollamaStubServer(t, stubOpts{})
+	defer srv.Close()
+	target := action.Target{Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://")}
+
+	fingerprinter, err := ollamafp.New()
+	if err != nil {
+		t.Fatalf("new fingerprinter: %v", err)
+	}
+	fingerprint, err := fingerprinter.Fingerprint(context.Background(), target)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	loot, err := (&Looter{}).Loot(context.Background(), target, action.LootOptions{})
+	if err != nil {
+		t.Fatalf("loot: %v", err)
+	}
+	fingerprintNode := fingerprint.IngestData.Graph.Nodes[0]
+	lootNode := loot.IngestData.Graph.Nodes[0]
+	if fingerprintNode.ID != lootNode.ID {
+		t.Fatalf("same endpoint IDs differ: %q != %q", fingerprintNode.ID, lootNode.ID)
+	}
+	for key, fingerprintValue := range fingerprintNode.Properties {
+		if key == "last_verified_at" {
+			continue
+		}
+		if lootValue, shared := lootNode.Properties[key]; shared &&
+			!reflect.DeepEqual(fingerprintValue, lootValue) {
+			t.Errorf("shared property %q conflicts: fingerprint=%#v loot=%#v", key, fingerprintValue, lootValue)
+		}
+	}
+	if fingerprintNode.Properties["discovered_via"] != "network_scan" ||
+		lootNode.Properties["loot_observed"] != true {
+		t.Errorf("action provenance not separated: fingerprint=%+v loot=%+v", fingerprintNode.Properties, lootNode.Properties)
+	}
 }
 
 type stubOpts struct {
@@ -82,6 +124,12 @@ func TestLoot_AnonymousHappyPath(t *testing.T) {
 		switch n.Kinds[0] {
 		case "OllamaInstance":
 			ollama++
+			if n.Properties["loot_observed"] != true {
+				t.Errorf("OllamaInstance missing loot_observed: %+v", n.Properties)
+			}
+			if _, exists := n.Properties["discovered_via"]; exists {
+				t.Errorf("direct loot claimed discovery provenance: %+v", n.Properties)
+			}
 		case "AIModel":
 			ps, _ := n.Properties["parameter_size"].(string)
 			if ps == "" {
@@ -113,6 +161,7 @@ func TestLoot_AnonymousHappyPath(t *testing.T) {
 		t.Errorf("expected 1 OllamaInstance + 1 plain + 1 fine-tune; got %d/%d/%d",
 			ollama, modelLlama, modelFinetune)
 	}
+	assertAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
 
 	for _, e := range res.IngestData.Graph.Edges {
 		if e.Kind != "PROVIDES_MODEL" {
@@ -120,6 +169,81 @@ func TestLoot_AnonymousHappyPath(t *testing.T) {
 		}
 		if e.SourceKind != "OllamaInstance" || e.TargetKind != "AIModel" {
 			t.Errorf("edge endpoints = %s -> %s, want OllamaInstance -> AIModel", e.SourceKind, e.TargetKind)
+		}
+	}
+}
+
+func TestLoot_TagsFailureDoesNotClaimAnonymousAccess(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "authentication denial", status: http.StatusUnauthorized, body: `{}`},
+		{name: "malformed success shape", status: http.StatusOK, body: `{}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.body))
+			}))
+			defer srv.Close()
+
+			res, err := (&Looter{}).Loot(context.Background(), action.Target{
+				Kind:    "host",
+				Address: strings.TrimPrefix(srv.URL, "http://"),
+			}, action.LootOptions{})
+			if err != nil {
+				t.Fatalf("Loot: %v", err)
+			}
+			assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+			if res.Summary.PartialFailures != 1 {
+				t.Fatalf("PartialFailures = %d, want 1", res.Summary.PartialFailures)
+			}
+		})
+	}
+
+	t.Run("transport failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.NotFoundHandler())
+		address := strings.TrimPrefix(srv.URL, "http://")
+		srv.Close()
+
+		res, err := (&Looter{}).Loot(context.Background(), action.Target{
+			Kind: "host", Address: address,
+		}, action.LootOptions{})
+		if err != nil {
+			t.Fatalf("Loot: %v", err)
+		}
+		assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+		if res.Summary.PartialFailures != 1 {
+			t.Fatalf("PartialFailures = %d, want 1", res.Summary.PartialFailures)
+		}
+	})
+}
+
+func assertAnonymousInventoryClaim(t *testing.T, props map[string]any) {
+	t.Helper()
+	if props["auth_method"] != string(common.AuthNone) ||
+		props["auth_assurance"] != string(common.AuthAssuranceUnauthenticated) ||
+		props["auth_evidence"] != common.AuthEvidenceAnonymousProbeSucceeded ||
+		props["probe_status"] != string(common.VerificationVerified) ||
+		props["is_anonymous_loot"] != "true" {
+		t.Fatalf("anonymous inventory evidence = %+v", props)
+	}
+	if _, ok := props["last_verified_at"].(string); !ok {
+		t.Fatalf("last_verified_at missing from anonymous inventory evidence: %+v", props)
+	}
+}
+
+func assertNoAnonymousInventoryClaim(t *testing.T, props map[string]any) {
+	t.Helper()
+	for _, key := range []string{
+		"auth_method", "auth_assurance", "auth_evidence", "probe_status",
+		"last_verified_at", "is_anonymous_loot",
+	} {
+		if value, present := props[key]; present {
+			t.Errorf("failed inventory fabricated %s=%v: %+v", key, value, props)
 		}
 	}
 }

--- a/modules/openwebuifp/fingerprinter.go
+++ b/modules/openwebuifp/fingerprinter.go
@@ -89,13 +89,17 @@ func (f *Fingerprinter) Fingerprint(ctx context.Context, t action.Target) (*acti
 		}
 		props[k] = v
 	}
-	if _, ok := props["auth_method"]; !ok {
-		props["auth_method"] = "none"
-	}
-	auth := common.AssessAuth(fmt.Sprint(props["auth_method"]))
-	props["auth_method"] = string(auth.Method)
-	props["auth_assurance"] = string(auth.Assurance)
-	props["auth_evidence"] = common.AuthEvidenceAnonymousProbeSucceeded
+	// /api/version and /api/config are deliberately public even when Open
+	// WebUI protects chat and admin surfaces. A successful fingerprint probe
+	// therefore proves service identity only; it must not be promoted into an
+	// anonymous-access claim. Privileged access observations belong to the
+	// looter. Omit the auth fields entirely: writing "unknown" here would
+	// conflict with a looter's affirmative auth=false / anonymous observation
+	// when both actions own the same OpenWebUI node.
+	delete(props, "auth_method")
+	delete(props, "auth_assurance")
+	delete(props, "auth_evidence")
+	delete(props, "is_anonymous_loot")
 	props["probe_status"] = string(common.VerificationVerified)
 	props["last_verified_at"] = time.Now().UTC().Format(time.RFC3339)
 
@@ -113,7 +117,7 @@ func (f *Fingerprinter) Fingerprint(ctx context.Context, t action.Target) (*acti
 		Matched:     true,
 		ServiceKind: "openwebui",
 		Version:     res.Properties["version"],
-		AuthMethod:  res.Properties["auth_method"],
+		AuthMethod:  string(common.AuthUnknown),
 		IngestData:  out,
 		Properties:  res.Properties,
 	}, nil

--- a/modules/openwebuifp/fingerprinter_test.go
+++ b/modules/openwebuifp/fingerprinter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 )
 
 const owuiVersionBody = `{"version":"0.6.5"}`
@@ -62,6 +63,75 @@ func TestFingerprint_OpenWebUI_HappyPath(t *testing.T) {
 	}
 	if len(res.IngestData.Graph.Edges) != 0 {
 		t.Fatalf("expected 0 EXPOSES edges (dead capture removed in v3), got %d", len(res.IngestData.Graph.Edges))
+	}
+	props := res.IngestData.Graph.Nodes[0].Properties
+	if got := props["version"]; got != "0.6.5" {
+		t.Errorf("version = %v, want 0.6.5", got)
+	}
+	for _, key := range []string{"auth_method", "auth_assurance", "auth_evidence", "is_anonymous_loot"} {
+		if _, exists := props[key]; exists {
+			t.Errorf("public identity probe emitted %s: %+v", key, props)
+		}
+	}
+}
+
+// TestFingerprint_OpenWebUI_PublicIdentityDoesNotImplyAnonymousAccess covers
+// the production posture where WEBUI_AUTH=true still leaves the identity
+// endpoints public while privileged endpoints reject anonymous callers.
+func TestFingerprint_OpenWebUI_PublicIdentityDoesNotImplyAnonymousAccess(t *testing.T) {
+	protectedRequests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/version":
+			_, _ = w.Write([]byte(owuiVersionBody))
+		case "/api/config":
+			_, _ = w.Write([]byte(`{"name":"Open WebUI","status":true,"features":{"auth":true,"enable_signup":false}}`))
+		case "/ollama/config":
+			protectedRequests++
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	f, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := f.Fingerprint(context.Background(), action.Target{
+		Kind:    "host",
+		Address: strings.TrimPrefix(srv.URL, "http://"),
+	})
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	if !res.Matched {
+		t.Fatal("expected public Open WebUI identity probes to match")
+	}
+	props := res.IngestData.Graph.Nodes[0].Properties
+	if got := props["version"]; got != "0.6.5" {
+		t.Errorf("version = %v, want 0.6.5", got)
+	}
+	for _, key := range []string{"auth_method", "auth_assurance", "auth_evidence", "is_anonymous_loot"} {
+		if _, exists := props[key]; exists {
+			t.Errorf("public identity probe emitted %s: %+v", key, props)
+		}
+	}
+	if res.AuthMethod != string(common.AuthUnknown) {
+		t.Errorf("AuthMethod = %q, want unknown", res.AuthMethod)
+	}
+	if protectedRequests != 0 {
+		t.Errorf("fingerprinter unexpectedly probed protected endpoint %d times", protectedRequests)
+	}
+	protected, err := http.Get(srv.URL + "/ollama/config")
+	if err != nil {
+		t.Fatalf("GET protected endpoint: %v", err)
+	}
+	defer protected.Body.Close()
+	if protected.StatusCode != http.StatusUnauthorized {
+		t.Errorf("protected endpoint status = %d, want %d", protected.StatusCode, http.StatusUnauthorized)
 	}
 }
 

--- a/modules/openwebuiloot/looter.go
+++ b/modules/openwebuiloot/looter.go
@@ -130,11 +130,11 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		ID:    openwebuiID,
 		Kinds: []string{"OpenWebUIInstance", "AIService"},
 		Properties: map[string]any{
-			"objectid":       openwebuiID,
-			"endpoint":       baseURL,
-			"name":           host,
-			"discovered_via": "openwebui_loot",
-			"service_kind":   "openwebui",
+			"objectid":      openwebuiID,
+			"endpoint":      baseURL,
+			"name":          host,
+			"loot_observed": true,
+			"service_kind":  "openwebui",
 		},
 	})
 	res.Summary.EndpointsProbed++
@@ -418,12 +418,10 @@ func runOllamaConfig(
 			Properties: map[string]any{
 				"objectid":               ollamaID,
 				"endpoint":               canon,
-				"discovered_via":         "openwebui_ollama_config",
 				"service_kind":           "ollama",
 				"configuration_observed": true,
 				"configured_via":         "openwebui",
 				"configured_auth_method": string(common.AuthUnknown),
-				"probe_status":           string(common.VerificationConfiguredUnverified),
 			},
 		})
 		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges, ingest.Edge{

--- a/modules/openwebuiloot/looter_test.go
+++ b/modules/openwebuiloot/looter_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/adithyan-ak/agenthound/modules/openwebuifp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/common"
 )
@@ -65,6 +67,8 @@ func openwebuiStub(t *testing.T, opts openwebuiStubOptions) *httptest.Server {
 			}
 		}
 		switch r.URL.Path {
+		case "/api/version":
+			_, _ = w.Write([]byte(`{"version":"0.6.32"}`))
 		case "/api/config":
 			body := opts.config
 			if body == "" {
@@ -101,6 +105,83 @@ func openwebuiStub(t *testing.T, opts openwebuiStubOptions) *httptest.Server {
 	}))
 }
 
+func TestFingerprintAndLootPropertiesComposeOnSameEndpoint(t *testing.T) {
+	srv := openwebuiStub(t, openwebuiStubOptions{})
+	defer srv.Close()
+	target := action.Target{Kind: "host", Address: addrOf(srv)}
+
+	fingerprinter, err := openwebuifp.New()
+	if err != nil {
+		t.Fatalf("new fingerprinter: %v", err)
+	}
+	fingerprint, err := fingerprinter.Fingerprint(context.Background(), target)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	loot, err := (&Looter{}).Loot(context.Background(), target, action.LootOptions{})
+	if err != nil {
+		t.Fatalf("loot: %v", err)
+	}
+	fingerprintNode := fingerprint.IngestData.Graph.Nodes[0]
+	lootNode := loot.IngestData.Graph.Nodes[0]
+	if fingerprintNode.ID != lootNode.ID {
+		t.Fatalf("same endpoint IDs differ: %q != %q", fingerprintNode.ID, lootNode.ID)
+	}
+	for key, fingerprintValue := range fingerprintNode.Properties {
+		if key == "last_verified_at" {
+			continue
+		}
+		if lootValue, shared := lootNode.Properties[key]; shared &&
+			!reflect.DeepEqual(fingerprintValue, lootValue) {
+			t.Errorf("shared property %q conflicts: fingerprint=%#v loot=%#v", key, fingerprintValue, lootValue)
+		}
+	}
+	if _, exists := fingerprintNode.Properties["auth_method"]; exists {
+		t.Errorf("fingerprint authored auth_method: %+v", fingerprintNode.Properties)
+	}
+	if lootNode.Properties["auth_method"] != string(common.AuthNone) ||
+		lootNode.Properties["auth_evidence"] != common.AuthEvidenceAnonymousProbeSucceeded {
+		t.Errorf("looter lost affirmative anonymous evidence: %+v", lootNode.Properties)
+	}
+	if fingerprintNode.Properties["discovered_via"] != "network_scan" ||
+		lootNode.Properties["loot_observed"] != true {
+		t.Errorf("action provenance not separated: fingerprint=%+v loot=%+v", fingerprintNode.Properties, lootNode.Properties)
+	}
+}
+
+func TestProtectedFingerprintLeavesAuthOwnershipToLooter(t *testing.T) {
+	srv := openwebuiStub(t, openwebuiStubOptions{
+		config: `{"status":true,"name":"Open WebUI","version":"0.6.32","features":{"auth":true,"enable_signup":false}}`,
+	})
+	defer srv.Close()
+	target := action.Target{Kind: "host", Address: addrOf(srv)}
+
+	fingerprinter, err := openwebuifp.New()
+	if err != nil {
+		t.Fatalf("new fingerprinter: %v", err)
+	}
+	fingerprint, err := fingerprinter.Fingerprint(context.Background(), target)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	loot, err := (&Looter{}).Loot(context.Background(), target, action.LootOptions{})
+	if err != nil {
+		t.Fatalf("loot: %v", err)
+	}
+	fingerprintProps := fingerprint.IngestData.Graph.Nodes[0].Properties
+	lootProps := loot.IngestData.Graph.Nodes[0].Properties
+	for _, key := range []string{"auth_method", "auth_assurance", "auth_evidence"} {
+		if _, exists := fingerprintProps[key]; exists {
+			t.Errorf("protected public fingerprint authored %s: %+v", key, fingerprintProps)
+		}
+	}
+	if lootProps["auth_required"] != true ||
+		lootProps["auth_method"] != string(common.AuthUnknown) ||
+		lootProps["auth_evidence"] != common.AuthEvidenceUnknown {
+		t.Errorf("protected looter evidence = %+v", lootProps)
+	}
+}
+
 func addrOf(srv *httptest.Server) string {
 	return strings.TrimPrefix(srv.URL, "http://")
 }
@@ -124,6 +205,12 @@ func TestLoot_OpenWebUI_AnonymousPosture(t *testing.T) {
 	node := res.IngestData.Graph.Nodes[0]
 	if node.Kinds[0] != "OpenWebUIInstance" {
 		t.Errorf("kind = %v, want OpenWebUIInstance", node.Kinds)
+	}
+	if node.Properties["loot_observed"] != true {
+		t.Errorf("OpenWebUIInstance missing loot_observed: %+v", node.Properties)
+	}
+	if _, exists := node.Properties["discovered_via"]; exists {
+		t.Errorf("direct loot claimed discovery provenance: %+v", node.Properties)
 	}
 	if se, _ := node.Properties["signup_enabled"].(bool); !se {
 		t.Errorf("signup_enabled = %v, want true", node.Properties["signup_enabled"])
@@ -344,9 +431,14 @@ func TestLoot_OpenWebUI_OllamaConfig_KeyField(t *testing.T) {
 			if _, claimed := n.Properties["auth_method"]; claimed {
 				t.Errorf("configured backend claimed observed auth: %+v", n.Properties)
 			}
+			if _, claimed := n.Properties["probe_status"]; claimed {
+				t.Errorf("configured backend claimed a probe result: %+v", n.Properties)
+			}
+			if _, claimed := n.Properties["discovered_via"]; claimed {
+				t.Errorf("configured backend overwrote active discovery provenance: %+v", n.Properties)
+			}
 			if n.Properties["configuration_observed"] != true ||
-				n.Properties["configured_auth_method"] != "apiKey" ||
-				n.Properties["probe_status"] != string(common.VerificationConfiguredUnverified) {
+				n.Properties["configured_auth_method"] != "apiKey" {
 				t.Errorf("configured backend evidence missing: %+v", n.Properties)
 			}
 		}

--- a/modules/qdrantloot/looter.go
+++ b/modules/qdrantloot/looter.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -130,13 +131,11 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		ID:    qdrantID,
 		Kinds: []string{"QdrantInstance", "AIService"},
 		Properties: map[string]any{
-			"objectid":          qdrantID,
-			"endpoint":          baseURL,
-			"name":              host,
-			"discovered_via":    "qdrant_loot",
-			"service_kind":      "qdrant",
-			"auth_method":       "none",
-			"is_anonymous_loot": "true",
+			"objectid":      qdrantID,
+			"endpoint":      baseURL,
+			"name":          host,
+			"loot_observed": true,
+			"service_kind":  "qdrant",
 		},
 	})
 	res.Summary.EndpointsProbed++
@@ -152,6 +151,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 		res.Summary.PartialFailures++
 		return res, nil
 	}
+	markAnonymousInventorySuccess(res.IngestData.Graph.Nodes[0].Properties)
 
 	sort.Strings(names)
 
@@ -246,18 +246,35 @@ func fetchCollections(ctx context.Context, client *http.Client, baseURL string, 
 	if err != nil {
 		return nil, err
 	}
-	var parsed struct {
-		Result struct {
-			Collections []struct {
-				Name string `json:"name"`
-			} `json:"collections"`
-		} `json:"result"`
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+		Status string          `json:"status"`
 	}
-	if err := json.Unmarshal(body, &parsed); err != nil {
+	if err := json.Unmarshal(body, &envelope); err != nil {
 		return nil, fmt.Errorf("decode /collections: %w", err)
 	}
-	out := make([]string, 0, len(parsed.Result.Collections))
-	for _, c := range parsed.Result.Collections {
+	resultJSON := bytes.TrimSpace(envelope.Result)
+	if envelope.Status != "ok" || len(resultJSON) == 0 || resultJSON[0] != '{' {
+		return nil, errors.New("decode /collections: expected an ok result object")
+	}
+	var result struct {
+		Collections json.RawMessage `json:"collections"`
+	}
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		return nil, fmt.Errorf("decode /collections result: %w", err)
+	}
+	collectionsJSON := bytes.TrimSpace(result.Collections)
+	if len(collectionsJSON) == 0 || collectionsJSON[0] != '[' {
+		return nil, errors.New("decode /collections: expected a collections array")
+	}
+	var collections []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(collectionsJSON, &collections); err != nil {
+		return nil, fmt.Errorf("decode /collections array: %w", err)
+	}
+	out := make([]string, 0, len(collections))
+	for _, c := range collections {
 		if c.Name == "" {
 			continue
 		}
@@ -267,6 +284,15 @@ func fetchCollections(ctx context.Context, client *http.Client, baseURL string, 
 		}
 	}
 	return out, nil
+}
+
+func markAnonymousInventorySuccess(props map[string]any) {
+	props["auth_method"] = string(common.AuthNone)
+	props["auth_assurance"] = string(common.AuthAssuranceUnauthenticated)
+	props["auth_evidence"] = common.AuthEvidenceAnonymousProbeSucceeded
+	props["probe_status"] = string(common.VerificationVerified)
+	props["last_verified_at"] = time.Now().UTC().Format(time.RFC3339)
+	props["is_anonymous_loot"] = "true"
 }
 
 // fetchCollectionPoints reads /collections/{name} and returns the

--- a/modules/qdrantloot/looter_test.go
+++ b/modules/qdrantloot/looter_test.go
@@ -7,12 +7,15 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/adithyan-ak/agenthound/modules/qdrantfp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 )
 
 const collectionsBody = `{"result":{"collections":[{"name":"docs"},{"name":"chat-history"}]},"status":"ok","time":0.001}`
@@ -22,6 +25,8 @@ func qdrantStub(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.URL.Path == "/telemetry" && r.Method == "GET":
+			_, _ = w.Write([]byte(`{"result":{"app":{"name":"qdrant","version":"1.7.4"}}}`))
 		case r.URL.Path == "/collections" && r.Method == "GET":
 			_, _ = w.Write([]byte(collectionsBody))
 		case r.URL.Path == "/collections/docs" && r.Method == "GET":
@@ -32,6 +37,40 @@ func qdrantStub(t *testing.T) *httptest.Server {
 			w.WriteHeader(404)
 		}
 	}))
+}
+
+func TestFingerprintAndLootPropertiesComposeOnSameEndpoint(t *testing.T) {
+	srv := qdrantStub(t)
+	defer srv.Close()
+	target := action.Target{Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://")}
+
+	fingerprinter, err := qdrantfp.New()
+	if err != nil {
+		t.Fatalf("new fingerprinter: %v", err)
+	}
+	fingerprint, err := fingerprinter.Fingerprint(context.Background(), target)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	loot, err := (&Looter{}).Loot(context.Background(), target, action.LootOptions{})
+	if err != nil {
+		t.Fatalf("loot: %v", err)
+	}
+	fingerprintNode := fingerprint.IngestData.Graph.Nodes[0]
+	lootNode := loot.IngestData.Graph.Nodes[0]
+	if fingerprintNode.ID != lootNode.ID {
+		t.Fatalf("same endpoint IDs differ: %q != %q", fingerprintNode.ID, lootNode.ID)
+	}
+	for key, fingerprintValue := range fingerprintNode.Properties {
+		if lootValue, shared := lootNode.Properties[key]; shared &&
+			!reflect.DeepEqual(fingerprintValue, lootValue) {
+			t.Errorf("shared property %q conflicts: fingerprint=%#v loot=%#v", key, fingerprintValue, lootValue)
+		}
+	}
+	if fingerprintNode.Properties["discovered_via"] != "network_scan" ||
+		lootNode.Properties["loot_observed"] != true {
+		t.Errorf("action provenance not separated: fingerprint=%+v loot=%+v", fingerprintNode.Properties, lootNode.Properties)
+	}
 }
 
 func TestLoot_QdrantHappy(t *testing.T) {
@@ -53,6 +92,12 @@ func TestLoot_QdrantHappy(t *testing.T) {
 	if node.Kinds[0] != "QdrantInstance" {
 		t.Errorf("kind = %v, want QdrantInstance", node.Kinds)
 	}
+	if node.Properties["loot_observed"] != true {
+		t.Errorf("QdrantInstance missing loot_observed: %+v", node.Properties)
+	}
+	if _, exists := node.Properties["discovered_via"]; exists {
+		t.Errorf("direct loot claimed discovery provenance: %+v", node.Properties)
+	}
 	if cc, _ := node.Properties["collection_count"].(int); cc != 2 {
 		t.Errorf("collection_count = %v, want 2", node.Properties["collection_count"])
 	}
@@ -73,6 +118,7 @@ func TestLoot_QdrantHappy(t *testing.T) {
 	if res.Summary.PartialFailures != 0 {
 		t.Errorf("PartialFailures = %d, want 0", res.Summary.PartialFailures)
 	}
+	assertAnonymousInventoryClaim(t, node.Properties)
 }
 
 // A collection that returns a bad shape is counted in the inventory but
@@ -110,6 +156,65 @@ func TestLoot_Qdrant_CollectionDetailBadJSON(t *testing.T) {
 	if res.Summary.PartialFailures != 1 {
 		t.Errorf("PartialFailures = %d, want 1", res.Summary.PartialFailures)
 	}
+	assertAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+}
+
+func TestLoot_Qdrant_CollectionsMalformedOrUnavailableDoesNotClaimAnonymousAccess(t *testing.T) {
+	t.Run("malformed success shape", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		res, err := (&Looter{}).Loot(context.Background(), action.Target{
+			Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://"),
+		}, action.LootOptions{})
+		if err != nil {
+			t.Fatalf("Loot: %v", err)
+		}
+		assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+	})
+
+	t.Run("transport failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.NotFoundHandler())
+		address := strings.TrimPrefix(srv.URL, "http://")
+		srv.Close()
+
+		res, err := (&Looter{}).Loot(context.Background(), action.Target{
+			Kind: "host", Address: address,
+		}, action.LootOptions{})
+		if err != nil {
+			t.Fatalf("Loot: %v", err)
+		}
+		assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
+	})
+}
+
+func assertAnonymousInventoryClaim(t *testing.T, props map[string]any) {
+	t.Helper()
+	if props["auth_method"] != string(common.AuthNone) ||
+		props["auth_assurance"] != string(common.AuthAssuranceUnauthenticated) ||
+		props["auth_evidence"] != common.AuthEvidenceAnonymousProbeSucceeded ||
+		props["probe_status"] != string(common.VerificationVerified) ||
+		props["is_anonymous_loot"] != "true" {
+		t.Fatalf("anonymous inventory evidence = %+v", props)
+	}
+	if _, ok := props["last_verified_at"].(string); !ok {
+		t.Fatalf("last_verified_at missing from anonymous inventory evidence: %+v", props)
+	}
+}
+
+func assertNoAnonymousInventoryClaim(t *testing.T, props map[string]any) {
+	t.Helper()
+	for _, key := range []string{
+		"auth_method", "auth_assurance", "auth_evidence", "probe_status",
+		"last_verified_at", "is_anonymous_loot", "anonymous_listing",
+	} {
+		if value, present := props[key]; present {
+			t.Errorf("failed inventory fabricated %s=%v: %+v", key, value, props)
+		}
+	}
 }
 
 // A closed/unreachable port (and a non-200 listing) must not error — the
@@ -137,6 +242,7 @@ func TestLoot_Qdrant_CollectionsListFails(t *testing.T) {
 	if res.Summary.PartialFailures != 1 {
 		t.Errorf("PartialFailures = %d, want 1", res.Summary.PartialFailures)
 	}
+	assertNoAnonymousInventoryClaim(t, res.IngestData.Graph.Nodes[0].Properties)
 }
 
 // TestLoot_Qdrant_ManyCollectionsConcurrent exercises the bounded worker

--- a/sdk/rules/builtin/fingerprints/openwebui.yaml
+++ b/sdk/rules/builtin/fingerprints/openwebui.yaml
@@ -15,10 +15,9 @@
 # the backend URL is now captured by the openwebuiloot Looter via the
 # admin-gated /ollama/config endpoint (which does return OLLAMA_BASE_URLS).
 #
-# The second probe is retained as an anonymous shape guard: /api/config
-# is expected to return {"name": "Open WebUI", ...} on every version.
-# The soft matcher strengthens the fingerprint without depending on any
-# captured field.
+# The second probe is a public shape guard: /api/config is expected to return
+# {"name": "Open WebUI", ...} on every version. These public endpoints prove
+# service identity, not anonymous access to chat or admin surfaces.
 id: openwebui
 name: Open WebUI chat frontend
 description: 'Identifies Open WebUI from its version and application-config response shapes'
@@ -55,6 +54,4 @@ emit:
     - AIService
   properties:
     service_kind: openwebui
-    auth_method: none
-    is_anonymous_loot: "true"
     version: "{capture:version}"

--- a/server/internal/analysis/evidence_graph.go
+++ b/server/internal/analysis/evidence_graph.go
@@ -170,7 +170,13 @@ func calculateAttackCost(edges []PathEdge) AttackCost {
 
 	var total float64
 	for i, edge := range edges {
-		weight, ok := evidenceFloat(edge.Properties["risk_weight"])
+		rawWeight := edge.Properties["risk_weight"]
+		if edge.Kind == "TRUSTS_SERVER" {
+			if effective, exists := edge.Properties["effective_risk_weight"]; exists {
+				rawWeight = effective
+			}
+		}
+		weight, ok := evidenceFloat(rawWeight)
 		if !ok || weight < 0 || math.IsNaN(weight) || math.IsInf(weight, 0) {
 			cost.MissingWeightEdgeIndexes = append(cost.MissingWeightEdgeIndexes, i)
 			continue

--- a/server/internal/analysis/evidence_graph_test.go
+++ b/server/internal/analysis/evidence_graph_test.go
@@ -61,6 +61,28 @@ func TestEvidenceGraphMissingWeightHasNullableIncompleteCost(t *testing.T) {
 	}
 }
 
+func TestEvidenceGraphUsesEffectiveTrustWeightWithoutMutatingRawEvidence(t *testing.T) {
+	path, err := testAttackPath(evidenceRow(
+		[]string{"a", "b", "c"},
+		[]map[string]any{
+			evidenceEdge("a", "b", "TRUSTS_SERVER", map[string]any{
+				"risk_weight": 0.7, "effective_risk_weight": 0.1,
+			}),
+			evidenceEdge("b", "c", "PROVIDES_TOOL", map[string]any{"risk_weight": 0.2}),
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path.Cost.Value == nil || *path.Cost.Value < 0.299 || *path.Cost.Value > 0.301 {
+		t.Fatalf("effective trust weight was not used in evidence sum: %+v", path.Cost)
+	}
+	if path.Edges[0].Properties["risk_weight"] != 0.7 ||
+		path.Edges[0].Properties["effective_risk_weight"] != 0.1 {
+		t.Fatalf("configured/derived relationship evidence was mutated: %+v", path.Edges[0].Properties)
+	}
+}
+
 func TestEvidenceGraphPreservesBranchedAndDisconnectedShapes(t *testing.T) {
 	t.Run("branched", func(t *testing.T) {
 		path, err := testAttackPath(evidenceRow(

--- a/server/internal/analysis/prebuilt/auth_effective_integration_test.go
+++ b/server/internal/analysis/prebuilt/auth_effective_integration_test.go
@@ -1,0 +1,99 @@
+package prebuilt
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+func TestIntegrationNoAuthQueriesRequireObservedEffectiveTuple(t *testing.T) {
+	uri := os.Getenv("AGENTHOUND_NEO4J_URI")
+	if uri == "" {
+		t.Skip("skipping integration test: AGENTHOUND_NEO4J_URI not set")
+	}
+	ctx := context.Background()
+	driver, err := graph.NewDriver(
+		uri,
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+	db := graph.NewDB(graph.NewReader(driver), graph.NewWriter(driver))
+
+	const scanID = "test-prebuilt-effective-auth"
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(ctx,
+			"MATCH (n {scan_id: $scan_id}) DETACH DELETE n",
+			map[string]any{"scan_id": scanID})
+	}
+	cleanup()
+	defer cleanup()
+
+	_, err = db.ExecuteWrite(ctx, `CREATE
+  (:MCPServer {
+    objectid: 'prebuilt-observed-anon', name: 'Observed anonymous', scan_id: $scan_id,
+    effective_auth_method: 'none', effective_auth_assurance: 'unauthenticated',
+    effective_auth_evidence: 'anonymous_probe_succeeded', effective_auth_source: 'observed'
+  }),
+  (:MCPServer {
+    objectid: 'prebuilt-configured-none', name: 'Configured none', scan_id: $scan_id,
+    effective_auth_method: 'none', effective_auth_assurance: 'unauthenticated',
+    effective_auth_evidence: 'anonymous_probe_succeeded', effective_auth_source: 'configured'
+  }),
+  (:MCPServer {
+    objectid: 'prebuilt-observed-unknown', name: 'Observed unknown', scan_id: $scan_id,
+    effective_auth_method: 'unknown', effective_auth_assurance: 'unknown',
+    effective_auth_evidence: 'unknown', effective_auth_source: 'configured'
+  }),
+  (:A2AAgent {
+    objectid: 'prebuilt-a2a-observed-anon', name: 'Observed anonymous A2A', scan_id: $scan_id,
+    effective_auth_method: 'none', effective_auth_assurance: 'unauthenticated',
+    effective_auth_evidence: 'anonymous_probe_succeeded', effective_auth_source: 'observed'
+  }),
+  (:A2AAgent {
+    objectid: 'prebuilt-a2a-configured-none', name: 'Configured none A2A', scan_id: $scan_id,
+    effective_auth_method: 'none', effective_auth_assurance: 'unauthenticated',
+    effective_auth_evidence: 'anonymous_probe_succeeded', effective_auth_source: 'configured'
+  })
+RETURN 5 AS created`, map[string]any{"scan_id": scanID})
+	if err != nil {
+		t.Fatalf("seed effective auth nodes: %v", err)
+	}
+
+	rows, err := db.Query(ctx, CypherNoAuthServers, nil)
+	if err != nil {
+		t.Fatalf("run no-auth prebuilt query: %v", err)
+	}
+	matched := make([]string, 0, len(rows))
+	for _, row := range rows {
+		id, _ := row["server_id"].(string)
+		if id == "prebuilt-observed-anon" ||
+			id == "prebuilt-configured-none" ||
+			id == "prebuilt-observed-unknown" {
+			matched = append(matched, id)
+		}
+	}
+	if len(matched) != 1 || matched[0] != "prebuilt-observed-anon" {
+		t.Fatalf("effective no-auth matches = %v, want only observed anonymous", matched)
+	}
+
+	a2aRows, err := db.Query(ctx, CypherNoAuthA2A, nil)
+	if err != nil {
+		t.Fatalf("run A2A no-auth prebuilt query: %v", err)
+	}
+	a2aMatched := make([]string, 0, len(a2aRows))
+	for _, row := range a2aRows {
+		id, _ := row["agent_id"].(string)
+		if id == "prebuilt-a2a-observed-anon" || id == "prebuilt-a2a-configured-none" {
+			a2aMatched = append(a2aMatched, id)
+		}
+	}
+	if len(a2aMatched) != 1 || a2aMatched[0] != "prebuilt-a2a-observed-anon" {
+		t.Fatalf("effective A2A no-auth matches = %v, want only observed anonymous", a2aMatched)
+	}
+}

--- a/server/internal/analysis/prebuilt/cypher.go
+++ b/server/internal/analysis/prebuilt/cypher.go
@@ -46,7 +46,10 @@ WHERE ANY(cap IN t.capability_surface WHERE cap = 'shell_access')
 RETURN a.name AS agent_name,
        s.name AS server_name,
        t.name AS tool_name,
-       s.auth_method AS auth_method,
+       s.effective_auth_method AS auth_method,
+       s.effective_auth_assurance AS auth_assurance,
+       s.effective_auth_evidence AS auth_evidence,
+       s.effective_auth_source AS auth_source,
        a.objectid AS agent_id,
        s.objectid AS server_id,
        t.objectid AS tool_id
@@ -138,24 +141,30 @@ ORDER BY r.confidence DESC`
 
 const CypherNoAuthServers = `
 MATCH (s:MCPServer)
-WHERE s.auth_method = 'none'
-  AND s.auth_evidence = 'anonymous_probe_succeeded'
+WHERE s.effective_auth_source = 'observed'
+  AND s.effective_auth_method = 'none'
+  AND s.effective_auth_assurance = 'unauthenticated'
+  AND s.effective_auth_evidence = 'anonymous_probe_succeeded'
 OPTIONAL MATCH (s)-[:PROVIDES_TOOL]->(t:MCPTool)
 RETURN s.name AS server_name,
        s.endpoint AS endpoint,
        s.transport AS transport,
+       s.effective_auth_source AS auth_source,
        count(t) AS tool_count,
        s.objectid AS server_id
 ORDER BY tool_count DESC`
 
 const CypherNoAuthA2A = `
 MATCH (a:A2AAgent)
-WHERE a.auth_method = 'none'
-  AND a.auth_evidence = 'anonymous_probe_succeeded'
+WHERE a.effective_auth_source = 'observed'
+  AND a.effective_auth_method = 'none'
+  AND a.effective_auth_assurance = 'unauthenticated'
+  AND a.effective_auth_evidence = 'anonymous_probe_succeeded'
 OPTIONAL MATCH (a)-[:ADVERTISES_SKILL]->(sk:A2ASkill)
 RETURN a.name AS agent_name,
        a.url AS url,
        a.provider AS provider,
+       a.effective_auth_source AS auth_source,
        count(sk) AS skill_count,
        a.objectid AS agent_id
 ORDER BY skill_count DESC`
@@ -217,8 +226,8 @@ WHERE c.high_entropy = true
   AND c.material_status = 'observed'
   AND c.exposure_status = 'exposed'
   AND c.merge_key = 'value_hash'
-OPTIONAL MATCH (s:MCPServer)-[:HAS_ENV_VAR]->(c)
-RETURN c.name AS credential_name,
+OPTIONAL MATCH (s:MCPServer)-[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(c)
+RETURN DISTINCT c.name AS credential_name,
        c.type AS credential_type,
        c.source AS source,
        s.name AS server_name,
@@ -236,8 +245,10 @@ OPTIONAL MATCH (s)-[:PROVIDES_TOOL]->(t:MCPTool)
 RETURN s.name AS server_name,
        agent_count,
        count(t) AS tool_count,
-       s.auth_method AS auth_method,
-       s.auth_evidence AS auth_evidence,
+       s.effective_auth_method AS auth_method,
+       s.effective_auth_assurance AS auth_assurance,
+       s.effective_auth_evidence AS auth_evidence,
+       s.effective_auth_source AS auth_source,
        s.endpoint AS endpoint,
        s.objectid AS server_id
 ORDER BY agent_count DESC, tool_count DESC`

--- a/server/internal/analysis/prebuilt/cypher_truth_test.go
+++ b/server/internal/analysis/prebuilt/cypher_truth_test.go
@@ -10,14 +10,23 @@ func TestUnknownAuthAndSignatureDoNotMatchAbsenceQueries(t *testing.T) {
 		"mcp": CypherNoAuthServers,
 		"a2a": CypherNoAuthA2A,
 	} {
-		if strings.Contains(query, "auth_method IS NULL") {
+		if strings.Contains(query, "effective_auth_method IS NULL") {
 			t.Errorf("%s no-auth query treats unknown as none:\n%s", name, query)
 		}
-		if !strings.Contains(query, "auth_method = 'none'") {
+		if !strings.Contains(query, "effective_auth_method = 'none'") {
 			t.Errorf("%s no-auth query lacks explicit-none predicate", name)
 		}
-		if !strings.Contains(query, "auth_evidence = 'anonymous_probe_succeeded'") {
+		if !strings.Contains(query, "effective_auth_assurance = 'unauthenticated'") ||
+			!strings.Contains(query, "effective_auth_evidence = 'anonymous_probe_succeeded'") {
 			t.Errorf("%s no-auth query lacks explicit anonymous-probe evidence", name)
+		}
+	}
+	for name, query := range map[string]string{
+		"MCP": CypherNoAuthServers,
+		"A2A": CypherNoAuthA2A,
+	} {
+		if !strings.Contains(query, "effective_auth_source = 'observed'") {
+			t.Fatalf("%s no-auth query must require runtime observation:\n%s", name, query)
 		}
 	}
 	if strings.Contains(CypherUnsignedCards, "is_signed IS NULL") {
@@ -31,7 +40,7 @@ func TestUnknownAuthAndSignatureDoNotMatchAbsenceQueries(t *testing.T) {
 func TestChokepointQueryReturnsAnonymousEvidence(t *testing.T) {
 	if !strings.Contains(
 		CypherChokepointServers,
-		"s.auth_evidence AS auth_evidence",
+		"s.effective_auth_evidence AS auth_evidence",
 	) {
 		t.Fatalf(
 			"chokepoint query cannot distinguish confirmed anonymous access:\n%s",
@@ -40,11 +49,40 @@ func TestChokepointQueryReturnsAnonymousEvidence(t *testing.T) {
 	}
 }
 
+func TestAuthDisplayingPrebuiltQueriesUseEffectiveTuple(t *testing.T) {
+	for name, query := range map[string]string{
+		"agents shell": CypherAgentsShellAccess,
+		"chokepoints":  CypherChokepointServers,
+	} {
+		if !strings.Contains(query, "s.effective_auth_method AS auth_method") {
+			t.Errorf("%s query displays configured auth instead of effective auth:\n%s", name, query)
+		}
+		if strings.Contains(query, "s.auth_method AS auth_method") {
+			t.Errorf("%s query still displays stale configured auth:\n%s", name, query)
+		}
+	}
+	if !strings.Contains(CypherChokepointServers, "s.effective_auth_evidence AS auth_evidence") {
+		t.Fatalf("chokepoint query omits effective evidence:\n%s", CypherChokepointServers)
+	}
+	for name, query := range map[string]string{
+		"agents shell": CypherAgentsShellAccess,
+		"MCP no auth":  CypherNoAuthServers,
+		"A2A no auth":  CypherNoAuthA2A,
+		"chokepoints":  CypherChokepointServers,
+	} {
+		if !strings.Contains(query, "effective_auth_source AS auth_source") {
+			t.Errorf("%s query omits effective auth source:\n%s", name, query)
+		}
+	}
+}
+
 func TestHighEntropyQueryRequiresObservedMaterial(t *testing.T) {
 	for _, clause := range []string{
 		"c.material_status = 'observed'",
 		"c.exposure_status = 'exposed'",
 		"c.merge_key = 'value_hash'",
+		"-[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(c)",
+		"RETURN DISTINCT",
 	} {
 		if !strings.Contains(CypherHighEntropySecrets, clause) {
 			t.Errorf("high-entropy query missing explicit evidence gate %q", clause)
@@ -53,6 +91,10 @@ func TestHighEntropyQueryRequiresObservedMaterial(t *testing.T) {
 	if strings.Contains(CypherHighEntropySecrets, "material_status IS NULL") ||
 		strings.Contains(CypherHighEntropySecrets, "exposure_status IS NULL") {
 		t.Fatal("high-entropy query accepts legacy missing evidence as observed exposure")
+	}
+	if strings.Contains(CypherHighEntropySecrets, "HAS_ENV_VAR") ||
+		strings.Contains(CypherHighEntropySecrets, "location") {
+		t.Fatalf("high-entropy query attributes credentials by config location instead of canonical authentication topology:\n%s", CypherHighEntropySecrets)
 	}
 }
 

--- a/server/internal/analysis/processors/auth_strength.go
+++ b/server/internal/analysis/processors/auth_strength.go
@@ -12,14 +12,18 @@ import (
 	"github.com/adithyan-ak/agenthound/server/internal/graph"
 )
 
-// AuthStrength materializes a numeric auth_strength property on every node
-// that carries a categorical auth_method (MCPServer, A2AAgent). Downstream
-// processors (notably confused_deputy) can then compare auth gradients
-// directly in Cypher instead of re-deriving the score map.
+// AuthStrength materializes one paired effective authentication tuple and a
+// numeric auth_strength property on MCPServer and A2AAgent nodes. Configured
+// auth_* properties remain immutable collection provenance. A valid, known
+// MCP or A2A runtime observation wins for node posture only under its strict
+// protocol-specific evidence contract; unknown/unavailable runtime
+// observations fall back to the complete configured tuple.
 //
-// Pre-pass: no dependencies, and it only updates node properties — it
-// writes no composite edges, so it needs no source_collector and is not
-// touched by composite edge retirement.
+// The pre-pass also materializes derived effective_* properties on incoming
+// TRUSTS_SERVER relationships. Only confirmed observed anonymous access can
+// override every incoming relationship. For every other posture, each edge's
+// configured risk and completeness are retained independently; one observed
+// authenticated path must not rewrite unrelated configured access paths.
 type AuthStrength struct{}
 
 func (p *AuthStrength) Name() string           { return "auth_strength" }
@@ -28,15 +32,79 @@ func (p *AuthStrength) Dependencies() []string { return nil }
 func (p *AuthStrength) Process(ctx context.Context, db graph.GraphDB, _ string) (graph.ProcessingStats, error) {
 	start := time.Now()
 
-	cypher := fmt.Sprintf(`MATCH (n) WHERE n.auth_method IS NOT NULL
-SET n.auth_strength = %s,
-    n.auth_assurance = %s
-RETURN count(n) AS updated`,
-		authStrengthCase("n.auth_method", "n.auth_evidence"),
-		authAssuranceCase("n.auth_method", "n.auth_evidence"))
+	// This predicate intentionally duplicates the strict ingest contract at the
+	// analysis boundary. It makes upgrades safe for an existing database that
+	// predates tuple validation: malformed legacy observed fields cannot become
+	// effective merely because observed_auth_method is non-empty.
+	validKnownObserved := `(
+  (n:MCPServer AND n.transport = 'http' AND n.status = 'reachable' AND (
+    (n.observed_auth_method = 'none' AND
+     n.observed_auth_assurance = 'unauthenticated' AND
+     n.observed_auth_evidence = 'anonymous_probe_succeeded') OR
+    (n.observed_auth_method IN ['basic', 'apiKey'] AND
+     n.observed_auth_assurance = 'weak' AND
+     n.observed_auth_evidence = 'configured_credential') OR
+    (n.observed_auth_method = 'bearer' AND
+     n.observed_auth_assurance = 'moderate' AND
+     n.observed_auth_evidence = 'configured_credential') OR
+    (n.observed_auth_method IN ['oauth', 'oidc', 'mtls'] AND
+     n.observed_auth_assurance = 'strong' AND
+     n.observed_auth_evidence = 'configured_credential') OR
+    (n.observed_auth_method = 'custom' AND
+     n.observed_auth_assurance = 'unknown' AND
+     n.observed_auth_evidence = 'configured_credential')
+  )) OR
+  (n:A2AAgent AND
+   n.auth_probe_method = 'get_task_nonexistent' AND
+   n.auth_probe_status = 'anonymous_protocol_access' AND
+   n.auth_probe_detail IN ['task_not_found_v1', 'task_not_found_v0_3'] AND
+   n.observed_auth_method = 'none' AND
+   n.observed_auth_assurance = 'unauthenticated' AND
+   n.observed_auth_evidence = 'anonymous_probe_succeeded')
+)`
 
-	updated, err := db.ExecuteWrite(ctx, cypher, map[string]any{})
+	nodeCypher := fmt.Sprintf(`MATCH (n)
+WHERE (n:MCPServer OR n:A2AAgent) AND n.auth_method IS NOT NULL
+WITH n, %s AS use_observed
+WITH n,
+     CASE WHEN use_observed THEN n.observed_auth_method ELSE n.auth_method END AS effective_method,
+     CASE WHEN use_observed THEN n.observed_auth_evidence ELSE n.auth_evidence END AS effective_evidence,
+     CASE WHEN use_observed THEN 'observed' ELSE 'configured' END AS effective_source
+SET n.effective_auth_method = effective_method,
+    n.effective_auth_assurance = %s,
+    n.effective_auth_evidence = effective_evidence,
+    n.effective_auth_source = effective_source,
+    n.auth_strength = %s
+RETURN count(n) AS updated`,
+		validKnownObserved,
+		authAssuranceCase("effective_method", "effective_evidence", "effective_source"),
+		authStrengthCase("effective_method", "effective_evidence", "effective_source"))
+
+	updated, err := db.ExecuteWrite(ctx, nodeCypher, map[string]any{})
 	if err != nil {
+		return graph.ProcessingStats{ProcessorName: p.Name(), Duration: time.Since(start)}, err
+	}
+
+	trustCypher := `MATCH ()-[t:TRUSTS_SERVER]->(s:MCPServer)
+WITH t, s,
+     s.effective_auth_source = 'observed' AND
+     s.effective_auth_method = 'none' AND
+     s.effective_auth_assurance = 'unauthenticated' AND
+     s.effective_auth_evidence = 'anonymous_probe_succeeded' AS observed_anonymous
+SET t.effective_risk_weight = CASE
+      WHEN observed_anonymous THEN 0.1
+      ELSE t.risk_weight
+    END,
+    t.effective_auth_assessment_complete = CASE
+      WHEN observed_anonymous THEN true
+      ELSE t.auth_assessment_complete
+    END,
+    t.effective_auth_source = CASE
+      WHEN observed_anonymous THEN 'observed'
+      ELSE 'configured'
+    END
+RETURN count(t) AS updated`
+	if _, err := db.ExecuteWrite(ctx, trustCypher, map[string]any{}); err != nil {
 		return graph.ProcessingStats{ProcessorName: p.Name(), Duration: time.Since(start)}, err
 	}
 	return graph.ProcessingStats{
@@ -49,9 +117,11 @@ RETURN count(n) AS updated`,
 // authStrengthCase renders a Cypher CASE expression that maps the given
 // auth_method property to its numeric strength, sourced from
 // riskscore.AuthStrengthScores so the runtime risk model and the
-// materialized node property never drift. Unknown/custom methods yield null,
-// which removes any stale numeric property instead of inventing weakness.
-func authStrengthCase(prop, evidenceProp string) string {
+// materialized node property never drift. None requires affirmative observed
+// provenance in addition to anonymous-probe evidence. Unknown/custom methods
+// yield null, which removes any stale numeric property instead of inventing
+// weakness.
+func authStrengthCase(prop, evidenceProp, sourceProp string) string {
 	keys := make([]string, 0, len(riskscore.AuthStrengthScores))
 	for k := range riskscore.AuthStrengthScores {
 		keys = append(keys, k)
@@ -61,12 +131,13 @@ func authStrengthCase(prop, evidenceProp string) string {
 	var sb strings.Builder
 	fmt.Fprintf(
 		&sb,
-		"CASE WHEN %s = '%s' AND coalesce(%s, '%s') <> '%s' THEN null ELSE CASE %s",
+		"CASE WHEN %s = '%s' AND (coalesce(%s, '%s') <> '%s' OR coalesce(%s, 'configured') <> 'observed') THEN null ELSE CASE %s",
 		prop,
 		common.AuthNone,
 		evidenceProp,
 		common.AuthEvidenceUnknown,
 		common.AuthEvidenceAnonymousProbeSucceeded,
+		sourceProp,
 		prop,
 	)
 	for _, k := range keys {
@@ -76,9 +147,9 @@ func authStrengthCase(prop, evidenceProp string) string {
 	return sb.String()
 }
 
-func authAssuranceCase(prop, evidenceProp string) string {
+func authAssuranceCase(prop, evidenceProp, sourceProp string) string {
 	return fmt.Sprintf(
-		"CASE WHEN %s = '%s' AND coalesce(%s, '%s') <> '%s' THEN '%s' ELSE "+
+		"CASE WHEN %s = '%s' AND (coalesce(%s, '%s') <> '%s' OR coalesce(%s, 'configured') <> 'observed') THEN '%s' ELSE "+
 			"CASE %s WHEN '%s' THEN '%s' WHEN '%s' THEN '%s' WHEN '%s' THEN '%s' "+
 			"WHEN '%s' THEN '%s' WHEN '%s' THEN '%s' WHEN '%s' THEN '%s' "+
 			"WHEN '%s' THEN '%s' ELSE '%s' END END",
@@ -87,6 +158,7 @@ func authAssuranceCase(prop, evidenceProp string) string {
 		evidenceProp,
 		common.AuthEvidenceUnknown,
 		common.AuthEvidenceAnonymousProbeSucceeded,
+		sourceProp,
 		common.AuthAssuranceUnknown,
 		prop,
 		common.AuthNone, common.AuthAssuranceUnauthenticated,

--- a/server/internal/analysis/processors/auth_strength_integration_test.go
+++ b/server/internal/analysis/processors/auth_strength_integration_test.go
@@ -1,0 +1,262 @@
+package processors
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+// TestIntegrationAuthStrengthEffectiveTuple proves the effective-auth
+// precedence and trust-edge isolation against Neo4j. It is deliberately one
+// matrix so every case is evaluated by the same materialization pass:
+// observed anonymous wins globally, observed bearer wins node posture without
+// rewriting unrelated configured paths, unknown observations fall back, stdio
+// remains configured, and only exact bounded A2A probe evidence overrides its
+// card declaration.
+func TestIntegrationAuthStrengthEffectiveTuple(t *testing.T) {
+	uri := os.Getenv("AGENTHOUND_NEO4J_URI")
+	if uri == "" {
+		t.Skip("skipping integration test: AGENTHOUND_NEO4J_URI not set")
+	}
+	ctx := context.Background()
+	driver, err := graph.NewDriver(
+		uri,
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+
+	const scanID = "test-effective-auth"
+	db := graph.NewDB(graph.NewReader(driver), graph.NewWriter(driver))
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(ctx,
+			"MATCH (n) WHERE n.scan_id = $sid DETACH DELETE n",
+			map[string]any{"sid": scanID})
+	}
+	cleanup()
+	defer cleanup()
+
+	nodes := []ingest.Node{
+		authTestAgent("auth-agent-anon-a", scanID),
+		authTestAgent("auth-agent-anon-b", scanID),
+		authTestAgent("auth-agent-bearer-a", scanID),
+		authTestAgent("auth-agent-bearer-b", scanID),
+		authTestAgent("auth-agent-fallback", scanID),
+		authTestAgent("auth-agent-stdio", scanID),
+		{
+			ID: "auth-server-anon", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name": "anonymous runtime", "transport": "http", "status": "reachable",
+				"auth_method": "bearer", "auth_assurance": "moderate", "auth_evidence": "configured_credential",
+				"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+				"observed_auth_evidence": "anonymous_probe_succeeded", "scan_id": scanID,
+			},
+		},
+		{
+			ID: "auth-server-bearer", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name": "bearer runtime", "transport": "http", "status": "reachable",
+				"auth_method": "oauth", "auth_assurance": "strong", "auth_evidence": "configured_credential",
+				"observed_auth_method": "bearer", "observed_auth_assurance": "moderate",
+				"observed_auth_evidence": "configured_credential", "scan_id": scanID,
+			},
+		},
+		{
+			ID: "auth-server-fallback", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name": "unknown runtime", "transport": "http", "status": "reachable",
+				"auth_method": "apiKey", "auth_assurance": "weak", "auth_evidence": "configured_credential",
+				"observed_auth_method": "unknown", "observed_auth_assurance": "unknown",
+				"observed_auth_evidence": "configured_credential", "scan_id": scanID,
+			},
+		},
+		{
+			ID: "auth-server-stdio", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name": "local process", "transport": "stdio", "status": "reachable",
+				"auth_method": "unknown", "auth_assurance": "unknown", "auth_evidence": "local_process",
+				"observed_auth_method": "unknown", "observed_auth_assurance": "unknown",
+				"observed_auth_evidence": "local_process", "scan_id": scanID,
+			},
+		},
+		{
+			ID: "auth-a2a", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+				"name": "A2A fallback", "auth_method": "mtls", "auth_assurance": "strong",
+				"auth_evidence": "declared_security_scheme", "scan_id": scanID,
+			},
+		},
+		{
+			ID: "auth-a2a-observed", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+				"name": "A2A observed anonymous", "auth_method": "apiKey", "auth_assurance": "weak",
+				"auth_evidence": "declared_security_scheme", "scan_id": scanID,
+				"auth_probe_method": "get_task_nonexistent", "auth_probe_status": "anonymous_protocol_access",
+				"auth_probe_detail":    "task_not_found_v1",
+				"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+				"observed_auth_evidence": "anonymous_probe_succeeded",
+			},
+		},
+		{
+			ID: "auth-a2a-forged", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+				"name": "A2A legacy malformed observation", "auth_method": "bearer", "auth_assurance": "moderate",
+				"auth_evidence": "declared_security_scheme", "scan_id": scanID,
+				"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+				"observed_auth_evidence": "anonymous_probe_succeeded",
+			},
+		},
+		{
+			ID: "auth-a2a-raw-anon", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+				"name": "A2A raw anonymous claim", "auth_method": "none", "auth_assurance": "unauthenticated",
+				"auth_evidence": "anonymous_probe_succeeded", "scan_id": scanID,
+			},
+		},
+	}
+	writer := graph.NewWriter(driver)
+	if _, err := writer.WriteNodes(ctx, managedProcessorNodes(nodes), scanID); err != nil {
+		t.Fatalf("write nodes: %v", err)
+	}
+	edges := []ingest.Edge{
+		authTestTrust("auth-agent-anon-a", "auth-server-anon", 0.5, true),
+		authTestTrust("auth-agent-anon-b", "auth-server-anon", 0.7, true),
+		authTestTrust("auth-agent-bearer-a", "auth-server-bearer", 0.7, true),
+		authTestTrust("auth-agent-bearer-b", "auth-server-bearer", 0.5, false),
+		authTestTrust("auth-agent-fallback", "auth-server-fallback", 0.3, true),
+		authTestTrust("auth-agent-stdio", "auth-server-stdio", 0.5, false),
+	}
+	if _, err := writer.WriteEdges(ctx, managedProcessorEdges(edges), scanID); err != nil {
+		t.Fatalf("write edges: %v", err)
+	}
+
+	if _, err := (&AuthStrength{}).Process(ctx, db, scanID); err != nil {
+		t.Fatalf("materialize effective auth: %v", err)
+	}
+
+	rows, err := db.Query(ctx, `MATCH (n)
+WHERE n.objectid IN $ids
+RETURN n.objectid AS id,
+       n.auth_assurance AS configured_assurance,
+       n.effective_auth_method AS method,
+       n.effective_auth_assurance AS assurance,
+       n.effective_auth_evidence AS evidence,
+       n.effective_auth_source AS source,
+       n.auth_strength AS strength`, map[string]any{"ids": []string{
+		"auth-server-anon", "auth-server-bearer", "auth-server-fallback",
+		"auth-server-stdio", "auth-a2a", "auth-a2a-observed", "auth-a2a-forged",
+		"auth-a2a-raw-anon",
+	}})
+	if err != nil {
+		t.Fatalf("query effective nodes: %v", err)
+	}
+	byID := make(map[string]map[string]any, len(rows))
+	for _, row := range rows {
+		id, _ := row["id"].(string)
+		byID[id] = row
+	}
+	assertEffectiveAuthRow(t, byID["auth-server-anon"], "moderate", "none", "unauthenticated", "anonymous_probe_succeeded", "observed", 100)
+	assertEffectiveAuthRow(t, byID["auth-server-bearer"], "strong", "bearer", "moderate", "configured_credential", "observed", 50)
+	assertEffectiveAuthRow(t, byID["auth-server-fallback"], "weak", "apiKey", "weak", "configured_credential", "configured", 70)
+	assertEffectiveAuthRow(t, byID["auth-server-stdio"], "unknown", "unknown", "unknown", "local_process", "configured", nil)
+	assertEffectiveAuthRow(t, byID["auth-a2a"], "strong", "mtls", "strong", "declared_security_scheme", "configured", 10)
+	assertEffectiveAuthRow(t, byID["auth-a2a-observed"], "weak", "none", "unauthenticated", "anonymous_probe_succeeded", "observed", 100)
+	assertEffectiveAuthRow(t, byID["auth-a2a-forged"], "moderate", "bearer", "moderate", "declared_security_scheme", "configured", 50)
+	assertEffectiveAuthRow(t, byID["auth-a2a-raw-anon"], "unauthenticated", "none", "unknown", "anonymous_probe_succeeded", "configured", nil)
+
+	edgeRows, err := db.Query(ctx, `MATCH (a:AgentInstance)-[t:TRUSTS_SERVER]->(:MCPServer)
+WHERE a.objectid STARTS WITH 'auth-agent-'
+RETURN a.objectid AS agent,
+       t.risk_weight AS configured_weight,
+       t.auth_assessment_complete AS configured_complete,
+       t.effective_risk_weight AS effective_weight,
+       t.effective_auth_assessment_complete AS effective_complete,
+       t.effective_auth_source AS effective_source`, nil)
+	if err != nil {
+		t.Fatalf("query effective trust edges: %v", err)
+	}
+	edgesByAgent := make(map[string]map[string]any, len(edgeRows))
+	for _, row := range edgeRows {
+		agent, _ := row["agent"].(string)
+		edgesByAgent[agent] = row
+	}
+	assertEffectiveTrustRow(t, edgesByAgent["auth-agent-anon-a"], 0.5, true, 0.1, true, "observed")
+	assertEffectiveTrustRow(t, edgesByAgent["auth-agent-anon-b"], 0.7, true, 0.1, true, "observed")
+	assertEffectiveTrustRow(t, edgesByAgent["auth-agent-bearer-a"], 0.7, true, 0.7, true, "configured")
+	assertEffectiveTrustRow(t, edgesByAgent["auth-agent-bearer-b"], 0.5, false, 0.5, false, "configured")
+	assertEffectiveTrustRow(t, edgesByAgent["auth-agent-fallback"], 0.3, true, 0.3, true, "configured")
+	assertEffectiveTrustRow(t, edgesByAgent["auth-agent-stdio"], 0.5, false, 0.5, false, "configured")
+}
+
+func authTestAgent(id, scanID string) ingest.Node {
+	return ingest.Node{ID: id, Kinds: []string{"AgentInstance"}, Properties: map[string]any{
+		"name": id, "scan_id": scanID,
+	}}
+}
+
+func authTestTrust(source, target string, weight float64, complete bool) ingest.Edge {
+	return ingest.Edge{
+		Source: source, Target: target, Kind: "TRUSTS_SERVER",
+		SourceKind: "AgentInstance", TargetKind: "MCPServer",
+		Properties: map[string]any{
+			"risk_weight": weight, "auth_assessment_complete": complete,
+		},
+	}
+}
+
+func assertEffectiveAuthRow(
+	t *testing.T,
+	row map[string]any,
+	configuredAssurance, method, assurance, evidence, source string,
+	strength any,
+) {
+	t.Helper()
+	if row == nil ||
+		row["configured_assurance"] != configuredAssurance ||
+		row["method"] != method || row["assurance"] != assurance ||
+		row["evidence"] != evidence || row["source"] != source {
+		t.Fatalf("effective auth row = %+v, want configured=%s effective=%s/%s/%s source=%s", row, configuredAssurance, method, assurance, evidence, source)
+	}
+	if strength == nil {
+		if row["strength"] != nil {
+			t.Fatalf("auth strength = %v, want nil", row["strength"])
+		}
+		return
+	}
+	want, _ := strength.(int)
+	var got float64
+	switch value := row["strength"].(type) {
+	case float64:
+		got = value
+	case int64:
+		got = float64(value)
+	case int:
+		got = float64(value)
+	default:
+		t.Fatalf("auth strength = %v (%T), want %d", row["strength"], row["strength"], want)
+	}
+	if got != float64(want) {
+		t.Fatalf("auth strength = %v, want %d", row["strength"], want)
+	}
+}
+
+func assertEffectiveTrustRow(
+	t *testing.T,
+	row map[string]any,
+	configuredWeight float64,
+	configuredComplete bool,
+	effectiveWeight float64,
+	effectiveComplete bool,
+	effectiveSource string,
+) {
+	t.Helper()
+	if row == nil ||
+		row["configured_weight"] != configuredWeight ||
+		row["configured_complete"] != configuredComplete ||
+		row["effective_weight"] != effectiveWeight ||
+		row["effective_complete"] != effectiveComplete ||
+		row["effective_source"] != effectiveSource {
+		t.Fatalf(
+			"effective trust row = %+v, want configured=%g/%v effective=%g/%v source=%s",
+			row, configuredWeight, configuredComplete, effectiveWeight, effectiveComplete, effectiveSource,
+		)
+	}
+}

--- a/server/internal/analysis/processors/auth_strength_test.go
+++ b/server/internal/analysis/processors/auth_strength_test.go
@@ -46,20 +46,69 @@ func TestAuthStrength_ProcessSuccess(t *testing.T) {
 	}
 
 	calls := mock.CallsTo("ExecuteWrite")
-	if len(calls) != 1 {
-		t.Fatalf("ExecuteWrite called %d times, want 1", len(calls))
+	if len(calls) != 2 {
+		t.Fatalf("ExecuteWrite called %d times, want 2", len(calls))
 	}
 
 	cypher, _ := calls[0].Args[0].(string)
-	if !contains(cypher, "SET n.auth_strength =") {
+	if !contains(cypher, "n.auth_strength =") {
 		t.Errorf("Cypher should SET the auth_strength property; query:\n%s", cypher)
 	}
-	if !contains(cypher, "n.auth_assurance =") {
-		t.Errorf("Cypher should SET categorical auth_assurance; query:\n%s", cypher)
+	for _, property := range []string{
+		"n.effective_auth_method = effective_method",
+		"n.effective_auth_assurance =",
+		"n.effective_auth_evidence = effective_evidence",
+		"n.effective_auth_source = effective_source",
+	} {
+		if !contains(cypher, property) {
+			t.Errorf("Cypher should SET %s; query:\n%s", property, cypher)
+		}
 	}
-	if !contains(cypher, "n.auth_evidence") ||
-		!contains(cypher, "anonymous_probe_succeeded") {
-		t.Errorf("explicit none must require anonymous-probe evidence; query:\n%s", cypher)
+	if contains(cypher, "SET n.auth_assurance =") ||
+		contains(cypher, ", n.auth_assurance =") {
+		t.Errorf("configured auth_assurance must remain immutable; query:\n%s", cypher)
+	}
+	if !contains(cypher, "effective_evidence") ||
+		!contains(cypher, "anonymous_probe_succeeded") ||
+		!contains(cypher, "coalesce(effective_source, 'configured') <> 'observed'") {
+		t.Errorf("explicit none must require observed anonymous-probe evidence; query:\n%s", cypher)
+	}
+	for _, guard := range []string{
+		"n.status = 'reachable'",
+		"n.transport = 'http'",
+		"n.observed_auth_method = 'none'",
+		"n.observed_auth_assurance = 'unauthenticated'",
+		"n.observed_auth_evidence = 'anonymous_probe_succeeded'",
+		"n:A2AAgent",
+		"n.auth_probe_method = 'get_task_nonexistent'",
+		"n.auth_probe_status = 'anonymous_protocol_access'",
+		"n.auth_probe_detail IN ['task_not_found_v1', 'task_not_found_v0_3']",
+		"CASE WHEN use_observed THEN n.observed_auth_method ELSE n.auth_method END",
+		"CASE WHEN use_observed THEN n.observed_auth_evidence ELSE n.auth_evidence END",
+	} {
+		if !contains(cypher, guard) {
+			t.Errorf("effective tuple query missing %q; query:\n%s", guard, cypher)
+		}
+	}
+
+	trustCypher, _ := calls[1].Args[0].(string)
+	for _, guard := range []string{
+		"MATCH ()-[t:TRUSTS_SERVER]->(s:MCPServer)",
+		"s.effective_auth_source = 'observed'",
+		"s.effective_auth_method = 'none'",
+		"s.effective_auth_assurance = 'unauthenticated'",
+		"s.effective_auth_evidence = 'anonymous_probe_succeeded'",
+		"WHEN observed_anonymous THEN 0.1",
+		"ELSE t.risk_weight",
+		"WHEN observed_anonymous THEN true",
+		"ELSE t.auth_assessment_complete",
+		"t.effective_auth_source = CASE",
+		"WHEN observed_anonymous THEN 'observed'",
+		"ELSE 'configured'",
+	} {
+		if !contains(trustCypher, guard) {
+			t.Errorf("effective trust query missing %q; query:\n%s", guard, trustCypher)
+		}
 	}
 
 	// Drift guard: the CASE expression is built at runtime from
@@ -103,5 +152,26 @@ func TestAuthStrength_ProcessError(t *testing.T) {
 	_, err := p.Process(context.Background(), mock, "scan-1")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestAuthStrength_TrustMaterializationError(t *testing.T) {
+	calls := 0
+	mock := &graph.MockGraphDB{
+		ExecuteWriteFunc: func(_ context.Context, _ string, _ map[string]any) (int, error) {
+			calls++
+			if calls == 2 {
+				return 0, errors.New("trust materialization failed")
+			}
+			return 4, nil
+		},
+	}
+
+	stats, err := (&AuthStrength{}).Process(context.Background(), mock, "scan-1")
+	if err == nil {
+		t.Fatal("expected trust materialization error")
+	}
+	if stats.NodesUpdated != 0 || stats.EdgesCreated != 0 {
+		t.Fatalf("failed pre-pass reported partial success: %+v", stats)
 	}
 }

--- a/server/internal/analysis/processors/can_reach.go
+++ b/server/internal/analysis/processors/can_reach.go
@@ -13,7 +13,7 @@ import (
 type CanReach struct{}
 
 func (p *CanReach) Name() string           { return "can_reach" }
-func (p *CanReach) Dependencies() []string { return []string{"has_access_to"} }
+func (p *CanReach) Dependencies() []string { return []string{"auth_strength", "has_access_to"} }
 
 func (p *CanReach) Process(ctx context.Context, db graph.GraphDB, scanID string) (graph.ProcessingStats, error) {
 	start := time.Now()
@@ -24,8 +24,8 @@ MATCH (a:AgentInstance)-[ts:TRUSTS_SERVER]->(s:MCPServer)
 MERGE (a)-[e:CAN_REACH]->(r)
 SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true, e.source_collector = 'mcp',
     e.via_server = s.name, e.via_tool = t.name, e.hops = 3, e.risk_weight = 0.1,
-    e.confidence = CASE WHEN ts.risk_weight <= 0.1 THEN 1.0
-                        WHEN ts.risk_weight <= 0.3 THEN 0.8
+    e.confidence = CASE WHEN ts.effective_risk_weight <= 0.1 THEN 1.0
+                        WHEN ts.effective_risk_weight <= 0.3 THEN 0.8
                         ELSE 0.5 END,
     e.evidence_version = 1,
     e.evidence_node_ids = [a.objectid, s.objectid, t.objectid, r.objectid],
@@ -35,19 +35,27 @@ RETURN count(*) AS written`
 	credChainCypher := `
 MATCH (a:AgentInstance)-[trust1:TRUSTS_SERVER]->(s1:MCPServer)-[provides1:PROVIDES_TOOL]->(t1:MCPTool)
 WHERE ANY(cap IN t1.capability_surface WHERE cap IN ['file_read', 'credential_access'])
-MATCH (s2:MCPServer)-[environment:HAS_ENV_VAR]->(c:Credential)
-MATCH (c)<-[uses:USES_CREDENTIAL]-(i:Identity)<-[authenticates:AUTHENTICATES_WITH]-(s2)
+MATCH (s2:MCPServer)-[authenticates:AUTHENTICATES_WITH]->(i:Identity)-[uses:USES_CREDENTIAL]->(c:Credential)
 MATCH (s2)-[provides2:PROVIDES_TOOL]->(t2:MCPTool)-[access:HAS_ACCESS_TO]->(r:MCPResource)
 WHERE s1 <> s2
-  AND coalesce(s1.observed_auth_assurance, s1.auth_assurance) IN ['unauthenticated', 'weak']
-WITH a, s1, t1, s2, c, i, t2, r,
-     trust1, provides1, environment, uses, authenticates, provides2, access
+  AND (
+    (s1.effective_auth_assurance = 'unauthenticated'
+      AND s1.effective_auth_source = 'observed')
+    OR s1.effective_auth_assurance = 'weak'
+  )
+  AND c.value_hash IS NOT NULL AND c.value_hash <> ''
+  AND c.merge_key = 'value_hash'
+  AND c.identity_basis = 'value_hash'
+  AND c.material_status = 'observed'
+  AND c.exposure_status = 'exposed'
+WITH a, s1, t1, s2, i, c, t2, r,
+     trust1, provides1, authenticates, uses, provides2, access
 ORDER BY a.objectid, s1.objectid, t1.objectid, s2.objectid,
-         c.objectid, i.objectid, t2.objectid, r.objectid
+         i.objectid, c.objectid, t2.objectid, r.objectid
 WITH a, r, collect({
-  s1: s1, t1: t1, s2: s2, c: c, i: i, t2: t2,
-  trust1: trust1, provides1: provides1, environment: environment,
-  uses: uses, authenticates: authenticates, provides2: provides2, access: access
+  s1: s1, t1: t1, s2: s2, i: i, c: c, t2: t2,
+  trust1: trust1, provides1: provides1, authenticates: authenticates,
+  uses: uses, provides2: provides2, access: access
 })[0] AS winner
 WHERE NOT EXISTS {
     MATCH (a)-[current:CAN_REACH]->(r)
@@ -59,11 +67,11 @@ SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true, e.sou
     e.evidence_version = 1,
     e.evidence_node_ids = [
       a.objectid, winner.s1.objectid, winner.t1.objectid, winner.s2.objectid,
-      winner.c.objectid, winner.i.objectid, winner.t2.objectid, r.objectid
+      winner.i.objectid, winner.c.objectid, winner.t2.objectid, r.objectid
     ],
     e.evidence_relationship_ids = [
-      id(winner.trust1), id(winner.provides1), id(winner.environment), id(winner.uses),
-      id(winner.authenticates), id(winner.provides2), id(winner.access)
+      id(winner.trust1), id(winner.provides1), id(winner.authenticates),
+      id(winner.uses), id(winner.provides2), id(winner.access)
     ]
 RETURN count(*) AS written`
 

--- a/server/internal/analysis/processors/can_reach_test.go
+++ b/server/internal/analysis/processors/can_reach_test.go
@@ -22,8 +22,8 @@ func TestCanReach_Name(t *testing.T) {
 func TestCanReach_Dependencies(t *testing.T) {
 	p := &CanReach{}
 	deps := p.Dependencies()
-	if len(deps) != 1 || deps[0] != "has_access_to" {
-		t.Errorf("Dependencies() = %v, want [has_access_to]", deps)
+	if len(deps) != 2 || deps[0] != "auth_strength" || deps[1] != "has_access_to" {
+		t.Errorf("Dependencies() = %v, want [auth_strength has_access_to]", deps)
 	}
 }
 
@@ -51,6 +51,10 @@ func TestCanReach_ProcessSuccess(t *testing.T) {
 	if strings.Contains(direct, "WHERE NOT EXISTS((a)-[:CAN_REACH]->(r))") {
 		t.Fatalf("direct CAN_REACH must refresh an existing inferred edge:\n%s", direct)
 	}
+	if !strings.Contains(direct, "ts.effective_risk_weight <= 0.1") ||
+		strings.Contains(direct, "ts.risk_weight <=") {
+		t.Fatalf("direct confidence must use the derived effective trust weight:\n%s", direct)
+	}
 	credential, _ := calls[1].Args[0].(string)
 	if !strings.Contains(credential, "current.scan_id = $scan_id") {
 		t.Fatalf("credential pass must preserve a direct path refreshed this scan:\n%s", credential)
@@ -59,14 +63,32 @@ func TestCanReach_ProcessSuccess(t *testing.T) {
 		!strings.Contains(credential, "MATCH (a)-[current:CAN_REACH]->(r)") {
 		t.Fatalf("credential pass must use Neo4j-4.4-compatible EXISTS subquery:\n%s", credential)
 	}
-	if strings.Contains(credential, "s1.auth_method IS NULL OR") ||
-		!strings.Contains(credential, "coalesce(s1.observed_auth_assurance, s1.auth_assurance) IN ['unauthenticated', 'weak']") {
+	if strings.Contains(credential, "coalesce(s1.observed_auth_assurance, s1.auth_assurance)") ||
+		strings.Contains(credential, "s1.effective_auth_assurance IN ['unauthenticated', 'weak']") ||
+		!strings.Contains(credential, "s1.effective_auth_assurance = 'unauthenticated'") ||
+		!strings.Contains(credential, "s1.effective_auth_source = 'observed'") ||
+		!strings.Contains(credential, "OR s1.effective_auth_assurance = 'weak'") {
 		t.Fatalf("unknown auth must not satisfy credential delegation:\n%s", credential)
+	}
+	if strings.Contains(credential, "HAS_ENV_VAR") ||
+		!strings.Contains(credential, "MATCH (s2:MCPServer)-[authenticates:AUTHENTICATES_WITH]->(i:Identity)-[uses:USES_CREDENTIAL]->(c:Credential)") {
+		t.Fatalf("credential pass must use the canonical auth/uses topology, independent of credential location:\n%s", credential)
+	}
+	for _, predicate := range []string{
+		"c.value_hash IS NOT NULL AND c.value_hash <> ''",
+		"c.merge_key = 'value_hash'",
+		"c.identity_basis = 'value_hash'",
+		"c.material_status = 'observed'",
+		"c.exposure_status = 'exposed'",
+	} {
+		if !strings.Contains(credential, predicate) {
+			t.Fatalf("credential pass accepts a non-runnable credential; missing %q:\n%s", predicate, credential)
+		}
 	}
 	if !strings.Contains(
 		credential,
 		"ORDER BY a.objectid, s1.objectid, t1.objectid, s2.objectid,\n"+
-			"         c.objectid, i.objectid, t2.objectid, r.objectid",
+			"         i.objectid, c.objectid, t2.objectid, r.objectid",
 	) || !strings.Contains(credential, "})[0] AS winner") {
 		t.Fatalf("credential paths must reduce by the complete stable object-ID tuple:\n%s", credential)
 	}
@@ -75,6 +97,16 @@ func TestCanReach_ProcessSuccess(t *testing.T) {
 	if orderStart < 0 || winnerStart < orderStart ||
 		strings.Contains(credential[orderStart:winnerStart], "id(") {
 		t.Fatalf("relationship IDs must not participate in credential-path selection:\n%s", credential)
+	}
+	for _, orderedEvidence := range []string{
+		"a.objectid, winner.s1.objectid, winner.t1.objectid, winner.s2.objectid,\n" +
+			"      winner.i.objectid, winner.c.objectid, winner.t2.objectid, r.objectid",
+		"id(winner.trust1), id(winner.provides1), id(winner.authenticates),\n" +
+			"      id(winner.uses), id(winner.provides2), id(winner.access)",
+	} {
+		if !strings.Contains(credential, orderedEvidence) {
+			t.Fatalf("credential pass must persist canonical ordered evidence %q:\n%s", orderedEvidence, credential)
+		}
 	}
 }
 

--- a/server/internal/analysis/processors/confused_deputy.go
+++ b/server/internal/analysis/processors/confused_deputy.go
@@ -12,8 +12,9 @@ import (
 // escalation: the anonymous/low-trust caller borrows the high-trust agent's
 // privileges through the DELEGATES_TO edge.
 //
-// auth_assurance is materialized by the auth_strength pre-pass. Unknown and
-// custom methods are deliberately excluded rather than treated as weak.
+// effective_auth_assurance is materialized by the auth_strength pre-pass.
+// Unknown and custom methods are deliberately excluded rather than treated as
+// weak, while configured provenance remains intact on auth_assurance.
 type ConfusedDeputy struct{}
 
 func (p *ConfusedDeputy) Name() string { return "confused_deputy" }
@@ -32,13 +33,17 @@ func (p *ConfusedDeputy) Process(ctx context.Context, db graph.GraphDB, scanID s
 	// managed by the global derived epoch.
 	cypher := `
 MATCH (low:A2AAgent)-[delegation:DELEGATES_TO]->(high:A2AAgent)
-WHERE low.auth_assurance IN ['unauthenticated', 'weak']
-  AND high.auth_assurance = 'strong'
+WHERE (
+    (low.effective_auth_assurance = 'unauthenticated'
+      AND low.effective_auth_source = 'observed')
+    OR low.effective_auth_assurance = 'weak'
+  )
+  AND high.effective_auth_assurance = 'strong'
 MERGE (low)-[e:CONFUSED_DEPUTY]->(high)
 SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
     e.source_collector = 'a2a',
-    e.low_auth_method = low.auth_method,
-    e.high_auth_method = high.auth_method,
+    e.low_auth_method = low.effective_auth_method,
+    e.high_auth_method = high.effective_auth_method,
     e.confidence = 0.8, e.risk_weight = 0.3,
     e.evidence_version = 1,
     e.evidence_node_ids = [low.objectid, high.objectid],

--- a/server/internal/analysis/processors/confused_deputy_integration_test.go
+++ b/server/internal/analysis/processors/confused_deputy_integration_test.go
@@ -10,12 +10,14 @@ import (
 )
 
 // TestIntegrationConfusedDeputyAuthGradient locks the categorical assurance
-// predicate in confused_deputy.go. AuthStrength materializes assurance from
-// method plus evidence, so explicit anonymous access requires a successful
-// anonymous probe.
-//   - POSITIVE: unauthenticated -> strong delegation fires once.
-//   - FP-GUARD A: inverted gradient strong -> weak must not fire.
-//   - FP-GUARD B: equal strong -> strong delegation must not fire.
+// predicate in confused_deputy.go. AuthStrength materializes a paired effective
+// tuple, so unauthenticated access requires the exact bounded A2A observation
+// while configured weak authentication remains eligible.
+//   - POSITIVE A: observed unauthenticated -> strong delegation fires once.
+//   - POSITIVE B: configured weak -> strong delegation fires once.
+//   - FP-GUARD A: configured no-auth without observation must not fire.
+//   - FP-GUARD B: inverted gradient strong -> weak must not fire.
+//   - FP-GUARD C: equal strong -> strong delegation must not fire.
 func TestIntegrationConfusedDeputyAuthGradient(t *testing.T) {
 	uri := os.Getenv("AGENTHOUND_NEO4J_URI")
 	if uri == "" {
@@ -42,20 +44,38 @@ func TestIntegrationConfusedDeputyAuthGradient(t *testing.T) {
 	cleanup()
 	defer cleanup()
 
-	// AuthStrength keys on the auth_method node property.
 	nodes := []ingest.Node{
+		{ID: "cd-anon-observed", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+			"objectid": "cd-anon-observed", "name": "observed_anon_agent",
+			"auth_method": "apiKey", "auth_assurance": "weak",
+			"auth_evidence":           "declared_security_scheme",
+			"auth_probe_method":       "get_task_nonexistent",
+			"auth_probe_status":       "anonymous_protocol_access",
+			"auth_probe_detail":       "task_not_found_v1",
+			"observed_auth_method":    "none",
+			"observed_auth_assurance": "unauthenticated",
+			"observed_auth_evidence":  "anonymous_probe_succeeded",
+			"scan_id":                 scanID,
+		}},
 		{ID: "cd-weak", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
-			"objectid": "cd-weak", "name": "anon_agent",
-			"auth_method": "none", "auth_evidence": "anonymous_probe_succeeded",
-			"scan_id": scanID,
+			"objectid": "cd-weak", "name": "configured_weak_agent",
+			"auth_method": "apiKey", "auth_assurance": "weak",
+			"auth_evidence": "declared_security_scheme", "scan_id": scanID,
+		}},
+		{ID: "cd-unobserved-none", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+			"objectid": "cd-unobserved-none", "name": "configured_no_auth_agent",
+			"auth_method": "none", "auth_assurance": "unauthenticated",
+			"auth_evidence": "unknown", "scan_id": scanID,
 		}},
 		{ID: "cd-strong", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
 			"objectid": "cd-strong", "name": "mtls_agent",
-			"auth_method": "mtls", "scan_id": scanID,
+			"auth_method": "mtls", "auth_assurance": "strong",
+			"auth_evidence": "declared_security_scheme", "scan_id": scanID,
 		}},
 		{ID: "cd-strong2", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
 			"objectid": "cd-strong2", "name": "oauth_agent",
-			"auth_method": "oauth", "scan_id": scanID,
+			"auth_method": "oauth", "auth_assurance": "strong",
+			"auth_evidence": "declared_security_scheme", "scan_id": scanID,
 		}},
 	}
 	writer := graph.NewWriter(driver)
@@ -64,11 +84,15 @@ func TestIntegrationConfusedDeputyAuthGradient(t *testing.T) {
 	}
 
 	edges := []ingest.Edge{
-		// POSITIVE: unauthenticated -> strong.
+		// POSITIVE A: runtime-observed anonymous -> strong.
+		{Source: "cd-anon-observed", Target: "cd-strong", Kind: "DELEGATES_TO", SourceKind: "A2AAgent", TargetKind: "A2AAgent"},
+		// POSITIVE B: configured weak -> strong.
 		{Source: "cd-weak", Target: "cd-strong", Kind: "DELEGATES_TO", SourceKind: "A2AAgent", TargetKind: "A2AAgent"},
-		// FP-GUARD A: inverted, strong -> unauthenticated.
+		// FP-GUARD A: a configured no-auth claim is not runtime proof.
+		{Source: "cd-unobserved-none", Target: "cd-strong", Kind: "DELEGATES_TO", SourceKind: "A2AAgent", TargetKind: "A2AAgent"},
+		// FP-GUARD B: inverted, strong -> weak.
 		{Source: "cd-strong", Target: "cd-weak", Kind: "DELEGATES_TO", SourceKind: "A2AAgent", TargetKind: "A2AAgent"},
-		// FP-GUARD B: strong -> strong; low side is not weak.
+		// FP-GUARD C: strong -> strong; low side is not weak.
 		{Source: "cd-strong", Target: "cd-strong2", Kind: "DELEGATES_TO", SourceKind: "A2AAgent", TargetKind: "A2AAgent"},
 	}
 	if _, err := writer.WriteEdges(ctx, managedProcessorEdges(edges), scanID); err != nil {
@@ -83,14 +107,31 @@ func TestIntegrationConfusedDeputyAuthGradient(t *testing.T) {
 		t.Fatalf("confused_deputy process: %v", err)
 	}
 
-	// POSITIVE: exactly one CONFUSED_DEPUTY weak -> strong.
-	rows, err := db.Query(ctx,
-		"MATCH (:A2AAgent {objectid:'cd-weak'})-[:CONFUSED_DEPUTY]->(a:A2AAgent {objectid:'cd-strong'}) RETURN count(a) AS n", nil)
-	if err != nil {
-		t.Fatalf("query positive confused_deputy: %v", err)
+	for _, tc := range []struct {
+		name, source string
+	}{
+		{name: "observed anonymous", source: "cd-anon-observed"},
+		{name: "configured weak", source: "cd-weak"},
+	} {
+		rows, err := db.Query(ctx, `MATCH (:A2AAgent {objectid:$source})-[:CONFUSED_DEPUTY]->
+  (a:A2AAgent {objectid:'cd-strong'}) RETURN count(a) AS n`, map[string]any{"source": tc.source})
+		if err != nil {
+			t.Fatalf("query %s positive confused_deputy: %v", tc.name, err)
+		}
+		if got := toInt(rows[0]["n"]); got != 1 {
+			t.Errorf("%s -> strong got %d CONFUSED_DEPUTY edges, want 1", tc.name, got)
+		}
 	}
-	if got := toInt(rows[0]["n"]); got != 1 {
-		t.Errorf("weak->strong got %d CONFUSED_DEPUTY edges, want 1", got)
+
+	// FP-GUARD: configured no-auth without the exact runtime observation does
+	// not establish anonymous protocol access.
+	rows, err := db.Query(ctx,
+		"MATCH (:A2AAgent {objectid:'cd-unobserved-none'})-[:CONFUSED_DEPUTY]->(a:A2AAgent) RETURN count(a) AS n", nil)
+	if err != nil {
+		t.Fatalf("query configured-no-auth fp-guard: %v", err)
+	}
+	if got := toInt(rows[0]["n"]); got != 0 {
+		t.Errorf("configured no-auth source got %d CONFUSED_DEPUTY edges, want 0", got)
 	}
 
 	// FP-GUARD: no CONFUSED_DEPUTY should originate from the strong agent

--- a/server/internal/analysis/processors/confused_deputy_test.go
+++ b/server/internal/analysis/processors/confused_deputy_test.go
@@ -60,8 +60,12 @@ func TestConfusedDeputy_ProcessSuccess(t *testing.T) {
 	cypher, _ := calls[0].Args[0].(string)
 	for _, want := range []string{
 		"CONFUSED_DEPUTY",
-		"low.auth_assurance IN ['unauthenticated', 'weak']",
-		"high.auth_assurance = 'strong'",
+		"low.effective_auth_assurance = 'unauthenticated'",
+		"low.effective_auth_source = 'observed'",
+		"OR low.effective_auth_assurance = 'weak'",
+		"high.effective_auth_assurance = 'strong'",
+		"e.low_auth_method = low.effective_auth_method",
+		"e.high_auth_method = high.effective_auth_method",
 		"source_collector = 'a2a'",
 	} {
 		if !contains(cypher, want) {
@@ -70,6 +74,9 @@ func TestConfusedDeputy_ProcessSuccess(t *testing.T) {
 	}
 	if contains(cypher, "auth_strength >=") || contains(cypher, "auth_strength <=") {
 		t.Errorf("detector still uses numeric fallbacks that classify unknown auth: query:\n%s", cypher)
+	}
+	if contains(cypher, "low.effective_auth_assurance IN ['unauthenticated', 'weak']") {
+		t.Errorf("unauthenticated delegation must require observed provenance: query:\n%s", cypher)
 	}
 }
 

--- a/server/internal/analysis/processors/cross_protocol.go
+++ b/server/internal/analysis/processors/cross_protocol.go
@@ -9,8 +9,10 @@ import (
 
 type CrossProtocol struct{}
 
-func (p *CrossProtocol) Name() string           { return "cross_protocol" }
-func (p *CrossProtocol) Dependencies() []string { return []string{"has_access_to"} }
+func (p *CrossProtocol) Name() string { return "cross_protocol" }
+func (p *CrossProtocol) Dependencies() []string {
+	return []string{"auth_strength", "has_access_to"}
+}
 
 func (p *CrossProtocol) Process(ctx context.Context, db graph.GraphDB, scanID string) (graph.ProcessingStats, error) {
 	start := time.Now()
@@ -20,8 +22,9 @@ MATCH delegation = (ext:A2AAgent)-[:DELEGATES_TO*1..3]->(int:A2AAgent)
 MATCH (int)-[agent_host:RUNS_ON]->(h:Host)<-[server_host:RUNS_ON]-(s:MCPServer)
 MATCH (a:AgentInstance)-[trust:TRUSTS_SERVER]->(s)
       -[provides:PROVIDES_TOOL]->(t:MCPTool)-[access:HAS_ACCESS_TO]->(r:MCPResource)
-WHERE ext.auth_assurance = 'unauthenticated'
-  AND ext.auth_evidence = 'anonymous_probe_succeeded'
+WHERE ext.effective_auth_assurance = 'unauthenticated'
+  AND ext.effective_auth_source = 'observed'
+  AND ext.effective_auth_evidence = 'anonymous_probe_succeeded'
 MERGE (ext)-[e:CAN_REACH]->(r)
 SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
     e.cross_protocol = true, e.source_collector = 'a2a',

--- a/server/internal/analysis/processors/cross_protocol_test.go
+++ b/server/internal/analysis/processors/cross_protocol_test.go
@@ -19,8 +19,8 @@ func TestCrossProtocol_Name(t *testing.T) {
 func TestCrossProtocol_Dependencies(t *testing.T) {
 	p := &CrossProtocol{}
 	deps := p.Dependencies()
-	if len(deps) != 1 || deps[0] != "has_access_to" {
-		t.Errorf("Dependencies() = %v, want [has_access_to]", deps)
+	if len(deps) != 2 || deps[0] != "auth_strength" || deps[1] != "has_access_to" {
+		t.Errorf("Dependencies() = %v, want [auth_strength has_access_to]", deps)
 	}
 }
 
@@ -49,7 +49,9 @@ func TestCrossProtocol_ProcessSuccess(t *testing.T) {
 	}
 	cypher, _ := calls[0].Args[0].(string)
 	if strings.Contains(cypher, "ext.auth_method IS NULL)") ||
-		!strings.Contains(cypher, "ext.auth_assurance = 'unauthenticated'") {
+		!strings.Contains(cypher, "ext.effective_auth_assurance = 'unauthenticated'") ||
+		!strings.Contains(cypher, "ext.effective_auth_source = 'observed'") ||
+		!strings.Contains(cypher, "ext.effective_auth_evidence = 'anonymous_probe_succeeded'") {
 		t.Fatalf("unknown auth must not satisfy cross-protocol detection:\n%s", cypher)
 	}
 	if !strings.Contains(cypher, "e.confidence = 0.5") {

--- a/server/internal/analysis/processors/effective_auth_consumers_integration_test.go
+++ b/server/internal/analysis/processors/effective_auth_consumers_integration_test.go
@@ -1,0 +1,263 @@
+package processors
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+// TestIntegrationCanReachEffectiveAuthProvenance proves the credential-chain
+// auth predicate against Neo4j rather than only inspecting its Cypher text.
+// Runtime-observed anonymous access and configured weak authentication are
+// eligible; a configured no-auth claim without accepted runtime evidence is
+// not.
+func TestIntegrationCanReachEffectiveAuthProvenance(t *testing.T) {
+	ctx, db, writer, cleanup := effectiveAuthIntegrationDB(t, "test-can-reach-effective-auth")
+	defer cleanup()
+
+	const scanID = "test-can-reach-effective-auth"
+	nodes := []ingest.Node{
+		processorFixtureNode("creach-agent-observed", "AgentInstance", "observed-agent", scanID, nil),
+		processorFixtureNode("creach-agent-weak", "AgentInstance", "weak-agent", scanID, nil),
+		processorFixtureNode("creach-agent-unobserved", "AgentInstance", "unobserved-agent", scanID, nil),
+		processorFixtureNode("creach-entry-observed", "MCPServer", "observed-entry", scanID, map[string]any{
+			"transport": "http", "status": "reachable",
+			"auth_method": "bearer", "auth_assurance": "moderate",
+			"auth_evidence":        "configured_credential",
+			"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+			"observed_auth_evidence": "anonymous_probe_succeeded",
+		}),
+		processorFixtureNode("creach-entry-weak", "MCPServer", "weak-entry", scanID, map[string]any{
+			"transport": "http", "status": "reachable",
+			"auth_method": "apiKey", "auth_assurance": "weak",
+			"auth_evidence": "configured_credential",
+		}),
+		processorFixtureNode("creach-entry-unobserved", "MCPServer", "unobserved-entry", scanID, map[string]any{
+			"transport": "http", "status": "reachable",
+			"auth_method": "none", "auth_assurance": "unauthenticated",
+			"auth_evidence": "unknown",
+		}),
+		processorFixtureNode("creach-entry-tool-observed", "MCPTool", "observed-reader", scanID, map[string]any{
+			"capability_surface": []string{"file_read"},
+		}),
+		processorFixtureNode("creach-entry-tool-weak", "MCPTool", "weak-reader", scanID, map[string]any{
+			"capability_surface": []string{"credential_access"},
+		}),
+		processorFixtureNode("creach-entry-tool-unobserved", "MCPTool", "unobserved-reader", scanID, map[string]any{
+			"capability_surface": []string{"file_read"},
+		}),
+		processorFixtureNode("creach-target-server", "MCPServer", "target-server", scanID, map[string]any{
+			"transport": "http", "status": "reachable",
+			"auth_method": "mtls", "auth_assurance": "strong",
+			"auth_evidence": "configured_credential",
+		}),
+		processorFixtureNode("creach-target-identity", "Identity", "target-identity", scanID, nil),
+		processorFixtureCredential(
+			"creach-target-credential", "target-credential", scanID,
+			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			"value_hash", "value_hash",
+		),
+		processorFixtureNode("creach-target-tool", "MCPTool", "target-tool", scanID, nil),
+		processorFixtureNode("creach-resource", "MCPResource", "target-resource", scanID, nil),
+	}
+	if _, err := writer.WriteNodes(ctx, managedProcessorNodes(nodes), scanID); err != nil {
+		t.Fatalf("write nodes: %v", err)
+	}
+
+	rawEdges := []ingest.Edge{
+		processorFixtureEdge("creach-agent-observed", "creach-entry-observed", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		processorFixtureEdge("creach-agent-weak", "creach-entry-weak", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		processorFixtureEdge("creach-agent-unobserved", "creach-entry-unobserved", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		processorFixtureEdge("creach-entry-observed", "creach-entry-tool-observed", "PROVIDES_TOOL", "MCPServer", "MCPTool"),
+		processorFixtureEdge("creach-entry-weak", "creach-entry-tool-weak", "PROVIDES_TOOL", "MCPServer", "MCPTool"),
+		processorFixtureEdge("creach-entry-unobserved", "creach-entry-tool-unobserved", "PROVIDES_TOOL", "MCPServer", "MCPTool"),
+		processorFixtureEdge("creach-target-server", "creach-target-identity", "AUTHENTICATES_WITH", "MCPServer", "Identity"),
+		processorFixtureEdge("creach-target-identity", "creach-target-credential", "USES_CREDENTIAL", "Identity", "Credential"),
+		processorFixtureEdge("creach-target-server", "creach-target-tool", "PROVIDES_TOOL", "MCPServer", "MCPTool"),
+	}
+	if _, err := writer.WriteEdges(ctx, managedProcessorEdges(rawEdges), scanID); err != nil {
+		t.Fatalf("write raw edges: %v", err)
+	}
+	access := processorFixtureEdge(
+		"creach-target-tool", "creach-resource", "HAS_ACCESS_TO", "MCPTool", "MCPResource",
+	)
+	if _, err := writer.WriteCompositeEdges(
+		ctx, compositeProcessorEdges([]ingest.Edge{access}), scanID,
+	); err != nil {
+		t.Fatalf("write access edge: %v", err)
+	}
+
+	if _, err := (&AuthStrength{}).Process(ctx, db, scanID); err != nil {
+		t.Fatalf("materialize effective auth: %v", err)
+	}
+	if _, err := (&CanReach{}).Process(ctx, db, scanID); err != nil {
+		t.Fatalf("can_reach process: %v", err)
+	}
+
+	assertCompositeEdgeCount(t, ctx, db, "creach-agent-observed", "CAN_REACH", "creach-resource", 1)
+	assertCompositeEdgeCount(t, ctx, db, "creach-agent-weak", "CAN_REACH", "creach-resource", 1)
+	assertCompositeEdgeCount(t, ctx, db, "creach-agent-unobserved", "CAN_REACH", "creach-resource", 0)
+}
+
+// TestIntegrationCrossProtocolEffectiveAuthProvenance proves that shared-host
+// correlation accepts only exact observed anonymous A2A access. A configured
+// no-auth card without the bounded protocol observation is not enough.
+func TestIntegrationCrossProtocolEffectiveAuthProvenance(t *testing.T) {
+	ctx, db, writer, cleanup := effectiveAuthIntegrationDB(t, "test-cross-protocol-effective-auth")
+	defer cleanup()
+
+	const scanID = "test-cross-protocol-effective-auth"
+	nodes := []ingest.Node{
+		processorFixtureNode("xproto-ext-observed", "A2AAgent", "observed-external", scanID, map[string]any{
+			"auth_method": "apiKey", "auth_assurance": "weak",
+			"auth_evidence":        "declared_security_scheme",
+			"auth_probe_method":    "get_task_nonexistent",
+			"auth_probe_status":    "anonymous_protocol_access",
+			"auth_probe_detail":    "task_not_found_v1",
+			"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+			"observed_auth_evidence": "anonymous_probe_succeeded",
+		}),
+		processorFixtureNode("xproto-ext-unobserved", "A2AAgent", "unobserved-external", scanID, map[string]any{
+			"auth_method": "none", "auth_assurance": "unauthenticated",
+			"auth_evidence": "unknown",
+		}),
+		processorFixtureNode("xproto-internal", "A2AAgent", "internal", scanID, map[string]any{
+			"auth_method": "mtls", "auth_assurance": "strong",
+			"auth_evidence": "declared_security_scheme",
+		}),
+		processorFixtureNode("xproto-host", "Host", "shared-host", scanID, map[string]any{
+			"hostname": "shared-host.invalid",
+		}),
+		processorFixtureNode("xproto-server", "MCPServer", "shared-server", scanID, map[string]any{
+			"transport": "http", "status": "reachable",
+			"auth_method": "mtls", "auth_assurance": "strong",
+			"auth_evidence": "configured_credential",
+		}),
+		processorFixtureNode("xproto-agent-instance", "AgentInstance", "mcp-agent", scanID, nil),
+		processorFixtureNode("xproto-tool", "MCPTool", "shared-tool", scanID, nil),
+		processorFixtureNode("xproto-resource", "MCPResource", "shared-resource", scanID, nil),
+	}
+	if _, err := writer.WriteNodes(ctx, managedProcessorNodes(nodes), scanID); err != nil {
+		t.Fatalf("write nodes: %v", err)
+	}
+	rawEdges := []ingest.Edge{
+		processorFixtureEdge("xproto-ext-observed", "xproto-internal", "DELEGATES_TO", "A2AAgent", "A2AAgent"),
+		processorFixtureEdge("xproto-ext-unobserved", "xproto-internal", "DELEGATES_TO", "A2AAgent", "A2AAgent"),
+		processorFixtureEdge("xproto-internal", "xproto-host", "RUNS_ON", "A2AAgent", "Host"),
+		processorFixtureEdge("xproto-server", "xproto-host", "RUNS_ON", "MCPServer", "Host"),
+		processorFixtureEdge("xproto-agent-instance", "xproto-server", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		processorFixtureEdge("xproto-server", "xproto-tool", "PROVIDES_TOOL", "MCPServer", "MCPTool"),
+	}
+	if _, err := writer.WriteEdges(ctx, managedProcessorEdges(rawEdges), scanID); err != nil {
+		t.Fatalf("write raw edges: %v", err)
+	}
+	access := processorFixtureEdge("xproto-tool", "xproto-resource", "HAS_ACCESS_TO", "MCPTool", "MCPResource")
+	if _, err := writer.WriteCompositeEdges(
+		ctx, compositeProcessorEdges([]ingest.Edge{access}), scanID,
+	); err != nil {
+		t.Fatalf("write access edge: %v", err)
+	}
+
+	if _, err := (&AuthStrength{}).Process(ctx, db, scanID); err != nil {
+		t.Fatalf("materialize effective auth: %v", err)
+	}
+	if _, err := (&CrossProtocol{}).Process(ctx, db, scanID); err != nil {
+		t.Fatalf("cross_protocol process: %v", err)
+	}
+
+	assertCompositeEdgeCount(t, ctx, db, "xproto-ext-observed", "CAN_REACH", "xproto-resource", 1)
+	assertCompositeEdgeCount(t, ctx, db, "xproto-ext-unobserved", "CAN_REACH", "xproto-resource", 0)
+}
+
+func effectiveAuthIntegrationDB(
+	t *testing.T,
+	scanID string,
+) (context.Context, graph.GraphDB, *graph.Writer, func()) {
+	t.Helper()
+	uri := os.Getenv("AGENTHOUND_NEO4J_URI")
+	if uri == "" {
+		t.Skip("skipping integration test: AGENTHOUND_NEO4J_URI not set")
+	}
+	ctx := context.Background()
+	driver, err := graph.NewDriver(
+		uri,
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	db := graph.NewDB(graph.NewReader(driver), graph.NewWriter(driver))
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(ctx,
+			"MATCH (n) WHERE n.scan_id = $sid DETACH DELETE n",
+			map[string]any{"sid": scanID})
+		driver.Close(ctx)
+	}
+	_, _ = db.ExecuteWrite(ctx,
+		"MATCH (n) WHERE n.scan_id = $sid DETACH DELETE n",
+		map[string]any{"sid": scanID})
+	return ctx, db, graph.NewWriter(driver), cleanup
+}
+
+func processorFixtureNode(
+	id, kind, name, scanID string,
+	extra map[string]any,
+) ingest.Node {
+	properties := map[string]any{
+		"objectid": id,
+		"name":     name,
+		"scan_id":  scanID,
+	}
+	for key, value := range extra {
+		properties[key] = value
+	}
+	return ingest.Node{ID: id, Kinds: []string{kind}, Properties: properties}
+}
+
+func processorFixtureCredential(
+	id, name, scanID, valueHash, mergeKey, identityBasis string,
+) ingest.Node {
+	return processorFixtureNode(id, "Credential", name, scanID, map[string]any{
+		"type":            "apiKey",
+		"value_hash":      valueHash,
+		"merge_key":       mergeKey,
+		"identity_basis":  identityBasis,
+		"material_status": "observed",
+		"exposure_status": "exposed",
+	})
+}
+
+func processorFixtureEdge(source, target, kind, sourceKind, targetKind string) ingest.Edge {
+	return ingest.Edge{
+		Source: source, Target: target, Kind: kind,
+		SourceKind: sourceKind, TargetKind: targetKind,
+		Properties: map[string]any{"risk_weight": 0.1},
+	}
+}
+
+func assertCompositeEdgeCount(
+	t *testing.T,
+	ctx context.Context,
+	db graph.GraphDB,
+	sourceID, kind, targetID string,
+	want int,
+) {
+	t.Helper()
+	rows, err := db.Query(ctx, `MATCH (source {objectid:$source})-[edge]->(target {objectid:$target})
+WHERE type(edge) = $kind AND edge.is_composite = true
+RETURN count(edge) AS n`, map[string]any{
+		"source": sourceID,
+		"target": targetID,
+		"kind":   kind,
+	})
+	if err != nil {
+		t.Fatalf("query %s %s->%s: %v", kind, sourceID, targetID, err)
+	}
+	if got := toInt(rows[0]["n"]); got != want {
+		t.Errorf("%s %s->%s count = %d, want %d", kind, sourceID, targetID, got, want)
+	}
+}

--- a/server/internal/analysis/registry.go
+++ b/server/internal/analysis/registry.go
@@ -4,9 +4,9 @@ import "github.com/adithyan-ak/agenthound/server/internal/analysis/processors"
 
 func allProcessors() []PostProcessor {
 	return []PostProcessor{
-		// auth_strength is a pre-pass: it materializes a numeric
-		// auth_strength node property that confused_deputy compares in
-		// Cypher. No deps; must run before any processor that reads it.
+		// auth_strength is a pre-pass: it materializes paired effective node
+		// authentication plus effective TRUSTS_SERVER assessment properties.
+		// No deps; must run before any processor that reads those values.
 		&processors.AuthStrength{},
 		&processors.HasAccessTo{},
 		&processors.CanExecute{},

--- a/server/internal/analysis/remediation.go
+++ b/server/internal/analysis/remediation.go
@@ -165,36 +165,50 @@ func remediationForRelation(
 	switch edge.Kind {
 	case "TRUSTS_SERVER":
 		step.Title = "Verify server authentication"
-		methodRaw, _ := targetNode.Properties["auth_method"].(string)
+		methodRaw, authEvidence, authSource := pathNodeEffectiveAuth(targetNode.Properties)
 		method := common.NormalizeAuthMethod(methodRaw)
-		authEvidence, _ := targetNode.Properties["auth_evidence"].(string)
+		authReporter := fmt.Sprintf(
+			"Configured authentication evidence for %s",
+			typedRemediationActor(target, "MCP server"),
+		)
+		if authSource == "observed" {
+			authReporter = fmt.Sprintf(
+				"Runtime observation for %s",
+				typedRemediationActor(target, "MCP server"),
+			)
+		}
 		switch method {
 		case common.AuthNone:
-			if !common.IsConfirmedAnonymousAccess(methodRaw, authEvidence) {
+			if authSource != "observed" ||
+				!common.IsConfirmedAnonymousAccess(methodRaw, authEvidence) {
 				step.Description = fmt.Sprintf(
-					"%s reports auth_method=none, but explicit anonymous-access evidence is unavailable. Verify the configured scheme and server identity used by %s before concluding that it is unauthenticated.",
-					typedRemediationActor(target, "MCP server"),
+					"%s reports auth_method=none, but explicit anonymous-access evidence is unavailable (effective source: %s). Verify the configured scheme and server identity used by %s before concluding that it is unauthenticated.",
+					authReporter,
+					authSource,
 					typedRemediationActor(source, "agent"),
 				)
 				break
 			}
 			step.Description = fmt.Sprintf(
-				"%s explicitly reports no authentication. Configure an authenticated trust relationship and verify the server identity before %s invokes it.",
-				typedRemediationActor(target, "MCP server"),
+				"%s explicitly reports no authentication (effective source: %s). Configure an authenticated trust relationship and verify the server identity before %s invokes it.",
+				authReporter,
+				authSource,
 				typedRemediationActor(source, "agent"),
 			)
 		case common.AuthUnknown, common.AuthCustom:
 			step.Description = fmt.Sprintf(
-				"Authentication evidence for %s is %s. Verify the configured scheme and server identity used by %s; no specific authentication upgrade is inferred.",
+				"Authentication evidence for %s is %s (effective source: %s). Verify the configured scheme and server identity used by %s; no specific authentication upgrade is inferred.",
 				typedRemediationActor(target, "MCP server"),
 				method,
+				authSource,
 				typedRemediationActor(source, "agent"),
 			)
 		default:
 			step.Description = fmt.Sprintf(
-				"%s reports %s authentication. Verify that %s validates that identity and that the credential scope is least-privileged.",
-				typedRemediationActor(target, "MCP server"),
+				"%s reports %s authentication (effective source: %s). Verify that %s validates that identity and that the credential scope is least-privileged.",
+				authReporter,
 				method,
+				authSource,
 				typedRemediationActor(source, "agent"),
 			)
 		}
@@ -294,6 +308,26 @@ func remediationForRelation(
 		return RemediationStep{}, false
 	}
 	return step, true
+}
+
+// pathNodeEffectiveAuth reads the materialized tuple atomically. Historical
+// snapshots created before effective-auth materialization fall back to the
+// configured pair, but a partial effective tuple is never mixed with configured
+// evidence.
+func pathNodeEffectiveAuth(properties map[string]any) (string, string, string) {
+	method, methodOK := properties["effective_auth_method"].(string)
+	assurance, assuranceOK := properties["effective_auth_assurance"].(string)
+	evidence, evidenceOK := properties["effective_auth_evidence"].(string)
+	source, sourceOK := properties["effective_auth_source"].(string)
+	if methodOK && method != "" &&
+		assuranceOK && assurance != "" &&
+		evidenceOK && evidence != "" &&
+		sourceOK && (source == "configured" || source == "observed") {
+		return method, evidence, source
+	}
+	method, _ = properties["auth_method"].(string)
+	evidence, _ = properties["auth_evidence"].(string)
+	return method, evidence, "configured"
 }
 
 func actorFromPathNode(node PathNode, fallbackID string) RemediationActor {

--- a/server/internal/analysis/remediation_test.go
+++ b/server/internal/analysis/remediation_test.go
@@ -183,10 +183,11 @@ func TestBuildRemediation_AuthenticationAdviceUsesTargetEvidence(t *testing.T) {
 		notWant      string
 	}{
 		{
-			name:         "explicit none",
+			name:         "raw anonymous claim lacks observed provenance",
 			authMethod:   "none",
 			authEvidence: "anonymous_probe_succeeded",
-			want:         "explicitly reports no authentication",
+			want:         "explicit anonymous-access evidence is unavailable",
+			notWant:      "explicitly reports no authentication",
 		},
 		{
 			name:       "none without explicit evidence remains unverified",
@@ -237,6 +238,52 @@ func TestBuildRemediation_AuthenticationAdviceUsesTargetEvidence(t *testing.T) {
 				t.Fatalf("typed actors = %+v -> %+v", steps[0].Source, steps[0].Target)
 			}
 		})
+	}
+}
+
+func TestBuildRemediation_AuthenticationAdviceUsesPairedEffectiveSource(t *testing.T) {
+	path := &AttackPath{
+		Nodes: []PathNode{
+			{ID: "agent", Kinds: []string{"AgentInstance"}, Properties: map[string]any{"name": "Agent"}},
+			{ID: "server", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name":        "Server",
+				"auth_method": "bearer", "auth_assurance": "moderate",
+				"auth_evidence":         "configured_credential",
+				"effective_auth_method": "none", "effective_auth_assurance": "unauthenticated",
+				"effective_auth_evidence": "anonymous_probe_succeeded",
+				"effective_auth_source":   "observed",
+			}},
+		},
+		Edges: []PathEdge{{Source: "agent", Target: "server", Kind: "TRUSTS_SERVER"}},
+	}
+	steps := BuildRemediation(path, &model.Finding{EdgeKind: "CAN_REACH"})
+	if len(steps) != 1 {
+		t.Fatalf("steps = %+v", steps)
+	}
+	description := steps[0].Description
+	for _, want := range []string{
+		"Runtime observation",
+		"explicitly reports no authentication",
+		"effective source: observed",
+	} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("description %q missing %q", description, want)
+		}
+	}
+	if strings.Contains(description, "reports bearer authentication") {
+		t.Fatalf("configured method overrode the paired effective tuple: %q", description)
+	}
+}
+
+func TestPathNodeEffectiveAuthRejectsPartialTupleMixing(t *testing.T) {
+	method, evidence, source := pathNodeEffectiveAuth(map[string]any{
+		"auth_method": "oauth", "auth_evidence": "configured_credential",
+		"effective_auth_method":   "none",
+		"effective_auth_evidence": "anonymous_probe_succeeded",
+		// Deliberately omit effective assurance/source.
+	})
+	if method != "oauth" || evidence != "configured_credential" || source != "configured" {
+		t.Fatalf("partial tuple was mixed: %s/%s source=%s", method, evidence, source)
 	}
 }
 

--- a/server/internal/analysis/riskscore/a2a_agent.go
+++ b/server/internal/analysis/riskscore/a2a_agent.go
@@ -44,7 +44,10 @@ func A2AAgentRiskAssessment(ctx context.Context, db graph.GraphDB, objectID stri
 
 func a2aAuthAssessment(ctx context.Context, db graph.GraphDB, objectID string) (Assessment, error) {
 	cypher := `MATCH (a {objectid: $id})
-RETURN a.auth_method AS am, a.auth_evidence AS auth_evidence`
+RETURN a.effective_auth_method AS am,
+       a.effective_auth_assurance AS auth_assurance,
+       a.effective_auth_evidence AS auth_evidence,
+       a.effective_auth_source AS auth_source`
 	rows, err := db.Query(ctx, cypher, map[string]any{"id": objectID})
 	if err != nil {
 		return Assessment{}, err
@@ -53,10 +56,18 @@ RETURN a.auth_method AS am, a.auth_evidence AS auth_evidence`
 		return unknownAssessment("auth_method", 0, 100), nil
 	}
 	am, _ := rows[0]["am"].(string)
+	authAssurance, _ := rows[0]["auth_assurance"].(string)
 	authEvidence, _ := rows[0]["auth_evidence"].(string)
-	if common.NormalizeAuthMethod(am) == common.AuthNone &&
-		!common.IsConfirmedAnonymousAccess(am, authEvidence) {
-		return unknownAssessment("auth_evidence", 0, 100), nil
+	authSource, _ := rows[0]["auth_source"].(string)
+	if common.NormalizeAuthMethod(am) == common.AuthNone {
+		switch {
+		case !common.IsConfirmedAnonymousAccess(am, authEvidence):
+			return unknownAssessment("auth_evidence", 0, 100), nil
+		case authSource != "observed":
+			return unknownAssessment("auth_source", 0, 100), nil
+		case authAssurance != string(common.AuthAssuranceUnauthenticated):
+			return unknownAssessment("auth_assurance", 0, 100), nil
+		}
 	}
 	auth := common.AssessAuth(am)
 	if auth.Weakness == nil {

--- a/server/internal/analysis/riskscore/a2a_agent_test.go
+++ b/server/internal/analysis/riskscore/a2a_agent_test.go
@@ -51,7 +51,8 @@ func TestA2AAuthAssessmentRequiresExplicitAnonymousEvidence(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			db := &graph.MockGraphDB{QueryResult: []map[string]any{{
-				"am": "none", "auth_evidence": test.evidence,
+				"am": "none", "auth_assurance": "unauthenticated",
+				"auth_evidence": test.evidence, "auth_source": "observed",
 			}}}
 			assessment, err := a2aAuthAssessment(context.Background(), db, "a2a")
 			if err != nil {
@@ -76,5 +77,46 @@ func TestA2AAuthAssessmentRequiresExplicitAnonymousEvidence(t *testing.T) {
 				t.Fatalf("unconfirmed anonymous assessment = %+v", assessment)
 			}
 		})
+	}
+}
+
+func TestA2AAuthAssessmentUsesMaterializedEffectiveFields(t *testing.T) {
+	var captured string
+	db := &graph.MockGraphDB{
+		QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
+			captured = cypher
+			return []map[string]any{{
+				"am": "mtls", "auth_evidence": "declared_security_scheme",
+			}}, nil
+		},
+	}
+	assessment, err := a2aAuthAssessment(context.Background(), db, "a2a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !assessment.Complete || assessment.Score != 10 {
+		t.Fatalf("A2A effective configured assessment = %+v", assessment)
+	}
+	if !containsSubstring(captured, "a.effective_auth_method AS am") ||
+		!containsSubstring(captured, "a.effective_auth_assurance AS auth_assurance") ||
+		!containsSubstring(captured, "a.effective_auth_evidence AS auth_evidence") ||
+		!containsSubstring(captured, "a.effective_auth_source AS auth_source") ||
+		containsSubstring(captured, "a.observed_auth_") {
+		t.Fatalf("A2A risk did not use its materialized effective tuple:\n%s", captured)
+	}
+}
+
+func TestA2AAuthAssessmentRejectsConfiguredAnonymousClaim(t *testing.T) {
+	db := &graph.MockGraphDB{QueryResult: []map[string]any{{
+		"am": "none", "auth_assurance": "unknown",
+		"auth_evidence": "anonymous_probe_succeeded", "auth_source": "configured",
+	}}}
+	assessment, err := a2aAuthAssessment(context.Background(), db, "a2a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Complete || len(assessment.UnknownFactors) != 1 ||
+		assessment.UnknownFactors[0] != "auth_source" {
+		t.Fatalf("configured anonymous claim was treated as observed: %+v", assessment)
 	}
 }

--- a/server/internal/analysis/riskscore/a2a_import_test.go
+++ b/server/internal/analysis/riskscore/a2a_import_test.go
@@ -11,10 +11,11 @@ import (
 	serveringest "github.com/adithyan-ak/agenthound/server/internal/ingest"
 )
 
-func TestStrictV2ImportedA2ANoneAuthRequiresProbeEvidence(t *testing.T) {
+func TestStrictV3ImportedA2ANoneAuthRequiresProbeEvidence(t *testing.T) {
 	for _, test := range []struct {
 		name          string
 		authEvidence  string
+		observed      bool
 		wantComplete  bool
 		wantMin       float64
 		wantMax       float64
@@ -27,20 +28,35 @@ func TestStrictV2ImportedA2ANoneAuthRequiresProbeEvidence(t *testing.T) {
 			wantUnknownBy: "auth_evidence",
 		},
 		{
-			name:         "successful anonymous probe is exact",
-			authEvidence: "anonymous_probe_succeeded",
+			name:          "legacy raw anonymous evidence lacks runtime provenance",
+			authEvidence:  "anonymous_probe_succeeded",
+			wantMax:       30,
+			wantUnknownBy: "auth_source",
+		},
+		{
+			name:         "successful bounded anonymous probe is exact",
+			authEvidence: "declared_security_scheme",
+			observed:     true,
 			wantComplete: true,
 			wantMin:      30,
 			wantMax:      30,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			data := strictV2A2AImport(test.authEvidence)
+			data := strictV3A2AImport(test.authEvidence, test.observed)
 			if err := serveringest.NewValidator().Validate(data); err != nil {
-				t.Fatalf("strict-v2 A2A import rejected: %v", err)
+				t.Fatalf("strict-v3 A2A import rejected: %v", err)
 			}
 
 			properties := data.Graph.Nodes[0].Properties
+			effectiveEvidence := properties["auth_evidence"]
+			effectiveAssurance := "unknown"
+			effectiveSource := "configured"
+			if test.observed {
+				effectiveEvidence = properties["observed_auth_evidence"]
+				effectiveAssurance = "unauthenticated"
+				effectiveSource = "observed"
+			}
 			db := &graph.MockGraphDB{
 				QueryFunc: func(
 					_ context.Context,
@@ -49,8 +65,10 @@ func TestStrictV2ImportedA2ANoneAuthRequiresProbeEvidence(t *testing.T) {
 				) ([]map[string]any, error) {
 					if strings.Contains(cypher, "auth_method") {
 						return []map[string]any{{
-							"am":            properties["auth_method"],
-							"auth_evidence": properties["auth_evidence"],
+							"am":             properties["auth_method"],
+							"auth_assurance": effectiveAssurance,
+							"auth_evidence":  effectiveEvidence,
+							"auth_source":    effectiveSource,
 						}}, nil
 					}
 					return nil, nil
@@ -82,13 +100,13 @@ func TestStrictV2ImportedA2ANoneAuthRequiresProbeEvidence(t *testing.T) {
 	}
 }
 
-func strictV2A2AImport(authEvidence string) *sdkingest.IngestData {
+func strictV3A2AImport(authEvidence string, observed bool) *sdkingest.IngestData {
 	scope := sdkingest.CanonicalCoverageKey(
 		"a2a",
 		"target",
 		"https://imported.example/a2a",
 	)
-	return &sdkingest.IngestData{
+	data := &sdkingest.IngestData{
 		Meta: sdkingest.IngestMeta{
 			Version: sdkingest.CurrentVersion,
 			Type:    sdkingest.IngestType,
@@ -99,7 +117,7 @@ func strictV2A2AImport(authEvidence string) *sdkingest.IngestData {
 			Collector:        "a2a",
 			CollectorVersion: "import-test",
 			Timestamp:        "2026-07-12T00:00:00Z",
-			ScanID:           "strict-v2-a2a-import",
+			ScanID:           "strict-v3-a2a-import",
 			Collection: &sdkingest.CollectionReport{
 				State:        sdkingest.OutcomeComplete,
 				CoverageKeys: []string{scope},
@@ -137,4 +155,14 @@ func strictV2A2AImport(authEvidence string) *sdkingest.IngestData {
 			Edges: []sdkingest.Edge{},
 		},
 	}
+	if observed {
+		properties := data.Graph.Nodes[0].Properties
+		properties["observed_auth_method"] = "none"
+		properties["observed_auth_assurance"] = "unauthenticated"
+		properties["observed_auth_evidence"] = "anonymous_probe_succeeded"
+		properties["auth_probe_method"] = "get_task_nonexistent"
+		properties["auth_probe_status"] = "anonymous_protocol_access"
+		properties["auth_probe_detail"] = "task_not_found_v1"
+	}
+	return data
 }

--- a/server/internal/analysis/riskscore/agent.go
+++ b/server/internal/analysis/riskscore/agent.go
@@ -106,8 +106,8 @@ RETURN count(DISTINCT r) AS cnt`
 func agentAuthPosture(ctx context.Context, db graph.GraphDB, objectID string) (Assessment, error) {
 	cypher := `
 MATCH (a {objectid: $id})-[t:TRUSTS_SERVER]->(s:MCPServer)
-RETURN t.risk_weight AS rw,
-       t.auth_assessment_complete AS auth_assessment_complete`
+RETURN t.effective_risk_weight AS rw,
+       t.effective_auth_assessment_complete AS auth_assessment_complete`
 
 	rows, err := db.Query(ctx, cypher, map[string]any{"id": objectID})
 	if err != nil {

--- a/server/internal/analysis/riskscore/agent_test.go
+++ b/server/internal/analysis/riskscore/agent_test.go
@@ -136,9 +136,11 @@ func TestAgentRiskScore_BlastRadiusCapped(t *testing.T) {
 }
 
 func TestAgentRiskScore_AuthPosture(t *testing.T) {
+	var authQuery string
 	mock := &graph.MockGraphDB{
 		QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
 			if containsSubstring(cypher, "risk_weight") {
+				authQuery = cypher
 				return []map[string]any{{
 					"rw":                       0.1,
 					"auth_assessment_complete": true,
@@ -159,6 +161,11 @@ func TestAgentRiskScore_AuthPosture(t *testing.T) {
 		assessment.Max != 18 ||
 		len(assessment.UnknownFactors) != 0 {
 		t.Errorf("assessment = %+v, want exact score 18", assessment)
+	}
+	if !containsSubstring(authQuery, "t.effective_risk_weight AS rw") ||
+		!containsSubstring(authQuery, "t.effective_auth_assessment_complete AS auth_assessment_complete") ||
+		containsSubstring(authQuery, "RETURN t.risk_weight AS rw") {
+		t.Fatalf("agent risk did not consume the effective trust assessment:\n%s", authQuery)
 	}
 }
 

--- a/server/internal/analysis/riskscore/effective_auth_integration_test.go
+++ b/server/internal/analysis/riskscore/effective_auth_integration_test.go
@@ -1,0 +1,125 @@
+package riskscore
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+func TestIntegrationEffectiveAuthRiskExactness(t *testing.T) {
+	uri := os.Getenv("AGENTHOUND_NEO4J_URI")
+	if uri == "" {
+		t.Skip("skipping integration test: AGENTHOUND_NEO4J_URI not set")
+	}
+	ctx := context.Background()
+	driver, err := graph.NewDriver(
+		uri,
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+	db := graph.NewDB(graph.NewReader(driver), graph.NewWriter(driver))
+
+	const scanID = "test-effective-auth-risk"
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(ctx,
+			"MATCH (n {scan_id: $scan_id}) DETACH DELETE n",
+			map[string]any{"scan_id": scanID})
+	}
+	cleanup()
+	defer cleanup()
+
+	_, err = db.ExecuteWrite(ctx, `CREATE
+  (agent:AgentInstance {
+    objectid: 'risk-effective-agent', name: 'Effective Agent', scan_id: $scan_id
+  }),
+  (server:MCPServer {
+    objectid: 'risk-effective-server', name: 'Effective Server', scan_id: $scan_id,
+    auth_method: 'bearer', auth_assurance: 'moderate', auth_evidence: 'configured_credential',
+    effective_auth_method: 'none', effective_auth_assurance: 'unauthenticated',
+    effective_auth_evidence: 'anonymous_probe_succeeded', effective_auth_source: 'observed'
+  }),
+  (host:Host {
+    objectid: 'risk-effective-host', hostname: 'localhost', scope: 'local', scan_id: $scan_id
+  }),
+  (a2a:A2AAgent {
+    objectid: 'risk-effective-a2a', name: 'Effective A2A', scan_id: $scan_id,
+    auth_method: 'mtls', auth_assurance: 'strong', auth_evidence: 'declared_security_scheme',
+    effective_auth_method: 'mtls', effective_auth_assurance: 'strong',
+    effective_auth_evidence: 'declared_security_scheme', effective_auth_source: 'configured'
+  }),
+  (a2a_observed:A2AAgent {
+    objectid: 'risk-effective-a2a-observed', name: 'Observed Anonymous A2A', scan_id: $scan_id,
+    auth_method: 'unknown', auth_assurance: 'unknown', auth_evidence: 'declared_security_scheme',
+    effective_auth_method: 'none', effective_auth_assurance: 'unauthenticated',
+    effective_auth_evidence: 'anonymous_probe_succeeded', effective_auth_source: 'observed'
+  }),
+  (a2a_raw:A2AAgent {
+    objectid: 'risk-effective-a2a-raw', name: 'Raw Anonymous A2A', scan_id: $scan_id,
+    auth_method: 'none', auth_assurance: 'unauthenticated', auth_evidence: 'anonymous_probe_succeeded',
+    effective_auth_method: 'none', effective_auth_assurance: 'unknown',
+    effective_auth_evidence: 'anonymous_probe_succeeded', effective_auth_source: 'configured'
+  }),
+  (agent)-[:TRUSTS_SERVER {
+    risk_weight: 0.5, auth_assessment_complete: true,
+    effective_risk_weight: 0.1, effective_auth_assessment_complete: true,
+    effective_auth_source: 'observed'
+  }]->(server),
+  (server)-[:RUNS_ON {risk_weight: 0.1}]->(host)
+RETURN 1 AS created`, map[string]any{"scan_id": scanID})
+	if err != nil {
+		t.Fatalf("seed effective risk graph: %v", err)
+	}
+
+	agentAssessment, err := AgentRiskAssessment(ctx, db, "risk-effective-agent")
+	if err != nil {
+		t.Fatalf("agent risk: %v", err)
+	}
+	if !agentAssessment.Complete || agentAssessment.Score != 18 ||
+		agentAssessment.Min != 18 || agentAssessment.Max != 18 {
+		t.Fatalf("agent effective auth risk = %+v, want exact 18", agentAssessment)
+	}
+
+	serverAssessment, err := ServerRiskAssessment(ctx, db, "risk-effective-server")
+	if err != nil {
+		t.Fatalf("server risk: %v", err)
+	}
+	// auth=100 * 0.35, local exposure=20 * 0.20, other factors=0.
+	if !serverAssessment.Complete || serverAssessment.Score != 39 ||
+		serverAssessment.Min != 39 || serverAssessment.Max != 39 {
+		t.Fatalf("server effective auth risk = %+v, want exact 39", serverAssessment)
+	}
+
+	a2aAssessment, err := A2AAgentRiskAssessment(ctx, db, "risk-effective-a2a")
+	if err != nil {
+		t.Fatalf("A2A risk: %v", err)
+	}
+	// Configured-derived mTLS auth remains 10 * 0.30 when no exact A2A probe wins.
+	if !a2aAssessment.Complete || a2aAssessment.Score != 3 ||
+		a2aAssessment.Min != 3 || a2aAssessment.Max != 3 {
+		t.Fatalf("A2A effective configured auth risk = %+v, want exact 3", a2aAssessment)
+	}
+
+	observedA2A, err := A2AAgentRiskAssessment(ctx, db, "risk-effective-a2a-observed")
+	if err != nil {
+		t.Fatalf("observed A2A risk: %v", err)
+	}
+	if !observedA2A.Complete || observedA2A.Score != 30 ||
+		observedA2A.Min != 30 || observedA2A.Max != 30 {
+		t.Fatalf("A2A effective observed auth risk = %+v, want exact 30", observedA2A)
+	}
+
+	rawA2A, err := A2AAgentRiskAssessment(ctx, db, "risk-effective-a2a-raw")
+	if err != nil {
+		t.Fatalf("raw A2A risk: %v", err)
+	}
+	if rawA2A.Complete || rawA2A.Min != 0 || rawA2A.Max != 30 ||
+		len(rawA2A.UnknownFactors) != 1 || rawA2A.UnknownFactors[0] != "auth_source" {
+		t.Fatalf("raw configured anonymous A2A risk = %+v, want auth-source bound 0-30", rawA2A)
+	}
+}

--- a/server/internal/analysis/riskscore/server.go
+++ b/server/internal/analysis/riskscore/server.go
@@ -50,7 +50,10 @@ func ServerRiskAssessment(ctx context.Context, db graph.GraphDB, objectID string
 
 func serverAuthAssessment(ctx context.Context, db graph.GraphDB, objectID string) (Assessment, error) {
 	cypher := `MATCH (s {objectid: $id})
-RETURN s.auth_method AS am, s.auth_evidence AS auth_evidence`
+RETURN s.effective_auth_method AS am,
+       s.effective_auth_assurance AS auth_assurance,
+       s.effective_auth_evidence AS auth_evidence,
+       s.effective_auth_source AS auth_source`
 	rows, err := db.Query(ctx, cypher, map[string]any{"id": objectID})
 	if err != nil {
 		return Assessment{}, err
@@ -59,10 +62,18 @@ RETURN s.auth_method AS am, s.auth_evidence AS auth_evidence`
 		return unknownAssessment("auth_method", 0, 100), nil
 	}
 	am, _ := rows[0]["am"].(string)
+	authAssurance, _ := rows[0]["auth_assurance"].(string)
 	authEvidence, _ := rows[0]["auth_evidence"].(string)
-	if common.NormalizeAuthMethod(am) == common.AuthNone &&
-		!common.IsConfirmedAnonymousAccess(am, authEvidence) {
-		return unknownAssessment("auth_evidence", 0, 100), nil
+	authSource, _ := rows[0]["auth_source"].(string)
+	if common.NormalizeAuthMethod(am) == common.AuthNone {
+		switch {
+		case !common.IsConfirmedAnonymousAccess(am, authEvidence):
+			return unknownAssessment("auth_evidence", 0, 100), nil
+		case authSource != "observed":
+			return unknownAssessment("auth_source", 0, 100), nil
+		case authAssurance != string(common.AuthAssuranceUnauthenticated):
+			return unknownAssessment("auth_assurance", 0, 100), nil
+		}
 	}
 	auth := common.AssessAuth(am)
 	if auth.Weakness == nil {

--- a/server/internal/analysis/riskscore/server_test.go
+++ b/server/internal/analysis/riskscore/server_test.go
@@ -41,7 +41,13 @@ func TestServerRiskScore_AuthStrength(t *testing.T) {
 			mock := &graph.MockGraphDB{
 				QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
 					if containsSubstring(cypher, "auth_method") {
-						return []map[string]any{{"am": tt.method}}, nil
+						row := map[string]any{"am": tt.method}
+						if tt.method == "none" {
+							row["auth_assurance"] = "unauthenticated"
+							row["auth_evidence"] = "anonymous_probe_succeeded"
+							row["auth_source"] = "observed"
+						}
+						return []map[string]any{row}, nil
 					}
 					return nil, nil
 				},
@@ -73,7 +79,8 @@ func TestServerAuthAssessmentRequiresExplicitAnonymousEvidence(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			db := &graph.MockGraphDB{QueryResult: []map[string]any{{
-				"am": "none", "auth_evidence": tt.evidence,
+				"am": "none", "auth_assurance": "unauthenticated",
+				"auth_evidence": tt.evidence, "auth_source": "observed",
 			}}}
 			assessment, err := serverAuthAssessment(context.Background(), db, "server")
 			if err != nil {
@@ -83,6 +90,49 @@ func TestServerAuthAssessmentRequiresExplicitAnonymousEvidence(t *testing.T) {
 				t.Fatalf("assessment = %+v, want complete=%v", assessment, tt.complete)
 			}
 		})
+	}
+}
+
+func TestServerAuthAssessmentUsesPairedEffectiveTuple(t *testing.T) {
+	var captured string
+	db := &graph.MockGraphDB{
+		QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
+			captured = cypher
+			return []map[string]any{{
+				"am": "none", "auth_assurance": "unauthenticated",
+				"auth_evidence": "anonymous_probe_succeeded", "auth_source": "observed",
+			}}, nil
+		},
+	}
+	assessment, err := serverAuthAssessment(context.Background(), db, "server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !assessment.Complete || assessment.Score != 100 ||
+		assessment.Min != 100 || assessment.Max != 100 {
+		t.Fatalf("confirmed effective anonymous assessment = %+v", assessment)
+	}
+	if !containsSubstring(captured, "s.effective_auth_method AS am") ||
+		!containsSubstring(captured, "s.effective_auth_assurance AS auth_assurance") ||
+		!containsSubstring(captured, "s.effective_auth_evidence AS auth_evidence") ||
+		!containsSubstring(captured, "s.effective_auth_source AS auth_source") ||
+		containsSubstring(captured, "RETURN s.auth_method AS am") {
+		t.Fatalf("server risk did not consume the effective tuple:\n%s", captured)
+	}
+}
+
+func TestServerAuthAssessmentRejectsConfiguredAnonymousClaim(t *testing.T) {
+	db := &graph.MockGraphDB{QueryResult: []map[string]any{{
+		"am": "none", "auth_assurance": "unknown",
+		"auth_evidence": "anonymous_probe_succeeded", "auth_source": "configured",
+	}}}
+	assessment, err := serverAuthAssessment(context.Background(), db, "server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Complete || len(assessment.UnknownFactors) != 1 ||
+		assessment.UnknownFactors[0] != "auth_source" {
+		t.Fatalf("configured anonymous claim was treated as observed: %+v", assessment)
 	}
 }
 

--- a/server/internal/analysis/testdata/moat_detectors_scan.json
+++ b/server/internal/analysis/testdata/moat_detectors_scan.json
@@ -1,7 +1,8 @@
 {
   "meta": {
-    "version": 2,
+    "version": 3,
     "type": "agenthound-ingest",
+    "origin": {"host_id": "fixture-host", "network_realm_id": "fixture-realm"},
     "collector": "mcp",
     "collector_version": "0.1.0",
     "timestamp": "2026-06-19T10:00:00Z",
@@ -28,8 +29,8 @@
     "identity_schemes": [{
       "entity_kind": "MCPServer",
       "transport": "stdio",
-      "scheme": "mcp_stdio_v2_ordered",
-      "version": 2
+      "scheme": "mcp_stdio_v3_hashed_argv",
+      "version": 3
     }]
   },
   "graph": {

--- a/server/internal/analysis/testdata/moat_detectors_scan.json
+++ b/server/internal/analysis/testdata/moat_detectors_scan.json
@@ -128,9 +128,15 @@
         "properties": {
           "objectid": "moat-agent-weak",
           "name": "anon_agent",
-          "auth_method": "none",
-          "auth_assurance": "unauthenticated",
-          "auth_evidence": "anonymous_probe_succeeded",
+          "auth_method": "apiKey",
+          "auth_assurance": "weak",
+          "auth_evidence": "declared_security_scheme",
+          "auth_probe_method": "get_task_nonexistent",
+          "auth_probe_status": "anonymous_protocol_access",
+          "auth_probe_detail": "task_not_found_v1",
+          "observed_auth_method": "none",
+          "observed_auth_assurance": "unauthenticated",
+          "observed_auth_evidence": "anonymous_probe_succeeded",
           "is_signed": false,
           "signature_verification_status": "unsigned"
         },

--- a/server/internal/analysis/traversal.go
+++ b/server/internal/analysis/traversal.go
@@ -508,7 +508,10 @@ UNWIND $ids AS current_id
         startNode(r).objectid AS source,
         endNode(r).objectid AS target,
         type(r) AS kind,
-        r.risk_weight AS risk_weight
+        CASE WHEN type(r) = 'TRUSTS_SERVER'
+          THEN coalesce(r.effective_risk_weight, r.risk_weight)
+          ELSE r.risk_weight
+        END AS risk_weight
  ORDER BY traversal_source, kind, source, target, traversal_target`
 		rows, err := db.Query(ctx, cypher, params)
 		if err != nil {

--- a/server/internal/analysis/traversal_test.go
+++ b/server/internal/analysis/traversal_test.go
@@ -215,6 +215,55 @@ func TestBoundedMinimumWeightChoosesLongerCheaperPath(t *testing.T) {
 	}
 }
 
+func TestWeightedTraversalProjectsEffectiveTrustWeightIntoPathAndSum(t *testing.T) {
+	var adjacencyQuery string
+	db := &graph.MockGraphDB{
+		QueryFunc: func(_ context.Context, cypher string, params map[string]any) ([]map[string]any, error) {
+			if !strings.Contains(cypher, "traversal:adjacency") {
+				t.Fatalf("unexpected query: %s", cypher)
+			}
+			adjacencyQuery = cypher
+			ids, _ := params["ids"].([]string)
+			if len(ids) != 1 || ids[0] != "A" {
+				return nil, nil
+			}
+			return []map[string]any{{
+				"traversal_source": "A", "traversal_target": "S",
+				"next_id": "S", "next_name": "Server", "next_kinds": []any{"MCPServer"},
+				"next_properties": map[string]any{"objectid": "S", "name": "Server"},
+				"source":          "A", "target": "S", "kind": "TRUSTS_SERVER",
+				// This is the projected effective weight, not the configured 0.7.
+				"risk_weight": 0.1,
+			}}, nil
+		},
+	}
+	result, err := FindBoundedTraversalPaths(
+		context.Background(), db,
+		[]TraversalNode{traversalNode("A")},
+		[]TraversalNode{traversalNode("S")},
+		TraversalOptions{Scope: TraversalScopeSecurity, Cost: TraversalCostRisk, MaxHops: 1, Limit: 1},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, clause := range []string{
+		"type(r) = 'TRUSTS_SERVER'",
+		"coalesce(r.effective_risk_weight, r.risk_weight)",
+		"END AS risk_weight",
+	} {
+		if !strings.Contains(adjacencyQuery, clause) {
+			t.Fatalf("adjacency query missing %q:\n%s", clause, adjacencyQuery)
+		}
+	}
+	if len(result.Paths) != 1 || len(result.Paths[0].Edges) != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	edgeWeight := result.Paths[0].Edges[0].RiskWeight
+	if edgeWeight == nil || *edgeWeight != 0.1 || result.Paths[0].Weight != 0.1 {
+		t.Fatalf("effective edge/sum diverged: path=%+v", result.Paths[0])
+	}
+}
+
 func TestBoundedMinimumWeightHonorsHopLimit(t *testing.T) {
 	db := traversalFixtureDB(t, []traversalFixtureEdge{
 		{source: "A", target: "T", kind: "HAS_ACCESS_TO", weight: fixtureWeight(0.9)},

--- a/server/internal/ingest/campaign_vertical_integration_test.go
+++ b/server/internal/ingest/campaign_vertical_integration_test.go
@@ -190,7 +190,7 @@ func TestIntegrationCompiledCampaignExportProbeIngestPromotesOnlySourceAgent(t *
 	}
 	wantTopology := []string{
 		agentA, entryServer, entryTool, serverID,
-		credentialID, identityID, resourceTool, resourceID,
+		identityID, credentialID, resourceTool, resourceID,
 	}
 	if !reflect.DeepEqual(witness.EvidenceNodeIDs, wantTopology) {
 		t.Fatalf(

--- a/server/internal/ingest/normalizer.go
+++ b/server/internal/ingest/normalizer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
@@ -29,6 +30,16 @@ func (n *Normalizer) Normalize(data *ingest.IngestData) []ingest.NormalizationWa
 		if node.Properties == nil {
 			node.Properties = make(map[string]any)
 		}
+		if migratePreV1RawMCPAuthObservation(data.Meta.Collector, node) {
+			warnings = append(warnings, ingest.NormalizationWarning{
+				Code:              "pre_v1_mcp_auth_observation_migrated",
+				Status:            ingest.NormalizationStatusWarning,
+				Message:           fmt.Sprintf("migrated pre-v1 raw MCP anonymous observation on node %s", node.ID),
+				Context:           fmt.Sprintf("node %s", node.ID),
+				Property:          "auth_observation_compat",
+				PublicationUnsafe: false,
+			})
+		}
 
 		// Set objectid
 		node.Properties["objectid"] = node.ID
@@ -47,6 +58,41 @@ func (n *Normalizer) Normalize(data *ingest.IngestData) []ingest.NormalizationWa
 	}
 
 	return warnings
+}
+
+// migratePreV1RawMCPAuthObservation preserves the semantics of direct-URL MCP
+// artifacts produced before the configured/observed split. Those collectors
+// wrote a successful anonymous initialize observation into raw auth_* fields.
+// The envelope, kind, network reachability, exact tuple, and complete absence
+// of the newer observed tuple must all agree before migration. Near misses are
+// left untouched and therefore cannot satisfy observed-auth analysis.
+func migratePreV1RawMCPAuthObservation(collector string, node *ingest.Node) bool {
+	if collector != "mcp" ||
+		node.PropertySemantics != "" ||
+		ingest.ConcreteNodeKind(node.Kinds) != "MCPServer" ||
+		node.Properties == nil ||
+		node.Properties["transport"] != "http" ||
+		node.Properties["status"] != "reachable" ||
+		node.Properties["auth_method"] != string(common.AuthNone) ||
+		node.Properties["auth_assurance"] != string(common.AuthAssuranceUnauthenticated) ||
+		node.Properties["auth_evidence"] != common.AuthEvidenceAnonymousProbeSucceeded {
+		return false
+	}
+	for _, key := range []string{
+		"observed_auth_method",
+		"observed_auth_assurance",
+		"observed_auth_evidence",
+	} {
+		if _, present := node.Properties[key]; present {
+			return false
+		}
+	}
+
+	node.Properties["observed_auth_method"] = string(common.AuthNone)
+	node.Properties["observed_auth_assurance"] = string(common.AuthAssuranceUnauthenticated)
+	node.Properties["observed_auth_evidence"] = common.AuthEvidenceAnonymousProbeSucceeded
+	node.Properties["auth_observation_compat"] = "pre_v1_raw_mcp"
+	return true
 }
 
 func (n *Normalizer) normalizeProps(

--- a/server/internal/ingest/normalizer_test.go
+++ b/server/internal/ingest/normalizer_test.go
@@ -66,6 +66,95 @@ func TestNormalizerDoesNotRepairLocalProcessAuth(t *testing.T) {
 	}
 }
 
+func TestNormalizerMigratesPreV1RawMCPAnonymousObservation(t *testing.T) {
+	data := preV1RawMCPAnonymousData()
+	originalID := data.Graph.Nodes[0].ID
+
+	warnings := NewNormalizer().Normalize(data)
+	props := data.Graph.Nodes[0].Properties
+	if data.Graph.Nodes[0].ID != originalID {
+		t.Fatalf("compatibility migration changed identity: got %q want %q", data.Graph.Nodes[0].ID, originalID)
+	}
+	for key, want := range map[string]any{
+		"observed_auth_method":    "none",
+		"observed_auth_assurance": "unauthenticated",
+		"observed_auth_evidence":  "anonymous_probe_succeeded",
+		"auth_observation_compat": "pre_v1_raw_mcp",
+	} {
+		if got := props[key]; got != want {
+			t.Fatalf("%s = %v, want %v; properties=%+v", key, got, want, props)
+		}
+	}
+	if len(warnings) != 1 ||
+		warnings[0].Code != "pre_v1_mcp_auth_observation_migrated" ||
+		warnings[0].Status != ingest.NormalizationStatusWarning ||
+		warnings[0].PublicationUnsafe {
+		t.Fatalf("compatibility warnings = %+v", warnings)
+	}
+}
+
+func TestNormalizerDoesNotMigrateNearMissRawAuth(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*ingest.IngestData)
+	}{
+		{name: "config envelope", mutate: func(data *ingest.IngestData) { data.Meta.Collector = "config" }},
+		{name: "A2A kind", mutate: func(data *ingest.IngestData) { data.Graph.Nodes[0].Kinds = []string{"A2AAgent"} }},
+		{name: "reference only", mutate: func(data *ingest.IngestData) {
+			data.Graph.Nodes[0].PropertySemantics = ingest.NodePropertySemanticsReferenceOnly
+		}},
+		{name: "declaration only", mutate: func(data *ingest.IngestData) {
+			data.Graph.Nodes[0].Properties["auth_evidence"] = "declared_security_scheme"
+		}},
+		{name: "unknown posture", mutate: func(data *ingest.IngestData) {
+			data.Graph.Nodes[0].Properties["auth_method"] = "unknown"
+			data.Graph.Nodes[0].Properties["auth_assurance"] = "unknown"
+			data.Graph.Nodes[0].Properties["auth_evidence"] = "unknown"
+		}},
+		{name: "unreachable", mutate: func(data *ingest.IngestData) { data.Graph.Nodes[0].Properties["status"] = "unreachable" }},
+		{name: "stdio", mutate: func(data *ingest.IngestData) { data.Graph.Nodes[0].Properties["transport"] = "stdio" }},
+		{name: "partial observed tuple", mutate: func(data *ingest.IngestData) {
+			data.Graph.Nodes[0].Properties["observed_auth_method"] = "none"
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			data := preV1RawMCPAnonymousData()
+			test.mutate(data)
+			warnings := NewNormalizer().Normalize(data)
+			props := data.Graph.Nodes[0].Properties
+			if _, migrated := props["auth_observation_compat"]; migrated {
+				t.Fatalf("near miss migrated: %+v", props)
+			}
+			if _, migrated := props["observed_auth_assurance"]; migrated {
+				t.Fatalf("near miss gained observed assurance: %+v", props)
+			}
+			if _, migrated := props["observed_auth_evidence"]; migrated {
+				t.Fatalf("near miss gained observed evidence: %+v", props)
+			}
+			for _, warning := range warnings {
+				if warning.Code == "pre_v1_mcp_auth_observation_migrated" {
+					t.Fatalf("near miss emitted migration warning: %+v", warnings)
+				}
+			}
+		})
+	}
+}
+
+func preV1RawMCPAnonymousData() *ingest.IngestData {
+	return &ingest.IngestData{
+		Meta: ingest.IngestMeta{Collector: "mcp", ScanID: "pre-v1"},
+		Graph: ingest.GraphData{Nodes: []ingest.Node{{
+			ID:    "pre-v1-mcp-server",
+			Kinds: []string{"MCPServer"},
+			Properties: map[string]any{
+				"name": "legacy direct URL", "transport": "http", "status": "reachable",
+				"auth_method": "none", "auth_assurance": "unauthenticated",
+				"auth_evidence": "anonymous_probe_succeeded",
+			},
+		}}},
+	}
+}
+
 func TestNormalizerSerializesComplexValues(t *testing.T) {
 	n := NewNormalizer()
 	data := &ingest.IngestData{

--- a/server/ui/src/__tests__/Dashboard.test.tsx
+++ b/server/ui/src/__tests__/Dashboard.test.tsx
@@ -1,9 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { Dashboard } from "@features/dashboard";
 import { StatCards } from "@features/dashboard/ui/StatCards";
+import { ExposureGauge } from "@features/dashboard/ui/ExposureGauge";
+import type { Finding } from "@entities/finding/model";
 
 const publishedScan = vi.hoisted(() => ({
   id: "scan-1",
@@ -89,9 +91,62 @@ vi.mock("@entities/posture/api", () => ({
 
 import { useGraphStats } from "@entities/graph-stats/api";
 import { fetchFindings } from "@entities/finding/api";
+import { fetchNodeCollection } from "@entities/node/api";
 
 const mockedUseGraphStats = vi.mocked(useGraphStats);
 const mockedFetchFindings = vi.mocked(fetchFindings);
+const mockedFetchNodeCollection = vi.mocked(fetchNodeCollection);
+
+function observedAnonymousNode(id: string) {
+  return {
+    id,
+    kinds: ["MCPServer"],
+    properties: {
+      auth_method: "unknown",
+      auth_assurance: "unknown",
+      auth_evidence: "unknown",
+      observed_auth_method: "none",
+      observed_auth_assurance: "unauthenticated",
+      observed_auth_evidence: "anonymous_probe_succeeded",
+      effective_auth_method: "none",
+      effective_auth_assurance: "unauthenticated",
+      effective_auth_evidence: "anonymous_probe_succeeded",
+      effective_auth_source: "observed",
+    },
+  };
+}
+
+function nodeCollection(items: ReturnType<typeof observedAnonymousNode>[]) {
+  return {
+    items,
+    total: items.length,
+    complete: true,
+    revision: "graph-revision",
+    projection: { scanId: "scan-1", revision: 1 },
+  };
+}
+
+function highFinding(index: number): Finding {
+  return {
+    id: `finding-${index}`,
+    severity: "high",
+    category: "shadowing",
+    title: "shadowing",
+    description: "shadowing",
+    edge_kind: "SHADOWS",
+    source_id: `source-${index}`,
+    source_name: "source",
+    source_kind: "MCPTool",
+    target_id: `target-${index}`,
+    target_name: "target",
+    target_kind: "MCPTool",
+    confidence: 1,
+    variant: "default",
+    evidence: { state: "inferred" },
+    owasp_map: [],
+    atlas_map: [],
+  };
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -180,11 +235,93 @@ describe("StatCards", () => {
     const zeros = screen.getAllByText("0");
     expect(zeros).toHaveLength(5);
   });
+
+  it("counts observed anonymous MCP servers in the server tile", async () => {
+    mockedUseGraphStats.mockReturnValue({
+      data: {
+        node_counts: { MCPServer: 1 },
+        edge_counts: {},
+        total_nodes: 1,
+        total_edges: 0,
+        projection: { scanId: "scan-1", revision: 1 },
+      },
+      isLoading: false,
+      error: null,
+      isError: false,
+      isPending: false,
+    } as unknown as ReturnType<typeof useGraphStats>);
+    mockedFetchNodeCollection.mockReset();
+    mockedFetchNodeCollection.mockResolvedValue(
+      nodeCollection([observedAnonymousNode("anonymous")]),
+    );
+
+    render(<StatCards />, { wrapper: createWrapper() });
+
+    const tile = (await screen.findByText("1 unauth")).closest(
+      ".card-elevated",
+    );
+    expect(tile).not.toBeNull();
+    expect(within(tile as HTMLElement).getByText("1 unauth")).toBeInTheDocument();
+  });
+});
+
+describe("ExposureGauge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("includes observed anonymous servers in the public exposure index", async () => {
+    mockedFetchFindings.mockReset();
+    mockedFetchFindings.mockResolvedValue({
+      findings: Array.from({ length: 6 }, (_, index) => highFinding(index)),
+      scope: {
+        mode: "published",
+        scanId: "scan-1",
+        revision: 1,
+        publishedAt: "2026-07-11T00:00:00Z",
+        projectionStatus: "complete",
+        snapshotStatus: "complete",
+        available: true,
+        stale: false,
+      },
+    });
+    mockedFetchNodeCollection.mockReset();
+    mockedFetchNodeCollection.mockResolvedValue(
+      nodeCollection([
+        observedAnonymousNode("anonymous-1"),
+        observedAnonymousNode("anonymous-2"),
+      ]),
+    );
+
+    render(<ExposureGauge />, { wrapper: createWrapper() });
+
+    const unauthLabel = await screen.findByText("Unauth Srv");
+    expect(screen.getByText("Guarded")).toBeInTheDocument();
+    const unauth = unauthLabel.closest("div");
+    expect(unauth).not.toBeNull();
+    expect(within(unauth as HTMLElement).getByText("02")).toBeInTheDocument();
+  });
 });
 
 describe("Dashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedFetchNodeCollection.mockReset();
+    mockedFetchNodeCollection.mockResolvedValue(nodeCollection([]));
+    mockedFetchFindings.mockReset();
+    mockedFetchFindings.mockResolvedValue({
+      findings: [],
+      scope: {
+        mode: "published",
+        scanId: "scan-1",
+        revision: 1,
+        publishedAt: "2026-07-11T00:00:00Z",
+        projectionStatus: "complete",
+        snapshotStatus: "complete",
+        available: true,
+        stale: false,
+      },
+    });
   });
 
   it("renders an error state when graph stats fail", () => {

--- a/server/ui/src/entities/node/model.test.ts
+++ b/server/ui/src/entities/node/model.test.ts
@@ -25,8 +25,9 @@ describe("node evidence accessors", () => {
       auth_method: "none",
       auth_evidence: "local_process",
     });
-    const anonymous = node({
+    const unprovenRawAnonymous = node({
       auth_method: "none",
+      auth_assurance: "unauthenticated",
       auth_evidence: "anonymous_probe_succeeded",
     });
     expect(authMethod(unknown)).toBe("unknown");
@@ -36,8 +37,90 @@ describe("node evidence accessors", () => {
     expect(authMethod(local)).toBe("localProcess");
     expect(authMethod(configuredLocal)).toBe("localProcess");
     expect(hasConfirmedAnonymousAccess(configuredLocal.properties)).toBe(false);
-    expect(authMethod(anonymous)).toBe("none");
-    expect(isUnauth(anonymous)).toBe(true);
+    expect(authMethod(unprovenRawAnonymous)).toBe("unknown");
+    expect(isUnauth(unprovenRawAnonymous)).toBe(false);
+  });
+
+  it("selects one effective auth tuple with observed runtime precedence", () => {
+    const observedAnonymous = node({
+      auth_method: "unknown",
+      auth_assurance: "unknown",
+      auth_evidence: "unknown",
+      transport: "http",
+      status: "reachable",
+      observed_auth_method: "none",
+      observed_auth_assurance: "unauthenticated",
+      observed_auth_evidence: "anonymous_probe_succeeded",
+    });
+    const configuredFallback = node({
+      auth_method: "bearer",
+      auth_assurance: "moderate",
+      auth_evidence: "configured_credential",
+      observed_auth_method: "unknown",
+      observed_auth_assurance: "unknown",
+      observed_auth_evidence: "unknown",
+    });
+    const observedBearer = node({
+      auth_method: "none",
+      auth_assurance: "unauthenticated",
+      auth_evidence: "anonymous_probe_succeeded",
+      observed_auth_method: "bearer",
+      observed_auth_assurance: "moderate",
+      observed_auth_evidence: "configured_credential",
+    });
+    const materialized = node({
+      auth_method: "unknown",
+      auth_evidence: "unknown",
+      effective_auth_method: "none",
+      effective_auth_assurance: "unauthenticated",
+      effective_auth_evidence: "anonymous_probe_succeeded",
+      effective_auth_source: "observed",
+    });
+    const configuredAnonymousClaim = node({
+      auth_method: "none",
+      auth_assurance: "unauthenticated",
+      auth_evidence: "anonymous_probe_succeeded",
+      effective_auth_method: "none",
+      effective_auth_assurance: "unauthenticated",
+      effective_auth_evidence: "anonymous_probe_succeeded",
+      effective_auth_source: "configured",
+    });
+    const observedA2AAnonymous = node(
+      {
+        auth_probe_method: "get_task_nonexistent",
+        auth_probe_status: "anonymous_protocol_access",
+        auth_probe_detail: "task_not_found_v0_3",
+        observed_auth_method: "none",
+        observed_auth_assurance: "unauthenticated",
+        observed_auth_evidence: "anonymous_probe_succeeded",
+      },
+      ["A2AAgent"],
+    );
+    const a2aMissingDetail = node(
+      {
+        auth_probe_method: "get_task_nonexistent",
+        auth_probe_status: "anonymous_protocol_access",
+        observed_auth_method: "none",
+        observed_auth_assurance: "unauthenticated",
+        observed_auth_evidence: "anonymous_probe_succeeded",
+      },
+      ["A2AAgent"],
+    );
+
+    expect(authMethod(observedAnonymous)).toBe("none");
+    expect(isUnauth(observedAnonymous)).toBe(true);
+    expect(authMethod(configuredFallback)).toBe("bearer");
+    expect(isUnauth(configuredFallback)).toBe(false);
+    expect(authMethod(observedBearer)).toBe("bearer");
+    expect(isUnauth(observedBearer)).toBe(false);
+    expect(authMethod(materialized)).toBe("none");
+    expect(isUnauth(materialized)).toBe(true);
+    expect(authMethod(configuredAnonymousClaim)).toBe("unknown");
+    expect(isUnauth(configuredAnonymousClaim)).toBe(false);
+    expect(authMethod(observedA2AAnonymous)).toBe("none");
+    expect(isUnauth(observedA2AAnonymous)).toBe(true);
+    expect(authMethod(a2aMissingDetail)).toBe("unknown");
+    expect(isUnauth(a2aMissingDetail)).toBe(false);
   });
 
   it("does not turn a missing risk assessment into zero", () => {

--- a/server/ui/src/entities/node/model.ts
+++ b/server/ui/src/entities/node/model.ts
@@ -47,10 +47,7 @@ export type AuthMethod =
 
 type DeclaredAuthMethod = Exclude<AuthMethod, "localProcess">;
 
-function declaredAuthMethod(
-  properties: Record<string, unknown>,
-): DeclaredAuthMethod {
-  const method = properties.auth_method;
+function declaredAuthMethod(method: unknown): DeclaredAuthMethod {
   switch (method) {
     case "none":
       return "none";
@@ -75,13 +72,96 @@ function declaredAuthMethod(
   }
 }
 
+export interface EffectiveAuthTuple {
+  method: DeclaredAuthMethod;
+  evidence: string;
+  assurance: string;
+  source: "observed" | "configured";
+}
+
+/**
+ * Selects one paired authentication assessment without mixing method,
+ * evidence, or assurance from different collectors.
+ *
+ * New projections materialize `effective_auth_*` server-side. The observed
+ * fallback keeps the UI truthful when viewing an older projection that still
+ * carries the raw dual-lane MCP evidence, while unknown observed methods defer
+ * to the configured tuple.
+ */
+export function effectiveAuthTupleFromProperties(
+  properties: Record<string, unknown>,
+): EffectiveAuthTuple {
+  const effectiveSource = properties.effective_auth_source;
+  if (
+    typeof properties.effective_auth_method === "string" &&
+    typeof properties.effective_auth_assurance === "string" &&
+    typeof properties.effective_auth_evidence === "string" &&
+    (effectiveSource === "observed" || effectiveSource === "configured")
+  ) {
+    return {
+      method: declaredAuthMethod(properties.effective_auth_method),
+      evidence: properties.effective_auth_evidence,
+      assurance: properties.effective_auth_assurance,
+      source: effectiveSource,
+    };
+  }
+
+  const observedMethod = declaredAuthMethod(properties.observed_auth_method);
+  const observedEvidence = properties.observed_auth_evidence;
+  const observedAssurance = properties.observed_auth_assurance;
+  const exactMCPAnonymousObservation =
+    properties.transport === "http" &&
+    properties.status === "reachable" &&
+    observedMethod === "none" &&
+    observedAssurance === "unauthenticated" &&
+    observedEvidence === "anonymous_probe_succeeded";
+  const exactA2AAnonymousObservation =
+    properties.auth_probe_method === "get_task_nonexistent" &&
+    properties.auth_probe_status === "anonymous_protocol_access" &&
+    (properties.auth_probe_detail === "task_not_found_v1" ||
+      properties.auth_probe_detail === "task_not_found_v0_3") &&
+    observedMethod === "none" &&
+    observedAssurance === "unauthenticated" &&
+    observedEvidence === "anonymous_probe_succeeded";
+  const exactAuthenticatedObservation =
+    observedEvidence === "configured_credential" &&
+    ((["basic", "apiKey"].includes(observedMethod) &&
+      observedAssurance === "weak") ||
+      (observedMethod === "bearer" && observedAssurance === "moderate") ||
+      (["oauth", "oidc", "mtls"].includes(observedMethod) &&
+        observedAssurance === "strong") ||
+      (observedMethod === "custom" && observedAssurance === "unknown"));
+  const observedIsUsable =
+    exactMCPAnonymousObservation ||
+    exactA2AAnonymousObservation ||
+    exactAuthenticatedObservation;
+  if (observedIsUsable) {
+    return {
+      method: observedMethod,
+      evidence: String(observedEvidence),
+      assurance: String(observedAssurance),
+      source: "observed",
+    };
+  }
+
+  return {
+    method: declaredAuthMethod(properties.auth_method),
+    evidence: String(properties.auth_evidence ?? "unknown"),
+    assurance: String(properties.auth_assurance ?? "unknown"),
+    source: "configured",
+  };
+}
+
 /** True only when an anonymous network request succeeded. */
 export function hasConfirmedAnonymousAccess(
   properties: Record<string, unknown>,
 ): boolean {
+  const auth = effectiveAuthTupleFromProperties(properties);
   return (
-    declaredAuthMethod(properties) === "none" &&
-    properties.auth_evidence === "anonymous_probe_succeeded"
+    auth.source === "observed" &&
+    auth.method === "none" &&
+    auth.assurance === "unauthenticated" &&
+    auth.evidence === "anonymous_probe_succeeded"
   );
 }
 
@@ -94,8 +174,9 @@ export function hasConfirmedAnonymousAccess(
 export function authMethodFromProperties(
   properties: Record<string, unknown>,
 ): AuthMethod {
-  if (properties.auth_evidence === "local_process") return "localProcess";
-  const method = declaredAuthMethod(properties);
+  const auth = effectiveAuthTupleFromProperties(properties);
+  if (auth.evidence === "local_process") return "localProcess";
+  const method = auth.method;
   if (method === "none" && !hasConfirmedAnonymousAccess(properties)) {
     return "unknown";
   }

--- a/server/ui/src/entities/security/remediation.test.ts
+++ b/server/ui/src/entities/security/remediation.test.ts
@@ -53,17 +53,38 @@ describe("deriveRemediations evidence states", () => {
       true,
     );
 
-    const observed = deriveRemediations(
+    const unprovenRawClaim = deriveRemediations(
       node("MCPServer", {
         auth_method: "none",
+        auth_assurance: "unauthenticated",
         auth_evidence: "anonymous_probe_succeeded",
       }),
       "MCPServer",
       [],
     );
-    expect(observed.some((item) => item.title === "Add an authentication method")).toBe(
-      true,
+    expect(unprovenRawClaim.some((item) => item.title === "Add an authentication method")).toBe(
+      false,
     );
+
+    const observedRuntime = deriveRemediations(
+      node("MCPServer", {
+        auth_method: "unknown",
+        auth_evidence: "unknown",
+        transport: "http",
+        status: "reachable",
+        observed_auth_method: "none",
+        observed_auth_assurance: "unauthenticated",
+        observed_auth_evidence: "anonymous_probe_succeeded",
+      }),
+      "MCPServer",
+      [],
+    );
+    expect(
+      observedRuntime.some((item) => item.title === "Add an authentication method"),
+    ).toBe(true);
+    expect(
+      observedRuntime.some((item) => item.title === "Verify authentication posture"),
+    ).toBe(false);
   });
 
   it("requires explicit exposure evidence and retains the recorded source", () => {

--- a/server/ui/src/entities/security/remediation.ts
+++ b/server/ui/src/entities/security/remediation.ts
@@ -1,4 +1,8 @@
 import type { APIEdge, APINode } from "@entities/graph/dto";
+import {
+  authMethodFromProperties,
+  hasConfirmedAnonymousAccess,
+} from "@entities/node/model";
 
 export interface RemediationItem {
   severity: "critical" | "high" | "medium" | "low";
@@ -41,9 +45,8 @@ export function deriveRemediations(
 
   // No auth
   const isAuthEntity = kind === "MCPServer" || kind === "A2AAgent";
-  const explicitAnonymous =
-    props.auth_method === "none" &&
-    props.auth_evidence === "anonymous_probe_succeeded";
+  const explicitAnonymous = hasConfirmedAnonymousAccess(props);
+  const effectiveMethod = authMethodFromProperties(props);
   if (isAuthEntity && explicitAnonymous) {
     items.push({
       severity: "high",
@@ -53,9 +56,8 @@ export function deriveRemediations(
   }
   if (
     isAuthEntity &&
-    (props.auth_method == null ||
-      props.auth_method === "unknown" ||
-      (props.auth_method === "none" && !explicitAnonymous))
+    (effectiveMethod === "unknown" ||
+      (effectiveMethod === "none" && !explicitAnonymous))
   ) {
     items.push({
       severity: "low",

--- a/server/ui/src/features/dashboard/ui/AuthEvidence.test.tsx
+++ b/server/ui/src/features/dashboard/ui/AuthEvidence.test.tsx
@@ -47,7 +47,12 @@ describe("dashboard authentication evidence", () => {
       data: [
         node("anonymous", {
           auth_method: "none",
+          auth_assurance: "unauthenticated",
           auth_evidence: "anonymous_probe_succeeded",
+          effective_auth_method: "none",
+          effective_auth_assurance: "unauthenticated",
+          effective_auth_evidence: "anonymous_probe_succeeded",
+          effective_auth_source: "observed",
         }),
         node("stdio-local", {
           auth_method: "none",
@@ -57,13 +62,22 @@ describe("dashboard authentication evidence", () => {
           auth_method: "none",
           auth_evidence: "unknown",
         }),
+        node("observed-anonymous", {
+          auth_method: "unknown",
+          auth_evidence: "unknown",
+          transport: "http",
+          status: "reachable",
+          observed_auth_method: "none",
+          observed_auth_assurance: "unauthenticated",
+          observed_auth_evidence: "anonymous_probe_succeeded",
+        }),
       ],
       isLoading: false,
     } as ReturnType<typeof useNodes>);
 
     render(<AuthCoverage />);
 
-    expect(within(screen.getByText("None").closest("li")!).getByText("1"))
+    expect(within(screen.getByText("None").closest("li")!).getByText("2"))
       .toBeInTheDocument();
     expect(
       within(screen.getByText("Local Process").closest("li")!).getByText("1"),
@@ -81,21 +95,27 @@ describe("dashboard authentication evidence", () => {
             agent_count: 4,
             tool_count: 2,
             auth_method: "none",
+            auth_assurance: "unauthenticated",
             auth_evidence: "anonymous_probe_succeeded",
+            auth_source: "observed",
           },
           {
             server_name: "stdio-local",
             agent_count: 3,
             tool_count: 1,
             auth_method: "none",
+            auth_assurance: "unknown",
             auth_evidence: "local_process",
+            auth_source: "configured",
           },
           {
             server_name: "unverified-none",
             agent_count: 2,
             tool_count: 1,
             auth_method: "none",
+            auth_assurance: "unknown",
             auth_evidence: "unknown",
+            auth_source: "configured",
           },
         ],
       },

--- a/server/ui/src/features/dashboard/ui/Chokepoints.tsx
+++ b/server/ui/src/features/dashboard/ui/Chokepoints.tsx
@@ -24,7 +24,12 @@ function parse(rows: Record<string, unknown>[]): ServerRow[] {
       name: String(r["server_name"] ?? "unknown"),
       agentCount: Number(r["agent_count"] ?? 0),
       toolCount: Number(r["tool_count"] ?? 0),
-      unauth: hasConfirmedAnonymousAccess(r),
+      unauth: hasConfirmedAnonymousAccess({
+        effective_auth_method: r["auth_method"],
+        effective_auth_assurance: r["auth_assurance"],
+        effective_auth_evidence: r["auth_evidence"],
+        effective_auth_source: r["auth_source"],
+      }),
     }))
     .sort((a, b) => b.agentCount - a.agentCount)
     .slice(0, MAX_ROWS);

--- a/server/ui/src/features/explorer/lib/export-markdown.test.ts
+++ b/server/ui/src/features/explorer/lib/export-markdown.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { APINode } from "@entities/graph/dto";
+import { formatNodeAsMarkdown } from "./export-markdown";
+
+describe("formatNodeAsMarkdown authentication evidence", () => {
+  it("leads with the effective tuple while retaining both raw provenance lanes", () => {
+    const node: APINode = {
+      id: "sha256:server",
+      kinds: ["MCPServer"],
+      properties: {
+        name: "anonymous-runtime-server",
+        auth_method: "unknown",
+        auth_assurance: "unknown",
+        auth_evidence: "unknown",
+        observed_auth_method: "none",
+        observed_auth_assurance: "unauthenticated",
+        observed_auth_evidence: "anonymous_probe_succeeded",
+        effective_auth_method: "none",
+        effective_auth_assurance: "unauthenticated",
+        effective_auth_evidence: "anonymous_probe_succeeded",
+        effective_auth_source: "observed",
+      },
+    };
+
+    const markdown = formatNodeAsMarkdown(node, "MCP Server", false, false);
+    const effective = markdown.indexOf("`effective_auth_method`: none");
+    const configured = markdown.indexOf("`auth_method`: unknown");
+    const observed = markdown.indexOf("`observed_auth_method`: none");
+
+    expect(effective).toBeGreaterThan(-1);
+    expect(configured).toBeGreaterThan(effective);
+    expect(observed).toBeGreaterThan(configured);
+    expect(markdown).toContain(
+      "`effective_auth_evidence`: anonymous_probe_succeeded",
+    );
+    expect(markdown).toContain("`effective_auth_source`: observed");
+  });
+});

--- a/server/ui/src/features/explorer/lib/export-markdown.ts
+++ b/server/ui/src/features/explorer/lib/export-markdown.ts
@@ -18,9 +18,16 @@ const MD_PRIORITY_KEYS = [
   "hostname",
   "transport",
   "protocol_version",
+  "effective_auth_method",
+  "effective_auth_assurance",
+  "effective_auth_evidence",
+  "effective_auth_source",
   "auth_method",
   "auth_assurance",
   "auth_evidence",
+  "observed_auth_method",
+  "observed_auth_assurance",
+  "observed_auth_evidence",
   "is_pinned",
   "scope",
   "exposure_status",
@@ -47,7 +54,8 @@ const MD_PRIORITY_KEYS = [
 /**
  * Format a node as a clean Markdown dump suitable for pasting into a
  * Jira ticket, GitHub issue, or incident report. Priority properties
- * (name, endpoint, auth_method, risk_score, etc.) are listed first in
+ * (name, endpoint, effective auth, configured/observed auth, risk_score, etc.)
+ * are listed first in
  * a stable order; everything else follows alphabetically. Noise fields
  * (hashes, timestamps, scan_id) are skipped.
  */

--- a/server/ui/src/features/explorer/ui/drawer/EvidenceTab.test.tsx
+++ b/server/ui/src/features/explorer/ui/drawer/EvidenceTab.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { APINode } from "@entities/graph/dto";
+import { EvidenceTab } from "./EvidenceTab";
+
+function server(properties: Record<string, unknown>): APINode {
+  return { id: "server-1", kinds: ["MCPServer"], properties };
+}
+
+function agent(properties: Record<string, unknown>): APINode {
+  return { id: "agent-1", kinds: ["A2AAgent"], properties };
+}
+
+describe("EvidenceTab MCP runtime evidence", () => {
+  it("represents a successful MCP enumeration as direct verification", () => {
+    render(
+      <EvidenceTab
+        node={server({
+          status: "reachable",
+          auth_method: "unknown",
+          auth_assurance: "unknown",
+          auth_evidence: "unknown",
+          observed_auth_method: "none",
+          observed_auth_assurance: "unauthenticated",
+          observed_auth_evidence: "anonymous_probe_succeeded",
+          effective_auth_method: "none",
+          effective_auth_assurance: "unauthenticated",
+          effective_auth_evidence: "anonymous_probe_succeeded",
+          effective_auth_source: "observed",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Directly verified")).toBeInTheDocument();
+    expect(screen.queryByText("Verification status unknown")).not.toBeInTheDocument();
+    expect(screen.getByText("observed auth method")).toBeInTheDocument();
+    expect(screen.getByText("observed auth evidence")).toBeInTheDocument();
+    expect(screen.getAllByText("anonymous_probe_succeeded")).toHaveLength(2);
+  });
+
+  it("represents an unsuccessful MCP connection as failed verification", () => {
+    render(
+      <EvidenceTab
+        node={server({
+          status: "unreachable",
+          error: "MCP operation failed; raw transport details omitted from artifact",
+          observed_auth_method: "unknown",
+          observed_auth_assurance: "unknown",
+          observed_auth_evidence: "unknown",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Verification failed")).toBeInTheDocument();
+    expect(screen.queryByText("Verification status unknown")).not.toBeInTheDocument();
+  });
+
+  it("does not let passive configuration evidence hide a failed probe", () => {
+    render(
+      <EvidenceTab
+        node={server({
+          status: "unreachable",
+          configuration_observed: true,
+          probe_status: "configured_unverified",
+          error: "MCP operation failed; raw transport details omitted from artifact",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Verification failed")).toBeInTheDocument();
+    expect(screen.queryByText("Configured, not verified")).not.toBeInTheDocument();
+  });
+});
+
+describe("EvidenceTab A2A authentication probe evidence", () => {
+  it("represents the exact anonymous read-only probe without claiming skill execution", () => {
+    render(
+      <EvidenceTab
+        node={agent({
+          auth_probe_method: "get_task_nonexistent",
+          auth_probe_status: "anonymous_protocol_access",
+          auth_probe_detail: "task_not_found_v1",
+          observed_auth_method: "none",
+          observed_auth_assurance: "unauthenticated",
+          observed_auth_evidence: "anonymous_probe_succeeded",
+          signature_verification_status: "valid_trusted",
+          signature_key_source: "trusted_store",
+          signature_key_trust: "trusted",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Directly verified")).toBeInTheDocument();
+    expect(
+      screen.getByText(/verifies anonymous protocol-handler access, not message submission or skill execution/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("auth probe method")).toBeInTheDocument();
+    expect(screen.getByText("auth probe status")).toBeInTheDocument();
+    expect(screen.getByText("signature verification status")).toBeInTheDocument();
+    expect(screen.queryByText("Verification status unknown")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes an observed authentication boundary from a failed service", () => {
+    render(
+      <EvidenceTab
+        node={agent({
+          auth_probe_method: "get_task_nonexistent",
+          auth_probe_status: "authentication_required",
+          auth_probe_detail: "http_unauthorized",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Authentication required")).toBeInTheDocument();
+    expect(screen.getByText(/rejected the credential-free read-only probe/i)).toBeInTheDocument();
+    expect(screen.queryByText("Verification failed")).not.toBeInTheDocument();
+  });
+
+  it("keeps an inconclusive protocol result explicitly unknown", () => {
+    render(
+      <EvidenceTab
+        node={agent({
+          auth_probe_method: "get_task_nonexistent",
+          auth_probe_status: "unknown",
+          auth_probe_detail: "method_not_supported",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Verification status unknown")).toBeInTheDocument();
+    expect(screen.queryByText("Directly verified")).not.toBeInTheDocument();
+    expect(screen.getByText("method_not_supported")).toBeInTheDocument();
+  });
+
+  it("does not trust an orphan anonymous status without the paired observation", () => {
+    render(
+      <EvidenceTab
+        node={agent({
+          auth_probe_method: "get_task_nonexistent",
+          auth_probe_status: "anonymous_protocol_access",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Verification status unknown")).toBeInTheDocument();
+    expect(screen.queryByText("Directly verified")).not.toBeInTheDocument();
+  });
+
+  it("does not trust otherwise complete A2A evidence without a canonical detail", () => {
+    render(
+      <EvidenceTab
+        node={agent({
+          auth_probe_method: "get_task_nonexistent",
+          auth_probe_status: "anonymous_protocol_access",
+          auth_probe_detail: "generic_not_found",
+          observed_auth_method: "none",
+          observed_auth_assurance: "unauthenticated",
+          observed_auth_evidence: "anonymous_probe_succeeded",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Verification status unknown")).toBeInTheDocument();
+    expect(screen.queryByText("Directly verified")).not.toBeInTheDocument();
+  });
+
+  it("does not label a noncanonical protected detail as an observed boundary", () => {
+    render(
+      <EvidenceTab
+        node={agent({
+          auth_probe_method: "get_task_nonexistent",
+          auth_probe_status: "authentication_required",
+          auth_probe_detail: "http_401",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Verification status unknown")).toBeInTheDocument();
+    expect(screen.queryByText("Authentication required")).not.toBeInTheDocument();
+  });
+});

--- a/server/ui/src/features/explorer/ui/drawer/EvidenceTab.tsx
+++ b/server/ui/src/features/explorer/ui/drawer/EvidenceTab.tsx
@@ -14,10 +14,29 @@ const EVIDENCE_KEYS = [
   "annotations",
   "security_schemes",
   "signatures",
+  "status",
   "probe_status",
+  "auth_probe_method",
+  "auth_probe_status",
+  "auth_probe_detail",
+  "collection_state",
+  "error",
   "configuration_observed",
   "configured_via",
   "configured_auth_method",
+  "auth_method",
+  "auth_assurance",
+  "auth_evidence",
+  "observed_auth_method",
+  "observed_auth_assurance",
+  "observed_auth_evidence",
+  "effective_auth_method",
+  "effective_auth_assurance",
+  "effective_auth_evidence",
+  "effective_auth_source",
+  "signature_verification_status",
+  "signature_key_source",
+  "signature_key_trust",
   "assertion_type",
   "confidence_scope",
 ];
@@ -37,23 +56,47 @@ export function EvidenceTab({ node }: { node: APINode }) {
   const lastSeen = String(props.last_seen ?? "");
   const createdAt = String(props.created_at ?? "");
   const objectId = node.id;
+  const exactAnonymousA2AProbe =
+    props.auth_probe_method === "get_task_nonexistent" &&
+    props.auth_probe_status === "anonymous_protocol_access" &&
+    (props.auth_probe_detail === "task_not_found_v1" ||
+      props.auth_probe_detail === "task_not_found_v0_3") &&
+    props.observed_auth_method === "none" &&
+    props.observed_auth_assurance === "unauthenticated" &&
+    props.observed_auth_evidence === "anonymous_probe_succeeded";
+  const exactProtectedA2AProbe =
+    props.auth_probe_method === "get_task_nonexistent" &&
+    props.auth_probe_status === "authentication_required" &&
+    (props.auth_probe_detail === "http_unauthorized" ||
+      props.auth_probe_detail === "http_forbidden") &&
+    props.observed_auth_method == null &&
+    props.observed_auth_assurance == null &&
+    props.observed_auth_evidence == null;
   const observation =
-    props.probe_status === "verified"
+    exactAnonymousA2AProbe
       ? {
           title: "Directly verified",
           detail:
-            "A direct probe verified this entity at collection time.",
+            "A bounded read-only request reached the A2A protocol handler without credentials and returned the exact nonexistent-task result. This verifies anonymous protocol-handler access, not message submission or skill execution.",
           className: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
         }
-      : props.configuration_observed === true ||
-          props.probe_status === "configured_unverified"
+      : exactProtectedA2AProbe
         ? {
-            title: "Configured, not verified",
+            title: "Authentication required",
             detail:
-              "AgentHound observed a configuration reference. Service availability and authentication were not directly verified.",
-            className: "border-amber-400/30 bg-amber-400/10 text-amber-200",
+              "The A2A protocol handler rejected the credential-free read-only probe with HTTP 401 or 403. Public Agent Card access does not imply anonymous operational access.",
+            className: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
           }
-        : props.probe_status === "failed"
+        : props.probe_status === "verified" || props.status === "reachable"
+      ? {
+          title: "Directly verified",
+          detail:
+            props.status === "reachable"
+              ? "A successful protocol interaction reached and enumerated this entity at collection time. Authentication evidence below describes the access path that succeeded."
+              : "A direct probe verified this entity at collection time.",
+          className: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
+        }
+        : props.probe_status === "failed" || props.status === "unreachable"
           ? {
               title: "Verification failed",
               detail:
@@ -61,12 +104,20 @@ export function EvidenceTab({ node }: { node: APINode }) {
               className:
                 "border-destructive/30 bg-destructive/10 text-destructive",
             }
-          : {
-              title: "Verification status unknown",
-              detail:
-                "No direct verification status was recorded. Do not infer availability or absence from this node alone.",
-              className: "border-border bg-black/30 text-muted-foreground",
-            };
+          : props.configuration_observed === true ||
+              props.probe_status === "configured_unverified"
+            ? {
+                title: "Configured, not verified",
+                detail:
+                  "AgentHound observed a configuration reference. Service availability and authentication were not directly verified.",
+                className: "border-amber-400/30 bg-amber-400/10 text-amber-200",
+              }
+            : {
+                title: "Verification status unknown",
+                detail:
+                  "No conclusive direct verification status was recorded. Do not infer availability, authentication, or absence from this node alone.",
+                className: "border-border bg-black/30 text-muted-foreground",
+              };
 
   return (
     <div className="space-y-5">

--- a/server/ui/src/features/findings/lib/property-chips.test.ts
+++ b/server/ui/src/features/findings/lib/property-chips.test.ts
@@ -7,7 +7,12 @@ describe("authentication property chips", () => {
       getPropertyChips("MCPServer", {
         transport: "http",
         auth_method: "none",
+        auth_assurance: "unauthenticated",
         auth_evidence: "anonymous_probe_succeeded",
+        effective_auth_method: "none",
+        effective_auth_assurance: "unauthenticated",
+        effective_auth_evidence: "anonymous_probe_succeeded",
+        effective_auth_source: "observed",
       }),
     ).toContain("no-auth");
 
@@ -29,5 +34,20 @@ describe("authentication property chips", () => {
 
     expect(chips).toContain("local-process");
     expect(chips).not.toContain("no-auth");
+  });
+
+  it("renders observed anonymous access when configuration was unknown", () => {
+    const chips = getPropertyChips("MCPServer", {
+      transport: "http",
+      status: "reachable",
+      auth_method: "unknown",
+      auth_evidence: "unknown",
+      observed_auth_method: "none",
+      observed_auth_assurance: "unauthenticated",
+      observed_auth_evidence: "anonymous_probe_succeeded",
+    });
+
+    expect(chips).toContain("no-auth");
+    expect(chips).not.toContain("auth-unknown");
   });
 });


### PR DESCRIPTION
## Review position

This is **4 of 6** in the AgentHound v1.0 candidate review stack.

- Base: `main` at `988afc2` (Stack 3 merged via PR #98)
- Head: `codex/release-stack-04-auth-evidence` at `776d287`
- Main-relative scope: 71 files, 4,452 insertions, 352 deletions across 3 commits
- Dependency: Stacks 1–3 are merged

This PR must be reviewed as the delta from Stack 3. It relies on the collector identity/privacy contract from Stack 2 and the owner-scoped lifecycle/publication rules from Stack 3.

Audit issue IDs below refer to the independent release ledger, not GitHub issues.

## Problem and true-positive findings

### RC-02 — configured authentication was presented as observed runtime authentication

Confirmed baseline product defects addressed by this delta:

- **Audit issue 2:** Open WebUI public identity probes fabricated anonymous privileged access.
- **Audit issue 9:** Open WebUI looting could report Ollama discovery that conflicted with the endpoint actually fingerprinted.
- **Audit issue 15:** the Open WebUI public fingerprint could say anonymous while authenticated looting proved the opposite.
- **Audit issue 16:** fingerprinter and looter observations of the same endpoint could conflict in authentication and active-discovery provenance. Stack 3 already treats `last_verified_at` as volatile and selects the latest valid timestamp, so timestamp convergence is not claimed as a Stack 4 fix.
- **Audit issue 35:** post-processors and other consumers ignored observed authentication evidence and reasoned from configuration alone.
- **Audit issue 40:** A2A unauthenticated-access detection lacked a bounded runtime producer, so its evidence claim could not be established.
- **Audit issue 45:** looters affirmed anonymous access before inventory had actually succeeded.
- **Audit issue 46:** a whitespace-only LiteLLM `master_key` could be hashed and emitted as observed/exposed credential material even though it could not authenticate. Other affected producers already rejected blank material; the independent review found and this PR closes the remaining LiteLLM path.

Inherited prerequisite, not owned by this delta:

- **Audit issue 44:** opaque non-empty MCP headers must remain `unknown/configured_credential`, never anonymous. Stack 2 implemented and tested this behavior; it is present on this PR's base and is consumed, not re-fixed, here.

Candidate-integration/hardening corrections, not independent base defects:

- **Audit issue 43:** the base collector could fetch an Agent Card through a query-bearing discovery URL but had no operational auth probe. The new credential-free control probe therefore rejects query-bearing advertised interfaces so query bytes cannot be forwarded or reinterpreted as anonymous operational evidence.
- **Audit issue 41:** the base UI had no A2A runtime-probe evidence to display. Once this PR introduces the producer, the Evidence drawer must expose the exact method/status/detail tuple so the conclusion is reviewable.

### RC-10 — dependent user-visible verification symptom

- **Audit issue 36:** Explorer already rendered missing verification evidence as unknown, but affected looters could falsely emit `probe_status=verified`, causing the truthful renderer to show “Directly verified.” This PR fixes the producer evidence and preserves evidence-aware UI states; it does not claim the base UI unconditionally labeled unknown nodes as verified.

### RC-09 — resource reachability recognized only environment-style credentials

- **Audit issue 32, authentication-evidence portion:** credential-to-resource reachability did not consume observed header/API-key evidence. The value-hash correlation and risk portion is completed in Stack 5.

## Root cause

The model collapsed three different facts into one field: authentication configured by an operator, authentication actually exercised by the collector, and the effective conclusion downstream analysis should use. That let configuration masquerade as runtime proof and also let individual modules publish contradictory endpoint truth.

## Solution

- Introduce explicit configured, observed, and effective authentication tuples with provenance; retain Stack 3's existing volatile timestamp merge behavior.
- Reconcile evidence monotonically so a stronger successful observation cannot be overwritten by weaker or stale module output.
- Require successful inventory before a looter affirms anonymous access or publishes discovered resources.
- Bound A2A authentication probing to one safe `GetTask` request per candidate and record the exact probe result without executing agents or mutating task state.
- Never forward discovered query credentials during the credential-free control probe.
- Reject empty or whitespace-only credential material before graph construction or network activity, while preserving the exact bytes of every nonblank credential; keep transport credentials out of graph-visible evidence.
- Make Open WebUI fingerprinting and looting agree on endpoint identity, observed auth, and Ollama inventory provenance.
- Update access, reachability, poisoning, cross-protocol, and related consumers to use effective authentication rather than raw configuration.
- Carry the evidence into API/UI details so reviewers can distinguish configured claims from runtime observations.
- Preserve evidence-aware Explorer states and prevent false producer `probe_status=verified` values from manufacturing a “Directly verified” display.

## Security and product impact

- “Unauthenticated access” now means the collector successfully observed access without credentials; it is not inferred from an empty or unfamiliar configuration field.
- Configured credentials remain useful context but cannot alone manufacture a privileged attack path.
- A2A probes are read-only, bounded, and do not leak query credentials into the control request.
- Negative and inconclusive observations remain distinguishable from positive evidence.
- Downstream findings, reachability, and UI claims share the same effective-auth semantics instead of independently guessing.

## Validation

Parent-relative acceptance passed:

- mandatory gofmt/build/vet/full race suite
- focused package suites across 10 affected packages
- complete UI suite at this checkpoint: 50 files / 229 tests, plus lint and production build
- strict documentation build

The checked-in real-infrastructure A2A service is pinned to the official Python SDK `a2a-sdk[http-server]==1.1.0`. The current [A2A v1 specification](https://a2a-protocol.org/latest/specification/) defines `GetTask` as read-only task retrieval with `TaskNotFoundError`; the [v0.3 specification](https://a2a-protocol.org/v0.3.0/specification/) defines the corresponding JSON-RPC method as `tasks/get`.

PR-local A2A controls prove:

- exactly one bounded `GetTask` or `tasks/get` request per canonical endpoint
- no Authorization, Cookie, API-key, userinfo, or query credential is forwarded
- redirects, cross-origin interfaces, query-bearing interfaces, timeouts, wrong IDs, wrong error shapes, and non-JSON responses remain inconclusive
- only the exact version-appropriate task-not-found response becomes positive anonymous evidence
- the stored observation accurately distinguishes success, authentication-required, transport failure, and inconclusive response

A retained release-validation variant additionally instrumented SDK-side executor/store counters, but that instrumentation is not checked into this PR; it is supporting audit evidence rather than a PR-local reproducible claim.

Real-service looter controls proved successful authenticated and genuinely anonymous inventory paths, plus decoy/denied negatives. They also verified that looters do not publish access or inventory before proof and do not emit empty credentials.

Neo4j 4.4 and 5.26 analysis runs agreed on effective-auth consumers and derived topology. Browser verification confirmed the Evidence drawer exposes A2A probe evidence and Explorer no longer claims unknown servers are verified.

The final Stack 6 candidate later passed the clean 24/24 real-infrastructure harness and all `make prerelease` gates.

### Independent review follow-up

Independent review reproduced one remaining issue-46 path before the fix: whitespace-only LiteLLM input returned success, emitted one observed/exposed master Credential, and recorded two partial HTTP failures because Go rejected the Authorization header. Commit `2df541c` now rejects that input before allocating a result or contacting the target. The regression asserts an error, a nil result, and zero server requests.

Post-fix validation passed:

- `gofmt -l .`, `go build ./...`, `go vet ./...`, and full `go test ./... -race`
- LiteLLM focused and full module race suites
- UI: 50 files / 229 tests, lint, and production build
- strict MkDocs
- the restacked final candidate's complete 13-gate `make prerelease`, including dependency/size boundaries, vulnerability/license checks, and cross-compilation

### Final stacked preflight corrections

The first forced live-database run of this exact intermediate slice exposed two stale test contracts caused by the behavior introduced here. Neither was a production-code regression.

- The Moat detector fixture labeled a configured `none` tuple as runtime-observed anonymous access without the bounded A2A probe required by this PR. It now models a declared API-key agent plus the exact successful `get_task_nonexistent` probe and observed anonymous tuple.
- The campaign integration expected the pre-PR evidence order `server -> credential -> identity`; this PR deliberately changes the supported chain to the real directed topology `server -> identity -> credential`. The expected witness was corrected here, where that behavior changes, instead of relying on the same one-line correction from Stack 5.

Commit `776d287` contains only those fixture/assertion corrections. Exact head `776d287` then passed the complete CI-equivalent sequence against Neo4j 4.4 and 5.26 with PostgreSQL 16, plus UI lint, 50 test files/229 tests, design-system checks, and production build. No production behavior was weakened to satisfy a test.

## Reviewer guide

Please focus on:

1. The configured → observed → effective decision table and precedence rules.
2. Whether every positive anonymous/authenticated claim has a successful runtime producer.
3. A2A probe safety: one read-only call, no executor or persistence side effects, no credential forwarding.
4. Cross-module reconciliation of endpoint identity and authentication/discovery provenance; timestamp merging is inherited from Stack 3.
5. Consumer completeness: derived edges and findings must use effective auth consistently.
6. Negative/inconclusive evidence behavior; absence of proof must not become proof of anonymous access.
7. API/UI wording and evidence visibility.

Credential value-hash correlation, global blast radius, and final risk semantics are deliberately isolated in Stack 5.

## Independent audit material

- [Root-cause index](https://github.com/adithyan-ak/AgentHound/blob/codex/validation-snapshot-20260719/validation/2026-07-19/root-cause-index.md)
- [Independent verdicts](https://github.com/adithyan-ak/AgentHound/blob/codex/validation-snapshot-20260719/validation/2026-07-19/root-cause-verdicts.md)
- [Stack 4 evidence and acceptance matrix](https://github.com/adithyan-ak/AgentHound/blob/codex/validation-snapshot-20260719/validation/2026-07-19/pr-slice-plan.md)
- [PR 99 independent-review adjudication](https://github.com/adithyan-ak/AgentHound/blob/codex/validation-snapshot-20260719/validation/2026-07-19/pr99-independent-review-followup.md)

The validation snapshot is audit evidence only and is intentionally outside the product merge chain.

## Stack map

1. [Realm-bound ingest v3 and release provenance](https://github.com/adithyan-ak/AgentHound/pull/96)
2. [Collector protocol truth and transport-secret closure](https://github.com/adithyan-ak/AgentHound/pull/97)
3. [Owner-scoped graph lifecycle and truthful CLI outcomes](https://github.com/adithyan-ak/AgentHound/pull/98)
4. [**This PR:** authentication evidence and effective-auth consumers](https://github.com/adithyan-ak/AgentHound/pull/99)
5. [Credential topology, correlation, blast radius, and risk](https://github.com/adithyan-ak/AgentHound/pull/100)
6. [Responsive UI, documentation truth, and real-infra oracles](https://github.com/adithyan-ak/AgentHound/pull/101)
