### PR TITLE
[Stack 5/6] Correlate credential evidence at value-hash grain

### DIFF
--- a/docs/architecture/post-processors.md
+++ b/docs/architecture/post-processors.md
@@ -244,19 +244,44 @@ credential material or references)
 Joins Config Collector and LiteLLM Looter emissions on `Credential.value_hash`:
 
 ```
-AgentInstance -> MCPServer -[HAS_ENV_VAR]-> Credential(c1)
+AgentInstance -> MCPServer -[AUTHENTICATES_WITH]-> Identity
+    -[USES_CREDENTIAL]-> Credential(c1)
     where c1.value_hash matches...
 LiteLLMGateway -[EXPOSES_CREDENTIAL]-> Credential(c1master)
 LiteLLMGateway -[EXPOSES_CREDENTIAL]-> Credential(c2, type IN [apiKey, virtual_key])
 ```
 
+Both `c1` and `c1master` must have a non-empty hash and explicit
+`merge_key=value_hash`, `identity_basis=value_hash`, `material_status=observed`,
+and `exposure_status=exposed`. Optional `HAS_ENV_VAR` location evidence is not
+part of the correlation path.
+
+Evidence nodes are ordered `(agent, server, identity, c1, c1master, gateway,
+c2)`. Raw relationship evidence is ordered `(TRUSTS_SERVER,
+AUTHENTICATES_WITH, USES_CREDENTIAL, EXPOSES_CREDENTIAL(master),
+EXPOSES_CREDENTIAL(upstream))`; the `c1`/`c1master` value-hash correlation is
+recorded separately as synthetic evidence.
+
 Emits: `(AgentInstance)-[:CAN_REACH]->(c2)` with evidence including
 `merge_value_hash`, `via_gateway`, `upstream_provider`. The resulting finding
 variant is `credential_chain_observed_material` only when c2 explicitly carries
 observed, exposed, non-identity material; masked/hashed targets are
-`credential_chain_reference`. Confidence: 0.95, hops metadata: 5.
+`credential_chain_reference`. Confidence: 0.95, hops metadata: 6.
+`via_gateway` uses the gateway name when present, then its endpoint, and finally
+its immutable object ID. The final fallback is required because a standalone
+LiteLLM loot collection references the gateway without claiming fingerprint-owned
+display properties.
 
-The same single query also computes **credential blast radius**: `count(DISTINCT agent)` reaching the merged secret, written as `blast_radius` on both `c1` (the env-var credential) and `c1master` (its value_hash twin). The agents are collected for the count and re-UNWOUND so the CAN_REACH MERGE stays one edge per (agent, upstream-credential). `blast_radius` then amplifies the server credential-handling risk term (see risk-scoring.md).
+The same single query also computes **credential blast radius** at the canonical
+`value_hash` grain: `count(DISTINCT agent)` across every configured credential
+node representing that secret. The global count is written to every matching
+`c1` and `c1master`; two config nodes with the same secret therefore cannot
+race to leave a smaller per-node count on the shared master. Candidate paths
+are then ordered by their stable seven-node object-ID tuple and reduced to one
+winner per `(agent, upstream credential)` before `MERGE`, so repeated runs and
+multiple config paths cannot overwrite evidence nondeterministically.
+`blast_radius` then amplifies the server credential-handling risk term (see
+risk-scoring.md).
 
 The `value_hash` is the cross-collector merge primitive -- same secret value regardless of how each collector derives its objectid.
 

--- a/docs/operator/attack-paths.md
+++ b/docs/operator/attack-paths.md
@@ -57,7 +57,8 @@ Example: a local MCP config exposes a LiteLLM master key, and the LiteLLM looter
 
 ```text
 (:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)
-  -[:HAS_ENV_VAR]->(:Credential {value_hash: H1})
+  -[:AUTHENTICATES_WITH]->(:Identity)
+  -[:USES_CREDENTIAL]->(:Credential {value_hash: H1})
 
 (:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(:Credential {value_hash: H1})
 (:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->(:Credential {type: "apiKey"})
@@ -71,9 +72,13 @@ The `cross_service_credential_chain` processor joins on `value_hash` and emits:
   via_gateway,
   merge_value_hash,
   upstream_provider,
-  hops: 5
+  hops: 6
 }]->(:Credential)
 ```
+
+`via_gateway` is always traceable: it uses the gateway name when available,
+then its endpoint, and otherwise the immutable gateway object ID emitted by the
+LiteLLM looter.
 
 It also writes `blast_radius` on the joined credential nodes: the number of
 distinct agents correlated with the merged secret. The upstream target remains

--- a/docs/operator/loot/litellm.md
+++ b/docs/operator/loot/litellm.md
@@ -93,10 +93,18 @@ The graph after a successful `agenthound loot --type litellm` run contains:
 If you previously ran the Config Collector against an MCP client config that referenced the master key by env var (e.g. `LITELLM_MASTER_KEY` in `claude_desktop_config.json`), the Config Collector emitted:
 
 ```
-(:MCPServer) -[HAS_ENV_VAR]-> (:Credential value_hash=H1)  // SAME hash as master Credential above
+(:MCPServer) -[AUTHENTICATES_WITH]-> (:Identity)
+  -[USES_CREDENTIAL]-> (:Credential value_hash=H1)  // SAME hash as master Credential above
 ```
 
-The `cross_service_credential_chain` post-processor joins on `value_hash`, walks `(:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)-[:HAS_ENV_VAR]->(c1)` and matches `c1.value_hash` to a master `:Credential` exposed by a `:LiteLLMGateway`, then emits `(:AgentInstance)-[:CAN_REACH]->(c2)` for every upstream provider Credential `c2` the gateway exposes.
+The same canonical identity topology is emitted when observed credential
+material came from a header, argument, or URL component; `HAS_ENV_VAR` is only
+extra location evidence for env-backed material. The
+`cross_service_credential_chain` post-processor joins on `value_hash`, walks
+`(:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)-[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(c1)`,
+and matches `c1.value_hash` to a master `:Credential` exposed by a
+`:LiteLLMGateway`, then emits `(:AgentInstance)-[:CAN_REACH]->(c2)` for every
+upstream provider Credential `c2` the gateway exposes.
 
 The pre-built `litellm-credential-leak` query reports the observed master-key
 exposure. It returns provider and virtual-key nodes only as explicit
@@ -121,7 +129,7 @@ findings remain separate analysis output.
 
 **Synthetic value_hash for unknown upstream values.** LiteLLM's `/model/info` strips upstream `api_key` server-side (`remove_sensitive_info_from_deployment` in `openai_endpoint_utils.py`), so the raw upstream provider key is never surfaced. The looter still emits a `:Credential` node for each upstream provider with `value_hash = HashCredentialValue(provider + ":" + model_name)` and marks it `merge_key: "identity"`. This makes the upstream Credential node identifiable across re-runs but excludes it from cross-collector value_hash joins — the `cross_service_credential_chain` post-processor filters `merge_key: "identity"` out of both sides of the join (`server/internal/analysis/processors/cross_service_credential_chain.go`) so a synthetic hash can never false-positive against a real credential. The chain join only fires for the master key (which the operator supplied and carries `merge_key: "value_hash"`).
 
-**Virtual-key value_hash is pre-hashed by LiteLLM.** LiteLLM's `/key/list` returns the token column verbatim, which is already `SHA-256(raw_key).hexdigest()` per `proxy/utils.py::hash_token()`. The looter assigns this string to `value_hash` DIRECTLY (no second hash). Any other collector that observes the raw `sk-...` value produces the same `SHA-256(raw)` and the two nodes merge on `value_hash` as intended. Pre-U-CRIT-1 the looter double-hashed (`SHA-256(SHA-256(raw))`) and the cross-collector merge silently failed.
+**Virtual-key value_hash is pre-hashed by LiteLLM.** LiteLLM's `/key/list` returns the token column verbatim, which is already `SHA-256(raw_key).hexdigest()` per `proxy/utils.py::hash_token()`. The looter assigns this string to `value_hash` DIRECTLY (no second hash). Any other collector that observes the raw `sk-...` value produces the same `SHA-256(raw)`, allowing the distinct collector-owned nodes to correlate on `value_hash`. Pre-U-CRIT-1 the looter double-hashed (`SHA-256(SHA-256(raw))`) and the cross-collector correlation silently failed.
 
 **`--include-credential-values=true` audit-mode.** The default loot is hash-only. With this flag, raw values land in the `value` property on every `:Credential` node. Use this for engagements where the deliverable explicitly includes the credentials themselves (e.g. internal red-team handoff to remediation). The cross-collector chain works the same way either way — `value_hash` is always populated.
 

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -435,15 +435,23 @@ The `value_hash` property on `Credential` nodes is the cross-collector merge pri
 
 **How it works:**
 
-1. Config Collector emits a Credential node via `HAS_ENV_VAR` (MCP server → credential)
+1. Config Collector emits an MCP server's canonical credential topology via
+   `AUTHENTICATES_WITH` and `USES_CREDENTIAL` (server → identity → credential),
+   independent of whether the material came from an env var, header, argument,
+   or URL component
 2. LiteLLM Looter emits a Credential node via `EXPOSES_CREDENTIAL` (gateway → master/upstream/virtual keys)
 3. Both compute `value_hash = SHA-256(credential_material)` via
    `sdk/common.HashCredentialValue`. For a recognized HTTP `Authorization`
    scheme, the material is the value after `Bearer`, `Basic`, or the other
    recognized scheme; protocol syntax is not part of the reusable secret.
