### PR TITLE
Fix release preflight authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          # The probe below supplies the separate tap token. Persisting the
+          # repository token here would send two Authorization headers.
+          persist-credentials: false
 
       - name: Verify release tag and Homebrew tap access
         env:


### PR DESCRIPTION
## Root cause

The new non-mutating Homebrew publishing preflight failed before testing the tap secret. `actions/checkout` persisted AgentHound's repository `Authorization` header in local Git config, and the probe then supplied the separate Homebrew tap token through a second `Authorization` header. GitHub correctly rejected the request with HTTP 400: `Duplicate header: Authorization`.

No tag, release, package, formula, or branch was created or deleted by the failed manual run.

## Fix

Set `persist-credentials: false` on the preflight checkout. Checkout still fetches the exact workflow revision, but it does not retain the repository token. The probe therefore sends only `HOMEBREW_TAP_GITHUB_TOKEN` when opening the tap's Git receive endpoint with `git push --dry-run`.

The actual tag release checkout remains unchanged.

## Validation

- `actionlint` passes for `release.yml`.
- `make prerelease` passes all 13 release gates.
- Version pins remain consistent at v1.0.0.
- Commit author and committer resolve to the `adithyan-ak` GitHub account.

After merge, the manual Release workflow will be rerun on `main`. Pre-v1 public artifacts will not be deleted unless that non-mutating permission probe passes.