### PR TITLE
fix(release): preserve container provenance and curated notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,13 +248,31 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.agenthound
+          load: true
           push: false
+          tags: agenthound:ci
+          build-args: |
+            VERSION=ci-test
+            COMMIT=ci-test-commit
       - name: Build server image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: docker/Dockerfile.agenthound-server
+          load: true
           push: false
+          tags: agenthound-server:ci
+          build-args: |
+            VERSION=ci-test
+            COMMIT=ci-test-commit
+      - name: Verify injected image version metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(docker run --rm agenthound:ci --version)" == \
+            "agenthound version ci-test (commit: ci-test-commit)" ]]
+          [[ "$(docker run --rm agenthound-server:ci --version)" == \
+            "agenthound-server version ci-test (commit: ci-test-commit)" ]]
       - name: Build standard image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare curated release notes
+        shell: bash
+        run: ./scripts/release-notes.sh > "${RUNNER_TEMP}/agenthound-release-notes.md"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
           version: 'v2.15.4'
-          args: release --clean
+          args: release --clean --release-notes=${{ runner.temp }}/agenthound-release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
@@ -128,6 +132,13 @@ jobs:
             exit 1
           fi
 
+          expected_notes="$(cat "${RUNNER_TEMP}/agenthound-release-notes.md")"
+          published_notes="$(gh release view "${tag}" --json body --jq '.body')"
+          if [[ "${published_notes}" != "${expected_notes}" ]]; then
+            echo "Published release notes do not match the curated changelog section" >&2
+            exit 1
+          fi
+
           for formula in agenthound agenthound-server; do
             formula_body="$(GH_TOKEN="${HOMEBREW_TAP_GITHUB_TOKEN}" gh api \
               -H 'Accept: application/vnd.github.raw+json' \
@@ -139,4 +150,11 @@ jobs:
             manifest="$(docker buildx imagetools inspect "ghcr.io/adithyan-ak/${image}:${version}")"
             grep -Fq 'linux/amd64' <<<"${manifest}"
             grep -Fq 'linux/arm64' <<<"${manifest}"
+
+            version_output="$(docker run --rm "ghcr.io/adithyan-ak/${image}:${version}" --version)"
+            expected_output="${image} version ${version} (commit: ${GITHUB_SHA})"
+            if [[ "${version_output}" != "${expected_output}" ]]; then
+              echo "Unexpected ${image} container version: ${version_output}" >&2
+              exit 1
+            fi
           done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,6 +94,8 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=COMMIT={{ .Commit }}"
       - "--label=org.opencontainers.image.title=agenthound"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.source=https://github.com/adithyan-ak/agenthound"
@@ -108,6 +110,8 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=COMMIT={{ .Commit }}"
     extra_files: [collector, server, sdk, modules, go.mod, go.sum]
     goarch: arm64
   - id: agenthound-server
@@ -118,6 +122,8 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=COMMIT={{ .Commit }}"
     extra_files: [collector, server, sdk, modules, go.mod, go.sum]
     goarch: amd64
   - id: agenthound-server-arm64
@@ -128,6 +134,8 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--build-arg=VERSION={{ .Version }}"
+      - "--build-arg=COMMIT={{ .Commit }}"
     extra_files: [collector, server, sdk, modules, go.mod, go.sum]
     goarch: arm64
 

--- a/docker/Dockerfile.agenthound
+++ b/docker/Dockerfile.agenthound
@@ -1,14 +1,16 @@
 # Collector image — lean field binary; no UI, no DBs, no chi/pgx/neo4j.
-# Versioning is handled at release time by goreleaser; this Dockerfile builds
-# an unversioned binary suitable for dev / CI smoke builds.
+# Source/CI builds keep honest dev defaults. GoReleaser supplies VERSION and
+# COMMIT so tagged images report the same provenance as release archives.
 FROM golang:1.25-alpine AS builder
 WORKDIR /src
+ARG VERSION=dev
+ARG COMMIT=none
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
-    -ldflags='-s -w' \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \
     -o /bin/agenthound \
     ./collector/cmd/agenthound
 