-4. Same secret value → same `value_hash` → nodes merge on `objectid` regardless of how each collector derives it
+   Empty and whitespace-only env, header, argument, URL userinfo, and URL query
+   values are placeholders rather than credentials and are omitted. Every
+   non-empty value otherwise preserves its exact bytes, including surrounding
+   whitespace, for hashing and optional raw-value output.
+4. Same secret value → same `value_hash` → the processor correlates the two
+   distinct collector-owned nodes without pretending their object IDs are equal
 
-This enables evidence graphs like `AgentInstance → MCPServer → Credential ← LiteLLMGateway → upstream provider`. An observed `value_hash` match correlates the local and gateway credential records; the upstream target is classified separately as observed material or a reference.
+This enables evidence graphs like `AgentInstance → MCPServer → Identity → Credential ← LiteLLMGateway → upstream provider`. An observed `value_hash` match correlates the local and gateway credential records; the upstream target is classified separately as observed material or a reference.
 
 **Requirement:** Every collector or looter MUST populate `value_hash` on every emitted Credential node.
 

--- a/docs/reference/risk-scoring.md
+++ b/docs/reference/risk-scoring.md
@@ -71,7 +71,7 @@ score = 0.30 * credential + 0.25 * blast_radius + 0.20 * auth_risk
 
 | Component | Computation |
 |-----------|-------------|
-| `credential` | 100 if any trusted server has high-entropy or hardcoded credentials; 60 if credentials exist but are vault-referenced; 0 otherwise |
+| `credential` | For observed/exposed value-hash material used by any trusted server: 100 if any credential is high-entropy or hardcoded, 60 if another eligible credential exists, and 0 otherwise. Config location (environment, header, argument, or URL component) does not change eligibility. |
 | `blast_radius` | `min(reachable_resource_count * 10, 100)` |
 | `auth_risk` | `(1 - avg_effective_trust_edge_weight) * 100` over complete effective assessments (weak auth = high score); incomplete edges contribute a bounded unknown factor |
 | `tool_surface` | `min(trusted_tool_count * 5, 100)` |
@@ -109,9 +109,14 @@ score = 0.35 * auth_strength + 0.25 * tool_risk + 0.20 * exposure
 | `auth_strength` | From the paired `effective_auth_*` tuple: none=100 only with explicit anonymous-probe evidence and `effective_auth_source=observed`; basic=85, apiKey=70, bearer=50, oauth=25, oidc=20, mtls=10; unknown/custom/configured-or-unsupported-none have no numeric weakness |
 | `tool_risk` | max `capability_risk` across all provided tools |
 | `exposure` | public host=100, private network=50, localhost=20; unknown contributes a 0-100 bound and marks assessment incomplete |
-| `credential_handling` | Observed/exposed material only: `max(base, blast)` where `base` = 100 if high-entropy or hardcoded creds else 50, and `blast` = `min(Credential.blast_radius * 10, 100)`. Masked, hashed, unobserved, and identity-only references do not count. |
+| `credential_handling` | Observed/exposed value-hash material used for server authentication, independent of config location: `max(base, blast)` where `base` = 100 if high-entropy or hardcoded creds else 50, and `blast` = `min(Credential.blast_radius * 10, 100)`. Masked, hashed, unobserved, and identity-only references do not count. |
 
-`Credential.blast_radius` (distinct agents that can reach a value_hash-merged secret) is materialized by the `cross_service_credential_chain` post-processor, so a widely-shared secret amplifies its server's credential-handling risk even when the secret itself is not high-entropy.
+Both credential components follow the canonical
+`MCPServer-[:AUTHENTICATES_WITH]->Identity-[:USES_CREDENTIAL]->Credential`
+topology. `HAS_ENV_VAR` records optional environment-location evidence only; it
+is not the server-to-credential ownership path.
+
+`Credential.blast_radius` (distinct agents that can reach a value-hash-correlated secret) is materialized by the `cross_service_credential_chain` post-processor, so a widely-shared secret amplifies its server's credential-handling risk even when the secret itself is not high-entropy.
 
 ### MCPTool
 

--- a/modules/litellmloot/looter.go
+++ b/modules/litellmloot/looter.go
@@ -81,7 +81,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 	}
 
 	// Emit a property-neutral edge-source reference so the production CLI
-	// envelope is independently valid ingest v2. The looter knows the canonical
+	// envelope is independently valid ingest v3. The looter knows the canonical
 	// node identity and kinds, but does not own discovery or auth posture.
 	res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
 		ID:                gatewayObjectID,
@@ -93,7 +93,7 @@ func (l *Looter) Loot(ctx context.Context, t action.Target, opts action.LootOpti
 	// 1. The master-key Credential — emitted unconditionally.
 	//    value_hash is the cross-collector merge primitive; the Config
 	//    Collector emits a Credential with the same value_hash for the
-	//    same secret seen as an env var, and the
+	//    same secret seen in any supported config location, and the
 	//    cross_service_credential_chain post-processor (Phase 5) joins
 	//    on this property. Without this node the demo fails silently.
 	masterValueHash := common.HashCredentialValue(masterKey)

--- a/server/internal/analysis/findings_test.go
+++ b/server/internal/analysis/findings_test.go
@@ -657,23 +657,42 @@ func TestQueryFindings_CapturesExactDetectorWitness(t *testing.T) {
 		"target_merge_key": "identity",
 		"evidence_version": int64(1),
 		"exact_evidence_nodes": []any{
-			map[string]any{"id": "agent", "kinds": []any{"AgentInstance"}, "properties": map[string]any{"name": "Agent"}},
-			map[string]any{"id": "left", "kinds": []any{"Credential"}, "properties": map[string]any{"name": "Left"}},
-			map[string]any{"id": "right", "kinds": []any{"Credential"}, "properties": map[string]any{"name": "Right"}},
+			map[string]any{"id": "agent", "kinds": []any{"AgentInstance"}, "properties": map[string]any{
+				"name": "Agent", "observation_fact_fingerprints": []any{"internal-node"},
+			}},
+			map[string]any{"id": "server", "kinds": []any{"MCPServer"}, "properties": map[string]any{"name": "Configured server"}},
+			map[string]any{"id": "identity", "kinds": []any{"Identity"}, "properties": map[string]any{"type": "bearer"}},
+			map[string]any{"id": "c1", "kinds": []any{"Credential"}, "properties": map[string]any{"name": "Configured key"}},
+			map[string]any{"id": "c1master", "kinds": []any{"Credential"}, "properties": map[string]any{"name": "Gateway master key"}},
+			map[string]any{"id": "gateway", "kinds": []any{"LiteLLMGateway", "AIService"}, "properties": map[string]any{"name": "Gateway"}},
 			map[string]any{"id": "credential", "kinds": []any{"Credential"}, "properties": map[string]any{"name": "Provider key"}},
 		},
 		"exact_evidence_edges": []any{
 			map[string]any{
-				"source": "agent", "target": "left", "kind": "HAS_ENV_VAR",
-				"properties": map[string]any{"risk_weight": 0.1},
+				"source": "agent", "target": "server", "kind": "TRUSTS_SERVER",
+				"properties": map[string]any{
+					"risk_weight": 0.1, "observation_fact_fingerprints": []any{"internal-edge"},
+				},
 			},
 			map[string]any{
-				"source": "right", "target": "credential", "kind": "EXPOSES_CREDENTIAL",
+				"source": "server", "target": "identity", "kind": "AUTHENTICATES_WITH",
+				"properties": map[string]any{"risk_weight": 0.2},
+			},
+			map[string]any{
+				"source": "identity", "target": "c1", "kind": "USES_CREDENTIAL",
+				"properties": map[string]any{"risk_weight": 0.2},
+			},
+			map[string]any{
+				"source": "gateway", "target": "c1master", "kind": "EXPOSES_CREDENTIAL",
+				"properties": map[string]any{"risk_weight": 0.2},
+			},
+			map[string]any{
+				"source": "gateway", "target": "credential", "kind": "EXPOSES_CREDENTIAL",
 				"properties": map[string]any{"risk_weight": 0.2},
 			},
 		},
 		"exact_evidence_synthetic_edge": []any{
-			"left", "right", "VALUE_HASH_MATCH",
+			"c1", "c1master", "VALUE_HASH_MATCH",
 			"identity_correlation", "value_hash", "cross_service_credential_chain",
 		},
 	}}}
@@ -685,11 +704,38 @@ func TestQueryFindings_CapturesExactDetectorWitness(t *testing.T) {
 		t.Fatalf("exact evidence missing: %+v", findings)
 	}
 	exact := findings[0].ExactEvidence
