### PR TITLE
test: serialize remaining Neo4j integration packages

### DIFF
--- a/server/internal/analysis/prebuilt/main_test.go
+++ b/server/internal/analysis/prebuilt/main_test.go
@@ -1,0 +1,21 @@
+package prebuilt
+
+import (
+	"os"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/server/internal/dbtest"
+)
+
+// TestMain serializes this package's integration tests against the shared Neo4j
+// with every other DB-touching package (see server/internal/dbtest). It is a
+// no-op without AGENTHOUND_NEO4J_URI, so unit-only runs stay parallel.
+func TestMain(m *testing.M) {
+	release, err := dbtest.Lock()
+	if err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	release()
+	os.Exit(code)
+}

--- a/server/internal/analysis/riskscore/main_test.go
+++ b/server/internal/analysis/riskscore/main_test.go
@@ -1,0 +1,21 @@
+package riskscore
+
+import (
+	"os"
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/server/internal/dbtest"
+)
+
+// TestMain serializes this package's integration tests against the shared Neo4j
+// with every other DB-touching package (see server/internal/dbtest). It is a
+// no-op without AGENTHOUND_NEO4J_URI, so unit-only runs stay parallel.
+func TestMain(m *testing.M) {
+	release, err := dbtest.Lock()
+	if err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	release()
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary

- add the existing package-level `dbtest.Lock()` test harness to `analysis/prebuilt`
- add the same harness to `analysis/riskscore`
- serialize all six current Neo4j-touching test packages without changing production code or globally disabling package parallelism

## Root cause

`go test ./...` runs package test binaries concurrently. The repository already serializes Neo4j integration packages with a shared advisory lock, but `analysis/prebuilt` and the recently added `analysis/riskscore` integration package were not participating. That allowed another package to mutate the shared graph while riskscore was calculating an exact assessment; CI observed a score of 10 instead of 18. `prebuilt` was a second latent gap and includes a destructive whole-database reset in its opt-in integration harness.

## Impact

This changes test execution only. Both files are `_test.go` files, and `dbtest.Lock()` is a no-op when `AGENTHOUND_NEO4J_URI` is unset, so ordinary unit-test parallelism and all collector/server behavior remain unchanged.

## Validation

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./... -race`
- Neo4j 4.4: concurrent three-package stress run, `-race -count=10 -p 3`, including the destructive storage-binding lifecycle and both newly locked integration packages
- Neo4j 5: same concurrent stress run
- Neo4j 5: CI-equivalent schema initialization followed by the full live-database `go test ./... -race -count=1` suite