--- a/docker/Dockerfile.agenthound-server
+++ b/docker/Dockerfile.agenthound-server
@@ -7,13 +7,15 @@ RUN npm run build
 
 FROM golang:1.25-alpine AS builder
 WORKDIR /src
+ARG VERSION=dev
+ARG COMMIT=none
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=ui-builder /ui/dist ./server/internal/api/ui/dist
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -trimpath \
-    -ldflags='-s -w' \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" \
     -o /bin/agenthound-server \
     ./server/cmd/agenthound-server
 

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Print the changelog title and newest version section for GoReleaser.
+# This keeps public release notes curated while CHANGELOG.md remains the SSOT.
+
+set -eu
+
+changelog=${1:-CHANGELOG.md}
+
+if [ ! -f "$changelog" ]; then
+  echo "release-notes: changelog not found: $changelog" >&2
+  exit 1
+fi
+
+awk '
+  NR == 1 && /^# / {
+    title = $0
+    next
+  }
+
+  /^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)/ {
+    sections++
+    if (sections > 1) {
+      exit
+    }
+
+    if (title != "") {
+      print title
+      print ""
+    }
+    emit = 1
+  }
+
+  emit {
+    print
+  }
+
+  END {
+    if (sections == 0) {
+      print "release-notes: no version section found" > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$changelog"


### PR DESCRIPTION
## Release-blocking defects

Independent verification of the first v1.0.0 publication found two true-positive release defects:

1. Both signed, multi-platform GHCR images were tagged `1.0.0` but their embedded binaries claimed to be development builds:

   ```text
   agenthound version dev (commit: none)
   agenthound-server version dev (commit: none)
   ```

   The native release archives correctly reported `1.0.0` and commit `b618cc17c9b84aa7e002ef9a9955bcd78bea8c3a`, which isolated the defect to the container build path.

2. GoReleaser initially populated the GitHub release body with its raw generated commit history instead of the curated public-launch changelog. The live release body was corrected manually, but the workflow had no durable mechanism or assertion preventing recurrence.

These are release-integrity/presentation defects, not speculative hardening findings. The container runtime and public Compose stack otherwise reached healthy state, rendered all frontend routes, and preserved truthful empty-database states.

## Root cause

- The release Dockerfiles compile from source independently of GoReleaser's archive builds. They used only `-ldflags='-s -w'`, so GoReleaser's version and commit values never reached `main.version` or `main.commit`.
- The GoReleaser action ran without `--release-notes`, so it generated notes from repository commit history rather than the CHANGELOG SSOT.

## Solution

- Add honest Docker build defaults (`VERSION=dev`, `COMMIT=none`) and inject both values into the collector and server linker variables.
- Pass `{{ .Version }}` and `{{ .Commit }}` through every amd64/arm64 GoReleaser Docker definition.
- Make the PR Docker job load both images and assert exact injected version output.
- Extend post-publication verification to run both actual versioned images and require the exact release version plus `GITHUB_SHA`.
- Add `scripts/release-notes.sh`, which prints the changelog title and newest version section while excluding any future Unreleased or older-version sections.
- Pass that curated file to GoReleaser and assert that the published release body matches it exactly.

## Validation performed

- Direct collector/server Docker builds with v1.0.0 inputs: exact version and full commit output passed.
- Default source/CI Docker builds: still truthfully report `dev (commit: none)`.
- GoReleaser 2.15.4 snapshot: all four images (collector/server × amd64/arm64) report `1.0.0-SNAPSHOT-b618cc1` and the full expected commit.
- `scripts/release-notes.sh` output exactly matches the current curated CHANGELOG and the corrected live v1.0.0 release body.
- `goreleaser check`: pass.
- `actionlint` 1.7.7 on CI and release workflows: pass.
- Mandatory checks: `gofmt -l .`, `go build ./...`, `go vet ./...`, and `go test ./... -race`: pass.
- Full `make prerelease` gate: all 13 stages pass.

## Scope and reviewer focus

This PR changes release packaging and its assertions only. It does not alter collectors, ingest semantics, graph analysis, API behavior, database schemas, or frontend functionality.

The public v1.0.0 replacement/retag decision is intentionally separate from this code review; this PR makes the corrected publication deterministic and testable.