-	if !exact.Complete || len(exact.Nodes) != 4 || len(exact.Edges) != 3 {
+	if !exact.Complete || len(exact.Nodes) != 7 || len(exact.Edges) != 6 {
 		t.Fatalf("exact evidence = %+v", exact)
 	}
-	synthetic := exact.Edges[2]
+	wantNodeIDs := []string{"agent", "server", "identity", "c1", "c1master", "gateway", "credential"}
+	for i, node := range exact.Nodes {
+		if node.ID != wantNodeIDs[i] {
+			t.Fatalf("exact evidence node %d = %q, want %q", i, node.ID, wantNodeIDs[i])
+		}
+		if _, exists := node.Properties["observation_fact_fingerprints"]; exists {
+			t.Fatalf("exact evidence node %d leaked internal fingerprint: %+v", i, node)
+		}
+	}
+	wantRawEdges := [][3]string{
+		{"agent", "server", "TRUSTS_SERVER"},
+		{"server", "identity", "AUTHENTICATES_WITH"},
+		{"identity", "c1", "USES_CREDENTIAL"},
+		{"gateway", "c1master", "EXPOSES_CREDENTIAL"},
+		{"gateway", "credential", "EXPOSES_CREDENTIAL"},
+	}
+	for i, edge := range exact.Edges {
+		if _, exists := edge.Properties["observation_fact_fingerprints"]; exists {
+			t.Fatalf("exact evidence edge %d leaked internal fingerprint: %+v", i, edge)
+		}
+		if i < len(wantRawEdges) &&
+			(edge.Source != wantRawEdges[i][0] || edge.Target != wantRawEdges[i][1] || edge.Kind != wantRawEdges[i][2]) {
+			t.Fatalf("exact evidence edge %d = %+v, want %v", i, edge, wantRawEdges[i])
+		}
+	}
+	synthetic := exact.Edges[5]
 	if !synthetic.Synthetic ||
+		synthetic.Source != "c1" ||
+		synthetic.Target != "c1master" ||
 		synthetic.Kind != "VALUE_HASH_MATCH" ||
 		synthetic.Provenance["basis"] != "value_hash" {
 		t.Fatalf("synthetic evidence = %+v", synthetic)

--- a/server/internal/analysis/processors/cross_service_credential_chain.go
+++ b/server/internal/analysis/processors/cross_service_credential_chain.go
@@ -8,8 +8,9 @@ import (
 )
 
 // CrossServiceCredentialChain wires the v0.2 credential-chain demo:
-// when the Config Collector emits a Credential C1 (an env var or
-// hardcoded value referenced by an MCP server) AND the LiteLLM Looter
+// when the Config Collector emits a Credential C1 (observed material
+// referenced by an MCP server, independent of its config location) AND the
+// LiteLLM Looter
 // emits a Credential C1master (the master key the operator supplied),
 // AND C1.value_hash == C1master.value_hash, those two nodes describe
 // the same secret. The LiteLLM gateway then exposes upstream provider
@@ -19,14 +20,14 @@ import (
 // Path:
 //
 //	(:AgentInstance)-[:TRUSTS_SERVER]->(:MCPServer)
-//	    -[:HAS_ENV_VAR]->(:Credential C1)
+//	    -[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(:Credential C1)
 //	    where C1.value_hash matches a Credential C1master from a LiteLLM Looter run
 //	(:LiteLLMGateway:AIService gw)-[:EXPOSES_CREDENTIAL]->(:Credential C1master)
 //	(gw)-[:EXPOSES_CREDENTIAL]->(:Credential C2)
 //	    where C2.type IN ["apiKey", "virtual_key"]
 //
 // We emit (:AgentInstance)-[:CAN_REACH]->(C2) with metadata that
-// records the merge endpoint (hash + LiteLLM gateway name).
+// records the merge endpoint (hash + a stable LiteLLM gateway identifier).
 //
 // Dependencies: ["has_access_to", "can_reach"] — has_access_to so the
 // graph has resource accessibility wired, can_reach so this processor
@@ -44,7 +45,9 @@ func (p *CrossServiceCredentialChain) Process(ctx context.Context, db graph.Grap
 	start := time.Now()
 
 	// The join: c1.value_hash = c1master.value_hash. c1 comes from the
-	// Config Collector (MCPServer-[:HAS_ENV_VAR]->c1). c1master comes
+	// Config Collector's canonical authentication topology
+	// (MCPServer-[:AUTHENTICATES_WITH]->Identity-[:USES_CREDENTIAL]->c1).
+	// c1master comes
 	// from the LiteLLM Looter ((gw:LiteLLMGateway)-[:EXPOSES_CREDENTIAL]->c1master).
 	// gw also -[:EXPOSES_CREDENTIAL]->c2, the upstream provider Credential.
 	//
@@ -55,14 +58,15 @@ func (p *CrossServiceCredentialChain) Process(ctx context.Context, db graph.Grap
 	// Single query (one ExecuteWrite): the same agent→server→credential
 	// join also yields the credential blast radius (count of distinct
 	// agents that can reach the merged secret), which we materialize on
-	// both the env-var credential (c1) and its value_hash-merged master
-	// (c1master). Folding it here avoids re-MATCHing the join path. The
-	// join is first reduced to the agent grain so blast radius counts
-	// DISTINCT agents rather than (agent, path) tuples — an agent with
-	// multiple reachable paths must not inflate the count. Each distinct
-	// agent's witness relationship IDs are preserved, then re-UNWOUND so the
-	// CAN_REACH MERGE stays one edge per (agent, upstream-credential) and each
-	// edge retains the exact relationship IDs for that agent's path.
+	// every configured credential (c1) and master credential (c1master)
+	// participating in the same value-hash correlation. Folding it here
+	// avoids re-MATCHing the join path. The aggregation grain is the shared
+	// value_hash, not an individual c1: distinct config nodes may represent
+	// the same secret, and their reachable agents must contribute to one
+	// global blast radius. Candidate paths are then ordered by their stable
+	// seven-node object-ID tuple before one winner per (agent, upstream
+	// credential) is selected. Relationship IDs are evidence only and do not
+	// influence the winner, so relationship recreation cannot flip topology.
 	// merge_key filter (U-MED-4): when a Looter cannot observe the raw
 	// credential value (e.g. LiteLLM masks upstream provider api_key
 	// server-side, so /model/info gives us no key material), it emits a
@@ -76,60 +80,83 @@ func (p *CrossServiceCredentialChain) Process(ctx context.Context, db graph.Grap
 	// merge_key='value_hash' credentials are eligible.
 	cypher := `
 MATCH (a:AgentInstance)-[trust:TRUSTS_SERVER]->(s:MCPServer)
-      -[environment:HAS_ENV_VAR]->(c1:Credential)
+      -[authenticates:AUTHENTICATES_WITH]->(i:Identity)-[uses:USES_CREDENTIAL]->(c1:Credential)
 WHERE c1.value_hash IS NOT NULL AND c1.value_hash <> ''
   AND c1.merge_key = 'value_hash'
+  AND c1.identity_basis = 'value_hash'
   AND c1.material_status = 'observed'
   AND c1.exposure_status = 'exposed'
 MATCH (gw:LiteLLMGateway)-[exposes_master:EXPOSES_CREDENTIAL]->(c1master:Credential)
 WHERE c1master.value_hash = c1.value_hash
+  AND c1master.value_hash IS NOT NULL AND c1master.value_hash <> ''
   AND c1master.objectid <> c1.objectid
   AND c1master.merge_key = 'value_hash'
+  AND c1master.identity_basis = 'value_hash'
   AND c1master.material_status = 'observed'
   AND c1master.exposure_status = 'exposed'
 MATCH (gw)-[exposes_upstream:EXPOSES_CREDENTIAL]->(c2:Credential)
 WHERE c2.type IN ['apiKey', 'virtual_key'] AND c2.objectid <> c1master.objectid
-// Collapse each agent's (possibly multiple) traversal paths to the agent
-// grain first. An agent that reaches the merged secret via more than one
-// path (e.g. two TRUSTS_SERVER or HAS_ENV_VAR edges) would otherwise yield
-// several distinct witness tuples and inflate the blast radius. Grouping by
-// the agent node here makes one row per distinct agent while collect() keeps
-// that agent's witness relationship-ID tuples for the CAN_REACH evidence.
-WITH s, c1, c1master, c2, gw, a,
-     collect([
-       id(trust), id(environment), id(exposes_master), id(exposes_upstream)
-     ]) AS agent_paths
-WITH s, c1, c1master, c2, gw, collect({
-  agent: a,
-  relationship_ids: agent_paths[0]
-}) AS agent_witnesses
-WITH s, c1, c1master, c2, gw, agent_witnesses,
-     size(agent_witnesses) AS reachable_agents
-SET c1.blast_radius = reachable_agents, c1master.blast_radius = reachable_agents
-WITH s, c1, c1master, c2, gw, agent_witnesses
-UNWIND agent_witnesses AS witness
-WITH s, c1, c1master, c2, gw,
-     witness.agent AS a,
-     witness.relationship_ids AS witness_relationship_ids
+// Aggregate globally by the cross-service identity key. Grouping by c1 here
+// would undercount a master credential when two distinct config credentials
+// carry the same secret. DISTINCT agents prevent multiple paths for one agent
+// from inflating the shared-secret blast radius.
+WITH c1.value_hash AS matched_value_hash,
+     collect(DISTINCT a) AS reachable_agents,
+     collect(DISTINCT c1) AS configured_credentials,
+     collect(DISTINCT c1master) AS master_credentials,
+     collect(DISTINCT {
+       agent: a,
+       server: s,
+       identity: i,
+       configured_credential: c1,
+       master_credential: c1master,
+       gateway: gw,
+       upstream_credential: c2,
+       relationship_ids: [
+         id(trust), id(authenticates), id(uses), id(exposes_master), id(exposes_upstream)
+       ]
+     }) AS candidates
+FOREACH (credential IN configured_credentials |
+  SET credential.blast_radius = size(reachable_agents))
+FOREACH (credential IN master_credentials |
+  SET credential.blast_radius = size(reachable_agents))
+WITH candidates
+UNWIND candidates AS candidate
+// A single agent/upstream pair may be reachable through several config nodes
+// or servers. Select one stable seven-node evidence tuple before MERGE so later
+// rows cannot overwrite the edge with traversal-order-dependent evidence.
+WITH candidate
+ORDER BY candidate.agent.objectid,
+         candidate.upstream_credential.objectid,
+         candidate.server.objectid,
+         candidate.identity.objectid,
+         candidate.configured_credential.objectid,
+         candidate.master_credential.objectid,
+         candidate.gateway.objectid
+WITH candidate.agent AS a,
+     candidate.upstream_credential AS c2,
+     collect(candidate)[0] AS winner
 MERGE (a)-[e:CAN_REACH]->(c2)
 SET e.scan_id = $scan_id, e.last_seen = datetime(), e.is_composite = true,
     e.source_collector = 'cross_service_credential_chain',
-    e.via_server = s.name,
-    e.via_credential = c1.name,
-    e.via_gateway = gw.name,
-    e.merge_value_hash = c1.value_hash,
+    e.via_server = winner.server.name,
+    e.via_credential = winner.configured_credential.name,
+    e.via_gateway = COALESCE(winner.gateway.name, winner.gateway.endpoint, winner.gateway.objectid),
+    e.merge_value_hash = winner.configured_credential.value_hash,
     e.upstream_provider = COALESCE(c2.provider, 'unknown'),
-    e.hops = 5,
+    e.hops = 6,
     e.confidence = 0.95,
     e.risk_weight = 0.1,
     e.evidence_version = 1,
     e.evidence_node_ids = [
-      a.objectid, s.objectid, c1.objectid, c1master.objectid,
-      gw.objectid, c2.objectid
+      a.objectid, winner.server.objectid, winner.identity.objectid,
+      winner.configured_credential.objectid, winner.master_credential.objectid,
+      winner.gateway.objectid, c2.objectid
     ],
-    e.evidence_relationship_ids = witness_relationship_ids,
+    e.evidence_relationship_ids = winner.relationship_ids,
     e.evidence_synthetic_edge = [
-      c1.objectid, c1master.objectid, 'VALUE_HASH_MATCH',
+      winner.configured_credential.objectid, winner.master_credential.objectid,
+      'VALUE_HASH_MATCH',
       'identity_correlation', 'value_hash', 'cross_service_credential_chain'
     ]
 RETURN count(e) AS written`

--- a/server/internal/analysis/processors/cross_service_credential_chain_integration_test.go
+++ b/server/internal/analysis/processors/cross_service_credential_chain_integration_test.go
@@ -1,0 +1,346 @@
+package processors
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/adithyan-ak/agenthound/server/internal/graph"
+)
+
+const crossServiceFixtureHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+// TestIntegrationCrossServiceCredentialChainGlobalBlastRadius is the
+// regression for the shared-secret aggregation grain. Two distinct config
+// credential nodes carry the same value_hash and are reachable by two agents;
+// agent A also has both paths, deliberately creating two candidates for the
+// same (agent, upstream credential) edge. The processor must:
+//   - count the two distinct agents globally for every correlated credential;
+//   - choose the stable seven-node tuple for agent A rather than the last row;
+//   - emit exactly one edge per agent/upstream with canonical evidence; and
+//   - remain structurally and evidentially idempotent across repeated runs.
+func TestIntegrationCrossServiceCredentialChainGlobalBlastRadius(t *testing.T) {
+	uri := os.Getenv("AGENTHOUND_NEO4J_URI")
+	if uri == "" {
+		t.Skip("skipping integration test: AGENTHOUND_NEO4J_URI not set")
+	}
+	user := os.Getenv("AGENTHOUND_NEO4J_USER")
+	pass := os.Getenv("AGENTHOUND_NEO4J_PASSWORD")
+
+	ctx := context.Background()
+	driver, err := graph.NewDriver(uri, user, pass)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+
+	const fixtureScanID = "test-cross-service-global"
+	db := graph.NewDB(graph.NewReader(driver), graph.NewWriter(driver))
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(ctx,
+			"MATCH (n) WHERE n.scan_id = $sid DETACH DELETE n",
+			map[string]any{"sid": fixtureScanID})
+	}
+	cleanup()
+	defer cleanup()
+
+	nodes := []ingest.Node{
+		processorFixtureNode("cscg-agent-a", "AgentInstance", "agent-a", fixtureScanID, nil),
+		processorFixtureNode("cscg-agent-b", "AgentInstance", "agent-b", fixtureScanID, nil),
+		processorFixtureNode("cscg-agent-decoy", "AgentInstance", "agent-decoy", fixtureScanID, nil),
+		processorFixtureNode("cscg-server-a", "MCPServer", "server-a", fixtureScanID, nil),
+		processorFixtureNode("cscg-server-b", "MCPServer", "server-b", fixtureScanID, nil),
+		processorFixtureNode("cscg-server-decoy", "MCPServer", "server-decoy", fixtureScanID, nil),
+		processorFixtureNode("cscg-identity-a", "Identity", "identity-a", fixtureScanID, nil),
+		processorFixtureNode("cscg-identity-b", "Identity", "identity-b", fixtureScanID, nil),
+		processorFixtureNode("cscg-identity-decoy", "Identity", "identity-decoy", fixtureScanID, nil),
+		processorFixtureCredential("cscg-config-a", "config-a", fixtureScanID, crossServiceFixtureHash, "value_hash", "value_hash"),
+		processorFixtureCredential("cscg-config-b", "config-b", fixtureScanID, crossServiceFixtureHash, "value_hash", "value_hash"),
+		// Same crafted hash, but identity-only correlation is ineligible and
+		// must neither add an agent nor receive blast-radius enrichment.
+		processorFixtureCredential("cscg-config-decoy", "config-decoy", fixtureScanID, crossServiceFixtureHash, "identity", "identity"),
+		processorFixtureCredential("cscg-master", "master", fixtureScanID, crossServiceFixtureHash, "value_hash", "value_hash"),
+		// Match the real looter's property-neutral edge-source reference. A loot
+		// collection can be ingested without a retained fingerprint collection,
+		// so neither name nor endpoint is guaranteed on this node.
+		{ID: "cscg-gateway", Kinds: []string{"LiteLLMGateway", "AIService"}, Properties: map[string]any{
+			"objectid": "cscg-gateway",
+			"scan_id":  fixtureScanID,
+		}},
+		processorFixtureNode("cscg-upstream", "Credential", "upstream", fixtureScanID, map[string]any{
+			"type":            "apiKey",
+			"provider":        "fixture-provider",
+			"material_status": "masked",
+			"exposure_status": "not_observed",
+			"merge_key":       "identity",
+			"identity_basis":  "provider_name",
+		}),
+	}
+	writer := graph.NewWriter(driver)
+	if _, err := writer.WriteNodes(ctx, managedProcessorNodes(nodes), fixtureScanID); err != nil {
+		t.Fatalf("write nodes: %v", err)
+	}
+
+	edges := []ingest.Edge{
+		processorFixtureEdge("cscg-agent-a", "cscg-server-b", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		// Insert the lexicographically later route first. Winner selection must
+		// still choose server-a for agent-a.
+		processorFixtureEdge("cscg-agent-a", "cscg-server-a", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		processorFixtureEdge("cscg-agent-b", "cscg-server-b", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		processorFixtureEdge("cscg-agent-decoy", "cscg-server-decoy", "TRUSTS_SERVER", "AgentInstance", "MCPServer"),
+		processorFixtureEdge("cscg-server-a", "cscg-identity-a", "AUTHENTICATES_WITH", "MCPServer", "Identity"),
+		processorFixtureEdge("cscg-server-b", "cscg-identity-b", "AUTHENTICATES_WITH", "MCPServer", "Identity"),
+		processorFixtureEdge("cscg-server-decoy", "cscg-identity-decoy", "AUTHENTICATES_WITH", "MCPServer", "Identity"),
+		processorFixtureEdge("cscg-identity-a", "cscg-config-a", "USES_CREDENTIAL", "Identity", "Credential"),
+		processorFixtureEdge("cscg-identity-b", "cscg-config-b", "USES_CREDENTIAL", "Identity", "Credential"),
+		processorFixtureEdge("cscg-identity-decoy", "cscg-config-decoy", "USES_CREDENTIAL", "Identity", "Credential"),
+		processorFixtureEdge("cscg-gateway", "cscg-master", "EXPOSES_CREDENTIAL", "AIService", "Credential"),
+		processorFixtureEdge("cscg-gateway", "cscg-upstream", "EXPOSES_CREDENTIAL", "AIService", "Credential"),
+	}
+	if _, err := writer.WriteEdges(ctx, managedProcessorEdges(edges), fixtureScanID); err != nil {
+		t.Fatalf("write edges: %v", err)
+	}
+
+	processor := &CrossServiceCredentialChain{}
+	stats, err := processor.Process(ctx, db, fixtureScanID+"-run-0")
+	if err != nil {
+		t.Fatalf("process first run: %v", err)
+	}
+	if stats.EdgesCreated != 2 {
+		t.Fatalf("first run wrote %d CAN_REACH rows, want 2", stats.EdgesCreated)
+	}
+
+	wantNodes := map[string][]string{
+		"cscg-agent-a": {
+			"cscg-agent-a", "cscg-server-a", "cscg-identity-a",
+			"cscg-config-a", "cscg-master", "cscg-gateway", "cscg-upstream",
+		},
+		"cscg-agent-b": {
+			"cscg-agent-b", "cscg-server-b", "cscg-identity-b",
+			"cscg-config-b", "cscg-master", "cscg-gateway", "cscg-upstream",
+		},
+	}
+	wantSynthetic := map[string][]string{
+		"cscg-agent-a": {
+			"cscg-config-a", "cscg-master", "VALUE_HASH_MATCH",
+			"identity_correlation", "value_hash", "cross_service_credential_chain",
+		},
+		"cscg-agent-b": {
+			"cscg-config-b", "cscg-master", "VALUE_HASH_MATCH",
+			"identity_correlation", "value_hash", "cross_service_credential_chain",
+		},
+	}
+	wantRelationshipKinds := []string{
+		"TRUSTS_SERVER", "AUTHENTICATES_WITH", "USES_CREDENTIAL",
+		"EXPOSES_CREDENTIAL", "EXPOSES_CREDENTIAL",
+	}
+
+	firstEvidence := assertCrossServiceCredentialChainState(
+		t, ctx, db, fixtureScanID+"-run-0", wantNodes, wantSynthetic, wantRelationshipKinds,
+	)
+	assertCrossServiceBlastRadius(t, ctx, db)
+
+	// Repeated execution must update the epoch in place without adding edges
+	// or changing the deterministic evidence winner.
+	for run := 1; run <= 5; run++ {
+		runID := fmt.Sprintf("%s-run-%d", fixtureScanID, run)
+		stats, err = processor.Process(ctx, db, runID)
+		if err != nil {
+			t.Fatalf("process repeat %d: %v", run, err)
+		}
+		if stats.EdgesCreated != 2 {
+			t.Fatalf("repeat %d wrote %d CAN_REACH rows, want 2", run, stats.EdgesCreated)
+		}
+		gotEvidence := assertCrossServiceCredentialChainState(
+			t, ctx, db, runID, wantNodes, wantSynthetic, wantRelationshipKinds,
+		)
+		if !reflect.DeepEqual(gotEvidence, firstEvidence) {
+			t.Fatalf("repeat %d changed evidence:\nfirst=%v\n got=%v", run, firstEvidence, gotEvidence)
+		}
+		assertCrossServiceBlastRadius(t, ctx, db)
+	}
+}
+
+func processorFixtureNode(
+	id, kind, name, scanID string,
+	extra map[string]any,
+) ingest.Node {
+	properties := map[string]any{
+		"objectid": id,
+		"name":     name,
+		"scan_id":  scanID,
+	}
+	for key, value := range extra {
+		properties[key] = value
+	}
+	return ingest.Node{ID: id, Kinds: []string{kind}, Properties: properties}
+}
+
+func processorFixtureCredential(
+	id, name, scanID, valueHash, mergeKey, identityBasis string,
+) ingest.Node {
+	return processorFixtureNode(id, "Credential", name, scanID, map[string]any{
+		"type":            "apiKey",
+		"value_hash":      valueHash,
+		"merge_key":       mergeKey,
+		"identity_basis":  identityBasis,
+		"material_status": "observed",
+		"exposure_status": "exposed",
+	})
+}
+
+func processorFixtureEdge(source, target, kind, sourceKind, targetKind string) ingest.Edge {
+	return ingest.Edge{
+		Source: source, Target: target, Kind: kind,
+		SourceKind: sourceKind, TargetKind: targetKind,
+		Properties: map[string]any{"risk_weight": 0.1},
+	}
+}
+
+func assertCrossServiceCredentialChainState(
+	t *testing.T,
+	ctx context.Context,
+	db graph.GraphDB,
+	wantScanID string,
+	wantNodes, wantSynthetic map[string][]string,
+	wantRelationshipKinds []string,
+) map[string][]string {
+	t.Helper()
+
+	rows, err := db.Query(ctx, `
+MATCH (a:AgentInstance)-[e:CAN_REACH]->(c:Credential {objectid: 'cscg-upstream'})
+WHERE a.objectid STARTS WITH 'cscg-agent-'
+RETURN a.objectid AS agent_id,
+       e.scan_id AS scan_id,
+       e.source_collector AS source_collector,
+       e.is_composite AS is_composite,
+       e.hops AS hops,
+       e.confidence AS confidence,
+       e.risk_weight AS risk_weight,
+       e.evidence_version AS evidence_version,
+       e.merge_value_hash AS merge_value_hash,
+       e.via_server AS via_server,
+       e.via_credential AS via_credential,
+       e.via_gateway AS via_gateway,
+       e.upstream_provider AS upstream_provider,
+       e.evidence_node_ids AS evidence_node_ids,
+       e.evidence_synthetic_edge AS evidence_synthetic_edge
+ORDER BY agent_id`, nil)
+	if err != nil {
+		t.Fatalf("query CAN_REACH state: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d agent/upstream CAN_REACH edges, want 2: %v", len(rows), rows)
+	}
+
+	evidence := make(map[string][]string, len(rows))
+	for _, row := range rows {
+		agentID, _ := row["agent_id"].(string)
+		if _, known := wantNodes[agentID]; !known {
+			t.Fatalf("ineligible or unknown agent received CAN_REACH: %v", row)
+		}
+		if got, _ := row["scan_id"].(string); got != wantScanID {
+			t.Errorf("%s scan_id = %q, want %q", agentID, got, wantScanID)
+		}
+		if got, _ := row["source_collector"].(string); got != "cross_service_credential_chain" {
+			t.Errorf("%s source_collector = %q", agentID, got)
+		}
+		if got, _ := row["is_composite"].(bool); !got {
+			t.Errorf("%s is_composite = false", agentID)
+		}
+		if got := toInt(row["hops"]); got != 6 {
+			t.Errorf("%s hops = %d, want 6", agentID, got)
+		}
+		if got, _ := row["confidence"].(float64); got != 0.95 {
+			t.Errorf("%s confidence = %v, want 0.95", agentID, row["confidence"])
+		}
+		if got, _ := row["risk_weight"].(float64); got != 0.1 {
+			t.Errorf("%s risk_weight = %v, want 0.1", agentID, row["risk_weight"])
+		}
+		if got := toInt(row["evidence_version"]); got != 1 {
+			t.Errorf("%s evidence_version = %d, want 1", agentID, got)
+		}
+		if got, _ := row["merge_value_hash"].(string); got != crossServiceFixtureHash {
+			t.Errorf("%s merge_value_hash = %q, want fixture hash", agentID, got)
+		}
+		if got, _ := row["via_gateway"].(string); got != "cscg-gateway" {
+			t.Errorf("%s via_gateway = %q, want stable gateway object ID fallback", agentID, got)
+		}
+		if got, _ := row["upstream_provider"].(string); got != "fixture-provider" {
+			t.Errorf("%s upstream_provider = %q, want fixture-provider", agentID, got)
+		}
+		wantViaServer := map[string]string{"cscg-agent-a": "server-a", "cscg-agent-b": "server-b"}[agentID]
+		wantViaCredential := map[string]string{"cscg-agent-a": "config-a", "cscg-agent-b": "config-b"}[agentID]
+		if got, _ := row["via_server"].(string); got != wantViaServer {
+			t.Errorf("%s via_server = %q, want %q", agentID, got, wantViaServer)
+		}
+		if got, _ := row["via_credential"].(string); got != wantViaCredential {
+			t.Errorf("%s via_credential = %q, want %q", agentID, got, wantViaCredential)
+		}
+		nodeIDs := stringSliceProperty(row, "evidence_node_ids")
+		if !reflect.DeepEqual(nodeIDs, wantNodes[agentID]) {
+			t.Errorf("%s evidence nodes = %v, want %v", agentID, nodeIDs, wantNodes[agentID])
+		}
+		synthetic := stringSliceProperty(row, "evidence_synthetic_edge")
+		if !reflect.DeepEqual(synthetic, wantSynthetic[agentID]) {
+			t.Errorf("%s synthetic evidence = %v, want %v", agentID, synthetic, wantSynthetic[agentID])
+		}
+		evidence[agentID] = append(append([]string(nil), nodeIDs...), synthetic...)
+	}
+
+	kindRows, err := db.Query(ctx, `
+MATCH (a:AgentInstance)-[e:CAN_REACH]->(:Credential {objectid: 'cscg-upstream'})
+WHERE a.objectid STARTS WITH 'cscg-agent-'
+UNWIND range(0, size(e.evidence_relationship_ids) - 1) AS evidence_index
+MATCH ()-[raw]->()
+WHERE id(raw) = e.evidence_relationship_ids[evidence_index]
+WITH a, evidence_index, type(raw) AS relationship_kind
+ORDER BY a.objectid, evidence_index
+RETURN a.objectid AS agent_id, collect(relationship_kind) AS relationship_kinds
+ORDER BY agent_id`, nil)
+	if err != nil {
+		t.Fatalf("query evidence relationship kinds: %v", err)
+	}
+	if len(kindRows) != 2 {
+		t.Fatalf("got %d relationship-evidence rows, want 2: %v", len(kindRows), kindRows)
+	}
+	for _, row := range kindRows {
+		agentID, _ := row["agent_id"].(string)
+		gotKinds := stringSliceProperty(row, "relationship_kinds")
+		if !reflect.DeepEqual(gotKinds, wantRelationshipKinds) {
+			t.Errorf("%s evidence relationship kinds = %v, want %v", agentID, gotKinds, wantRelationshipKinds)
+		}
+		evidence[agentID] = append(evidence[agentID], gotKinds...)
+	}
+	return evidence
+}
+
+func assertCrossServiceBlastRadius(t *testing.T, ctx context.Context, db graph.GraphDB) {
+	t.Helper()
+	rows, err := db.Query(ctx, `
+MATCH (c:Credential)
+WHERE c.objectid IN ['cscg-config-a', 'cscg-config-b', 'cscg-config-decoy', 'cscg-master']
+RETURN c.objectid AS credential_id, c.blast_radius AS blast_radius
+ORDER BY credential_id`, nil)
+	if err != nil {
+		t.Fatalf("query blast radius: %v", err)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("got %d credential rows, want 4: %v", len(rows), rows)
+	}
+	for _, row := range rows {
+		credentialID, _ := row["credential_id"].(string)
+		if credentialID == "cscg-config-decoy" {
+			if row["blast_radius"] != nil {
+				t.Errorf("identity-only decoy blast_radius = %v, want null", row["blast_radius"])
+			}
+			continue
+		}
+		if got := toInt(row["blast_radius"]); got != 2 {
+			t.Errorf("%s blast_radius = %d, want global distinct-agent count 2", credentialID, got)
+		}
+	}
+}

--- a/server/internal/analysis/processors/cross_service_credential_chain_test.go
+++ b/server/internal/analysis/processors/cross_service_credential_chain_test.go
@@ -107,6 +107,10 @@ func TestCrossServiceCredentialChain_CypherJoinsOnValueHash(t *testing.T) {
 	if strings.Contains(captured, "NOT EXISTS((a)-[:CAN_REACH]->(c2))") {
 		t.Errorf("Cypher must refresh existing CAN_REACH scan_id instead of skipping matches; query:\n%s", captured)
 	}
+	if strings.Contains(captured, "HAS_ENV_VAR") ||
+		!strings.Contains(captured, "-[authenticates:AUTHENTICATES_WITH]->(i:Identity)-[uses:USES_CREDENTIAL]->(c1:Credential)") {
+		t.Fatalf("Cypher must use the canonical auth/uses topology, independent of credential location; query:\n%s", captured)
+	}
 }
 
 // TestCrossServiceCredentialChain_MergeKeyFilter guards the U-MED-4
@@ -129,6 +133,8 @@ func TestCrossServiceCredentialChain_MergeKeyFilter(t *testing.T) {
 	for _, side := range []string{
 		"c1.merge_key = 'value_hash'",
 		"c1master.merge_key = 'value_hash'",
+		"c1.identity_basis = 'value_hash'",
+		"c1master.identity_basis = 'value_hash'",
 		"c1.material_status = 'observed'",
 		"c1master.material_status = 'observed'",
 		"c1.exposure_status = 'exposed'",
@@ -136,6 +142,14 @@ func TestCrossServiceCredentialChain_MergeKeyFilter(t *testing.T) {
 	} {
 		if !strings.Contains(captured, side) {
 			t.Errorf("Cypher missing merge_key filter %q; query:\n%s", side, captured)
+		}
+	}
+	for _, nonemptyHash := range []string{
+		"c1.value_hash IS NOT NULL AND c1.value_hash <> ''",
+		"c1master.value_hash IS NOT NULL AND c1master.value_hash <> ''",
+	} {
+		if !strings.Contains(captured, nonemptyHash) {
+			t.Errorf("Cypher accepts an empty value_hash; missing %q; query:\n%s", nonemptyHash, captured)
 		}
 	}
 	if strings.Contains(captured, "material_status IS NULL") ||
@@ -149,7 +163,7 @@ func TestCrossServiceCredentialChain_MergeKeyFilter(t *testing.T) {
 	}
 }
 
-func TestCrossServiceCredentialChain_PreservesPerAgentWitnesses(t *testing.T) {
+func TestCrossServiceCredentialChain_GlobalBlastRadiusAndDeterministicWitnessSelection(t *testing.T) {
 	var captured string
 	mock := &graph.MockGraphDB{
 		ExecuteWriteFunc: func(_ context.Context, cypher string, _ map[string]any) (int, error) {
@@ -165,17 +179,39 @@ func TestCrossServiceCredentialChain_PreservesPerAgentWitnesses(t *testing.T) {
 		t.Fatalf("Process: %v", err)
 	}
 	for _, witness := range []string{
-		"id(trust)", "id(environment)", "id(exposes_master)",
-		"id(exposes_upstream)", "witness.relationship_ids",
-		"e.evidence_relationship_ids = witness_relationship_ids",
-		"collect({\n  agent: a,\n  relationship_ids: agent_paths[0]\n}) AS agent_witnesses",
-		"size(agent_witnesses) AS reachable_agents",
+		"id(trust)", "id(authenticates)", "id(uses)", "id(exposes_master)",
+		"id(exposes_upstream)",
+		"WITH c1.value_hash AS matched_value_hash",
+		"collect(DISTINCT a) AS reachable_agents",
+		"collect(DISTINCT c1) AS configured_credentials",
+		"collect(DISTINCT c1master) AS master_credentials",
+		"SET credential.blast_radius = size(reachable_agents)",
+		"collect(candidate)[0] AS winner",
+		"e.evidence_relationship_ids = winner.relationship_ids",
+		"e.via_gateway = COALESCE(winner.gateway.name, winner.gateway.endpoint, winner.gateway.objectid)",
 	} {
 		if !strings.Contains(captured, witness) {
-			t.Errorf("Cypher missing per-agent witness %q; query:\n%s", witness, captured)
+			t.Errorf("Cypher missing global aggregation or deterministic witness %q; query:\n%s", witness, captured)
 		}
 	}
-	if strings.Contains(captured, "collect(DISTINCT {\n  agent: a,") {
-		t.Errorf("blast radius must not count distinct agent/path tuples; query:\n%s", captured)
+	if strings.Contains(captured, "WITH s, i, c1, c1master, c2, gw") ||
+		strings.Contains(captured, "size(agent_witnesses) AS reachable_agents") {
+		t.Errorf("blast radius must aggregate across distinct c1 nodes sharing one value_hash; query:\n%s", captured)
+	}
+	for _, orderedEvidence := range []string{
+		"candidate.server.objectid,\n" +
+			"         candidate.identity.objectid,\n" +
+			"         candidate.configured_credential.objectid,\n" +
+			"         candidate.master_credential.objectid,\n" +
+			"         candidate.gateway.objectid",
+		"a.objectid, winner.server.objectid, winner.identity.objectid,\n" +
+			"      winner.configured_credential.objectid, winner.master_credential.objectid,\n" +
+			"      winner.gateway.objectid, c2.objectid",
+		"id(trust), id(authenticates), id(uses), id(exposes_master), id(exposes_upstream)",
+		"e.hops = 6",
+	} {
+		if !strings.Contains(captured, orderedEvidence) {
+			t.Errorf("Cypher missing canonical ordered evidence %q; query:\n%s", orderedEvidence, captured)
+		}
 	}
 }

--- a/server/internal/analysis/processors/effective_auth_consumers_integration_test.go
+++ b/server/internal/analysis/processors/effective_auth_consumers_integration_test.go
@@ -203,42 +203,6 @@ func effectiveAuthIntegrationDB(
 	return ctx, db, graph.NewWriter(driver), cleanup
 }
 
-func processorFixtureNode(
-	id, kind, name, scanID string,
-	extra map[string]any,
-) ingest.Node {
-	properties := map[string]any{
-		"objectid": id,
-		"name":     name,
-		"scan_id":  scanID,
-	}
-	for key, value := range extra {
-		properties[key] = value
-	}
-	return ingest.Node{ID: id, Kinds: []string{kind}, Properties: properties}
-}
-
-func processorFixtureCredential(
-	id, name, scanID, valueHash, mergeKey, identityBasis string,
-) ingest.Node {
-	return processorFixtureNode(id, "Credential", name, scanID, map[string]any{
-		"type":            "apiKey",
-		"value_hash":      valueHash,
-		"merge_key":       mergeKey,
-		"identity_basis":  identityBasis,
-		"material_status": "observed",
-		"exposure_status": "exposed",
-	})
-}
-
-func processorFixtureEdge(source, target, kind, sourceKind, targetKind string) ingest.Edge {
-	return ingest.Edge{
-		Source: source, Target: target, Kind: kind,
-		SourceKind: sourceKind, TargetKind: targetKind,
-		Properties: map[string]any{"risk_weight": 0.1},
-	}
-}
-
 func assertCompositeEdgeCount(
 	t *testing.T,
 	ctx context.Context,

--- a/server/internal/analysis/riskscore/agent.go
+++ b/server/internal/analysis/riskscore/agent.go
@@ -49,7 +49,14 @@ func AgentRiskAssessment(ctx context.Context, db graph.GraphDB, objectID string)
 
 func agentCredentialRisk(ctx context.Context, db graph.GraphDB, objectID string) (float64, error) {
 	cypher := `
-MATCH (a {objectid: $id})-[:TRUSTS_SERVER]->(s:MCPServer)-[:HAS_ENV_VAR]->(c:Credential)
+MATCH (a {objectid: $id})-[:TRUSTS_SERVER]->(s:MCPServer)
+      -[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(c:Credential)
+WHERE c.value_hash IS NOT NULL AND c.value_hash <> ''
+  AND c.merge_key = 'value_hash'
+  AND c.identity_basis = 'value_hash'
+  AND c.material_status = 'observed'
+  AND c.exposure_status = 'exposed'
+WITH DISTINCT c
 RETURN c.high_entropy AS high_entropy, c.type AS cred_type,
        c.material_status AS material_status, c.exposure_status AS exposure_status,
        c.merge_key AS merge_key`

--- a/server/internal/analysis/riskscore/agent_test.go
+++ b/server/internal/analysis/riskscore/agent_test.go
@@ -21,7 +21,7 @@ func TestAgentRiskScore_AllZero(t *testing.T) {
 func TestAgentRiskScore_HighEntropyCreds(t *testing.T) {
 	mock := &graph.MockGraphDB{
 		QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
-			if containsSubstring(cypher, "HAS_ENV_VAR") {
+			if containsSubstring(cypher, "USES_CREDENTIAL") {
 				return []map[string]any{
 					{
 						"high_entropy": true, "cred_type": "envVar",
@@ -47,7 +47,7 @@ func TestAgentRiskScore_HighEntropyCreds(t *testing.T) {
 func TestAgentRiskScore_HardcodedCreds(t *testing.T) {
 	mock := &graph.MockGraphDB{
 		QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
-			if containsSubstring(cypher, "HAS_ENV_VAR") {
+			if containsSubstring(cypher, "USES_CREDENTIAL") {
 				return []map[string]any{
 					{
 						"high_entropy": false, "cred_type": "hardcoded",
@@ -72,7 +72,7 @@ func TestAgentRiskScore_HardcodedCreds(t *testing.T) {
 func TestAgentRiskScore_NormalCreds(t *testing.T) {
 	mock := &graph.MockGraphDB{
 		QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
-			if containsSubstring(cypher, "HAS_ENV_VAR") {
+			if containsSubstring(cypher, "USES_CREDENTIAL") {
 				return []map[string]any{
 					{
 						"high_entropy": false, "cred_type": "envVar",
@@ -92,6 +92,55 @@ func TestAgentRiskScore_NormalCreds(t *testing.T) {
 	// cred=60, rest=0. score = 0.30*60 = 18
 	if score != 18 {
 		t.Errorf("score = %f, want 18", score)
+	}
+}
+
+func TestAgentCredentialRiskUsesCanonicalTopologyForEveryConfigLocation(t *testing.T) {
+	for _, location := range []string{"header", "arg:1", "url_query:token"} {
+		t.Run(location, func(t *testing.T) {
+			var captured string
+			mock := &graph.MockGraphDB{
+				QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
+					captured = cypher
+					return []map[string]any{{
+						"location": location, "high_entropy": true, "cred_type": "hardcoded",
+						"merge_key": "value_hash", "material_status": "observed",
+						"exposure_status": "exposed",
+					}}, nil
+				},
+			}
+
+			risk, err := agentCredentialRisk(context.Background(), mock, "agent-1")
+			if err != nil {
+				t.Fatalf("agentCredentialRisk: %v", err)
+			}
+			if risk != 100 {
+				t.Fatalf("risk = %v, want 100 for %s credential", risk, location)
+			}
+			assertCanonicalCredentialRiskQuery(t, captured)
+		})
+	}
+}
+
+func assertCanonicalCredentialRiskQuery(t *testing.T, cypher string) {
+	t.Helper()
+	for _, clause := range []string{
+		"TRUSTS_SERVER",
+		"-[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(c:Credential)",
+		"WITH DISTINCT c",
+		"c.value_hash IS NOT NULL",
+		"c.value_hash <> ''",
+		"c.merge_key = 'value_hash'",
+		"c.identity_basis = 'value_hash'",
+		"c.material_status = 'observed'",
+		"c.exposure_status = 'exposed'",
+	} {
+		if !containsSubstring(cypher, clause) {
+			t.Errorf("credential risk query missing %q:\n%s", clause, cypher)
+		}
+	}
+	if containsSubstring(cypher, "HAS_ENV_VAR") || containsSubstring(cypher, "location") {
+		t.Fatalf("credential risk query still depends on config location:\n%s", cypher)
 	}
 }
 

--- a/server/internal/analysis/riskscore/server.go
+++ b/server/internal/analysis/riskscore/server.go
@@ -152,7 +152,13 @@ RETURN h.scope AS scope`
 
 func serverCredentialHandlingAssessment(ctx context.Context, db graph.GraphDB, objectID string) (Assessment, error) {
 	cypher := `
-MATCH (s {objectid: $id})-[:HAS_ENV_VAR]->(c:Credential)
+MATCH (s {objectid: $id})-[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(c:Credential)
+WHERE c.value_hash IS NOT NULL AND c.value_hash <> ''
+  AND c.merge_key = 'value_hash'
+  AND c.identity_basis = 'value_hash'
+  AND c.material_status = 'observed'
+  AND c.exposure_status = 'exposed'
+WITH DISTINCT c
 RETURN c.high_entropy AS high_entropy, c.type AS cred_type,
        c.blast_radius AS blast_radius, c.material_status AS material_status,
        c.exposure_status AS exposure_status, c.merge_key AS merge_key`

--- a/server/internal/analysis/riskscore/server_test.go
+++ b/server/internal/analysis/riskscore/server_test.go
@@ -231,7 +231,7 @@ func TestServerRiskScore_CredentialHandling(t *testing.T) {
 					if containsSubstring(cypher, "auth_method") {
 						return []map[string]any{{"am": "mtls"}}, nil
 					}
-					if containsSubstring(cypher, "HAS_ENV_VAR") {
+					if containsSubstring(cypher, "USES_CREDENTIAL") {
 						return []map[string]any{tt.row}, nil
 					}
 					return nil, nil
@@ -278,7 +278,7 @@ func TestServerRiskScoreIgnoresUnobservedCredentialMaterial(t *testing.T) {
 				return []map[string]any{{"am": "mtls"}}, nil
 			case containsSubstring(cypher, "RUNS_ON"):
 				return []map[string]any{{"scope": "local"}}, nil
-			case containsSubstring(cypher, "HAS_ENV_VAR"):
+			case containsSubstring(cypher, "USES_CREDENTIAL"):
 				return []map[string]any{{
 					"material_status": "masked",
 					"exposure_status": "not_observed",
@@ -297,6 +297,54 @@ func TestServerRiskScoreIgnoresUnobservedCredentialMaterial(t *testing.T) {
 	}
 	if score != 7.5 { // 0.35*10 auth + 0.20*20 local exposure
 		t.Fatalf("masked identity affected credential risk: score=%v, want 7.5", score)
+	}
+}
+
+func TestServerCredentialHandlingUsesCanonicalTopologyForEveryConfigLocation(t *testing.T) {
+	for _, location := range []string{"header", "arg:1", "url_userinfo:password"} {
+		t.Run(location, func(t *testing.T) {
+			var captured string
+			mock := &graph.MockGraphDB{
+				QueryFunc: func(_ context.Context, cypher string, _ map[string]any) ([]map[string]any, error) {
+					captured = cypher
+					return []map[string]any{{
+						"location": location, "high_entropy": true, "cred_type": "hardcoded",
+						"merge_key": "value_hash", "material_status": "observed",
+						"exposure_status": "exposed",
+					}}, nil
+				},
+			}
+
+			assessment, err := serverCredentialHandlingAssessment(context.Background(), mock, "server-1")
+			if err != nil {
+				t.Fatalf("serverCredentialHandlingAssessment: %v", err)
+			}
+			if assessment.Score != 100 || !assessment.Complete {
+				t.Fatalf("assessment = %+v, want exact 100 for %s credential", assessment, location)
+			}
+			assertCanonicalServerCredentialRiskQuery(t, captured)
+		})
+	}
+}
+
+func assertCanonicalServerCredentialRiskQuery(t *testing.T, cypher string) {
+	t.Helper()
+	for _, clause := range []string{
+		"-[:AUTHENTICATES_WITH]->(:Identity)-[:USES_CREDENTIAL]->(c:Credential)",
+		"WITH DISTINCT c",
+		"c.value_hash IS NOT NULL",
+		"c.value_hash <> ''",
+		"c.merge_key = 'value_hash'",
+		"c.identity_basis = 'value_hash'",
+		"c.material_status = 'observed'",
+		"c.exposure_status = 'exposed'",
+	} {
+		if !containsSubstring(cypher, clause) {
+			t.Errorf("server credential-handling query missing %q:\n%s", clause, cypher)
+		}
+	}
+	if containsSubstring(cypher, "HAS_ENV_VAR") || containsSubstring(cypher, "location") {
+		t.Fatalf("server credential-handling query still depends on config location:\n%s", cypher)
 	}
 }
 

--- a/server/internal/ingest/campaign_vertical_integration_test.go
+++ b/server/internal/ingest/campaign_vertical_integration_test.go
@@ -123,6 +123,7 @@ func TestIntegrationCompiledCampaignExportProbeIngestPromotesOnlySourceAgent(t *
 		}),
 		node(credentialID, "Credential", map[string]any{
 			"name":       "DB_TOKEN",
+			"location":   "header",
 			"value_hash": common.HashCredentialValue(credentialMaterial),
 			"merge_key":  "value_hash", "identity_basis": "value_hash",
 			"material_status": "observed", "exposure_status": "exposed",
@@ -150,7 +151,6 @@ func TestIntegrationCompiledCampaignExportProbeIngestPromotesOnlySourceAgent(t *
 		edge(alternateServer, alternateTool, "PROVIDES_TOOL", "MCPServer", "MCPTool"),
 		edge(serverID, resourceTool, "PROVIDES_TOOL", "MCPServer", "MCPTool"),
 		edge(serverID, resourceID, "PROVIDES_RESOURCE", "MCPServer", "MCPResource"),
-		edge(serverID, credentialID, "HAS_ENV_VAR", "MCPServer", "Credential"),
 		edge(serverID, identityID, "AUTHENTICATES_WITH", "MCPServer", "Identity"),
 		edge(identityID, credentialID, "USES_CREDENTIAL", "Identity", "Credential"),
 	}


### PR DESCRIPTION
## Review position

This is **5 of 6** in the AgentHound v1.0 candidate review sequence.

- Base: merged `main` at `98a5608`
- Head: `codex/release-stack-05-credential-analysis` at `e255dd9`
- Scope: 16 files, 705 insertions, 125 deletions
- Commit count: 1
- Prerequisites: PRs #96–#99 are merged

Review this PR as the exact `main...e255dd9` delta. The merged parent already establishes trustworthy runtime authentication evidence and location-neutral MCP-resource reachability; this PR repairs the remaining cross-service credential-chain, blast-radius, and credential-risk consumers.

Audit issue IDs below refer to the independent release ledger, not GitHub issues.

## Problem and true-positive findings

### RC-09 — remaining credential analysis grouped by storage shape instead of credential material

- **Audit issue 32, remaining cross-service portion:** the merged parent already makes ordinary MCP-resource `CanReach` analysis location-neutral. However, `cross_service_credential_chain` still traversed only `MCPServer-[:HAS_ENV_VAR]->Credential`, so an otherwise identical header, argument, or URL credential could produce no upstream LiteLLM credential-chain finding. This PR does **not** claim that general MCP-resource reachability is still broken on its base.
- **Audit issue 33:** the agent and server credential-risk components still traversed only `HAS_ENV_VAR`. A supported high-entropy or hardcoded header/argument/URL credential could therefore contribute zero credential risk despite carrying the same observed, exposed material evidence.
- **Audit issue 37:** blast radius grouped exposure per individual Config credential node. Distinct collector-owned nodes carrying the same master `value_hash` could leave the shared credential with radius one even when two agents used that material.

### Stack-composition evidence defect

- **S5-F2:** a real cross-service finding could contain `via_gateway: null` when the LiteLLM looter emitted its intentional property-neutral gateway reference. Detection and six-hop topology were correct, but the advertised gateway field did not identify the proven gateway object.

### Valid finding no longer owned by this diff

**S5-F1** was a genuine validation-only composition finding: the compiled campaign fixture initially omitted the v3 origin contract. Its correction now lives in merged prerequisite commit `dd0c320`, and both the fixture graph and collector subprocess receive the required host/realm origin on this PR's base. It is retained in the audit history but is not presented as a change made by PR #100.

## Root cause

The remaining cross-service and risk consumers treated an optional storage/location edge (`HAS_ENV_VAR`) as the credential's semantic identity. AgentHound's intended cross-collector identity grain is the SHA-256 `value_hash` of observed raw credential material, reached through the canonical `MCPServer -> Identity -> Credential` topology. Grouping by a config node or requiring one location edge fractured the same real-world secret across observations.

Synthetic provider identities marked `merge_key: identity` remain excluded from value-hash joins because they do not represent observed raw credential material.

## Solution

- Traverse the canonical `AUTHENTICATES_WITH -> USES_CREDENTIAL` topology in the cross-service processor and agent/server credential-risk consumers, independently of config location.
- Require non-empty, observed, exposed material with `merge_key=value_hash` and `identity_basis=value_hash` on both sides of a cross-service join.
- Exclude synthetic identity-only credentials from material correlation.
- Correlate observations globally at `value_hash` grain across services and collector-owned configuration nodes.
- Compute one distinct-agent blast radius for the reused secret and write it to every participating configured and master credential.
- Deterministically reduce candidate paths to one exact seven-node/five-raw-edge witness per agent/target, plus the explicit synthetic `VALUE_HASH_MATCH` evidence tuple.
- Preserve exact target cardinality without cartesian multiplication or collapsing distinct targets.
- Derive `via_gateway` only from the witnessed gateway: name, then endpoint, then immutable object ID.
- Attribute high-entropy/hardcoded credential risk from the same evidence-qualified canonical topology.

## Security and product impact

- Header, argument, and URL credential material can no longer disappear from cross-service credential-chain findings or agent/server credential-risk components merely because it lacks `HAS_ENV_VAR`.
- General MCP-resource reachability remains the merged parent's responsibility and is unchanged by this PR.
- Reuse of one observed secret is represented as one correlated exposure even when independently discovered through different collectors or transports.
- Synthetic LiteLLM provider identities cannot false-positive against real credential material.
- Blast radius reflects all proven agents using the shared secret rather than an arbitrary config-node partition.
- Every cross-service finding names the actual witnessed gateway and carries a reviewable exact path.

## Validation

Fresh validation after retargeting to merged `main` passed:

- `gofmt -l .` — no output
- `go build ./...`
- `go vet ./...`
- `go test ./... -race`
- focused race suite for analysis processors, risk scoring, findings, ingest, and LiteLLM loot
- `git diff --check main...e255dd9`
- strict MkDocs build from the pinned `docs/requirements.txt`

The exact global-blast/gateway/evidence regression passed five race-enabled repetitions on each supported database generation:

- Neo4j 4.4.48 Community
- Neo4j 5.26.28 Community

Those controls use two agents, two distinct Config credential nodes with one shared material hash, a duplicate candidate route, an identity-only decoy, a property-neutral gateway, and one upstream target. They prove:

- exactly one finding per eligible agent/target
- global blast radius 2 on both Config credentials and the shared master
- no blast-radius enrichment or finding for the identity-only decoy
- stable deterministic evidence across repeated processing
- seven ordered evidence nodes
- five ordered raw relationships plus synthetic `VALUE_HASH_MATCH`
- six hops and the immutable gateway object ID fallback

The broader compiled campaign previously ran three repetitions on both Neo4j generations with PostgreSQL 16 and produced exactly three reference-only upstream findings. The assembled release-candidate validation independently reproduced those three findings inside the 24/24 real-infrastructure matrix.

## Independent review disposition

An independent base/head review returned **APPROVE — no material findings**. Its Issue 32 qualification was accepted: ordinary MCP-resource reachability is already location-neutral on this PR's base, while the environment-only cross-service processor fixed here remains a genuine defect. Issues 33 and 37 and S5-F2 were independently reproduced. S5-F1 was confirmed as a valid validation defect but is now assigned to its merged prerequisite rather than this diff.

No production-code change was added in response because the reviewer found no implementation gap and fresh local/database validation agreed. The meaningful correction is this narrower, evidence-backed statement of PR ownership.

## Reviewer guide

Please focus on:

1. Join eligibility: only observed/exposed material `value_hash` credentials, never `merge_key: identity` syntheses.
2. Cross-service parity across environment, header, argument, and URL credential locations; do not conflate this with the already-correct base `CanReach` resource processor.
3. Exact witness ordering and absence of cartesian target/credential multiplication.
4. Global distinct-agent blast-radius aggregation at `value_hash` grain.
5. Agent/server risk attribution through the canonical identity topology.
6. Neo4j 4.4/5 query compatibility and deterministic repeated results.
7. `via_gateway` fallback selecting only the gateway already present in the proven witness.

## Independent audit material

- [Root-cause index](https://github.com/adithyan-ak/AgentHound/blob/codex/validation-snapshot-20260719/validation/2026-07-19/root-cause-index.md)
- [Independent verdicts](https://github.com/adithyan-ak/AgentHound/blob/codex/validation-snapshot-20260719/validation/2026-07-19/root-cause-verdicts.md)
- [Stack 5 evidence and acceptance matrix](https://github.com/adithyan-ak/AgentHound/blob/codex/validation-snapshot-20260719/validation/2026-07-19/pr-slice-plan.md)

The validation snapshot is audit evidence only and is intentionally outside the product merge chain.

## Review sequence

1. [Realm-bound ingest v3 and release provenance — merged](https://github.com/adithyan-ak/AgentHound/pull/96)
2. [Collector protocol truth and transport-secret closure — merged](https://github.com/adithyan-ak/AgentHound/pull/97)
3. [Owner-scoped graph lifecycle and truthful CLI outcomes — merged](https://github.com/adithyan-ak/AgentHound/pull/98)
4. [Authentication evidence and effective-auth consumers — merged](https://github.com/adithyan-ak/AgentHound/pull/99)
5. [**This PR:** credential topology, correlation, blast radius, and risk](https://github.com/adithyan-ak/AgentHound/pull/100)
6. [Responsive UI, documentation truth, and real-infra oracles](https://github.com/adithyan-ak/AgentHound/pull/101)
