### PR TITLE
Prepare uniform v1.0.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,13 @@ name: Release
 on:
   push:
     tags: ['v*']
-  # A manual run executes only the publishing preflight. It proves that the
-  # Homebrew tap token can open the tap's Git receive endpoint without
-  # creating a commit, tag, branch, release, package, or formula update.
+  # A manual run executes only the publishing preflight: release metadata,
+  # GoReleaser snapshot, and non-mutating Homebrew tap access checks.
   workflow_dispatch:
 
 concurrency:
-  group: agenthound-release-${{ github.ref }}
-  cancel-in-progress: false
+  group: agenthound-release
+  queue: max
 
 permissions:
   contents: write
@@ -28,8 +27,13 @@ jobs:
           # repository token here would send two Authorization headers.
           persist-credentials: false
 
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version: "1.25.12"
+
       - name: Verify release tag and Homebrew tap access
         env:
+          GH_TOKEN: ${{ github.token }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         shell: bash
         run: |
@@ -37,6 +41,19 @@ jobs:
 
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             ./scripts/version-check.sh
+            git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
+            tag_commit="$(git rev-parse --verify "${GITHUB_REF_NAME}^{commit}")"
+            if ! git merge-base --is-ancestor "${tag_commit}" refs/remotes/origin/main; then
+              echo "Release tag ${GITHUB_REF_NAME} does not point to an ancestor of origin/main" >&2
+              exit 1
+            fi
+
+            latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"
+            highest_tag="$(printf '%s\n' "${latest_tag}" "${GITHUB_REF_NAME}" | sort -V | tail -n 1)"
+            if [[ "${latest_tag}" == "${GITHUB_REF_NAME}" || "${highest_tag}" != "${GITHUB_REF_NAME}" ]]; then
+              echo "Release tag ${GITHUB_REF_NAME} must be newer than current latest ${latest_tag}" >&2
+              exit 1
+            fi
           fi
 
           if [[ -z "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
@@ -57,6 +74,18 @@ jobs:
           git fetch --quiet "${tap_url}" "${tap_sha}"
           git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
             push --dry-run "${tap_url}" "${tap_sha}:refs/heads/main"
+
+      - name: Check GoReleaser configuration
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
+        with:
+          version: 'v2.15.4'
+          args: check
+
+      - name: Run GoReleaser snapshot preflight
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
+        with:
+          version: 'v2.15.4'
+          args: release --clean --snapshot --skip=docker,sign,sbom
 
   release:
     needs: publishing-preflight
@@ -105,7 +134,7 @@ jobs:
 
       - name: Prepare curated release notes
         shell: bash
-        run: ./scripts/release-notes.sh > "${RUNNER_TEMP}/agenthound-release-notes.md"
+        run: ./scripts/release-notes.sh CHANGELOG.md "${GITHUB_REF_NAME}" > "${RUNNER_TEMP}/agenthound-release-notes.md"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
@@ -126,35 +155,168 @@ jobs:
 
           tag="${GITHUB_REF_NAME}"
           version="${tag#v}"
-          asset_count="$(gh release view "${tag}" --json assets --jq '.assets | length')"
+          repo="${GITHUB_REPOSITORY}"
+          tag_commit="$(git rev-parse --verify "${tag}^{commit}")"
+          module="github.com/adithyan-ak/agenthound"
+
+          latest_tag="$(gh api "repos/${repo}/releases/latest" --jq '.tag_name')"
+          if [[ "${latest_tag}" != "${tag}" ]]; then
+            echo "Latest GitHub release is ${latest_tag}, expected ${tag}" >&2
+            exit 1
+          fi
+
+          asset_count="$(gh release view --repo "${repo}" "${tag}" --json assets --jq '.assets | length')"
           if [[ "${asset_count}" != "26" ]]; then
             echo "Expected 26 release assets, found ${asset_count}" >&2
             exit 1
           fi
 
           expected_notes="$(cat "${RUNNER_TEMP}/agenthound-release-notes.md")"
-          published_notes="$(gh release view "${tag}" --json body --jq '.body')"
+          published_notes="$(gh release view --repo "${repo}" "${tag}" --json body --jq '.body')"
           if [[ "${published_notes}" != "${expected_notes}" ]]; then
             echo "Published release notes do not match the curated changelog section" >&2
             exit 1
           fi
 
+          verify_dir="$(mktemp -d)"
+          gh release download --repo "${repo}" "${tag}" --pattern checksums.txt --dir "${verify_dir}"
+
           for formula in agenthound agenthound-server; do
             formula_body="$(GH_TOKEN="${HOMEBREW_TAP_GITHUB_TOKEN}" gh api \
               -H 'Accept: application/vnd.github.raw+json' \
               "repos/adithyan-ak/homebrew-agenthound/contents/Formula/${formula}.rb")"
-            grep -Fq "version \"${version}\"" <<<"${formula_body}"
+            if ! grep -Fq "version \"${version}\"" <<<"${formula_body}"; then
+              echo "Homebrew formula ${formula} does not declare version ${version}" >&2
+              exit 1
+            fi
+
+            mapfile -t formula_urls < <(sed -nE 's/^[[:space:]]*url "([^"]+)".*/\1/p' <<<"${formula_body}")
+            mapfile -t formula_sums < <(sed -nE 's/^[[:space:]]*sha256 "([0-9a-f]{64})".*/\1/p' <<<"${formula_body}")
+            if (( ${#formula_urls[@]} == 0 || ${#formula_urls[@]} != ${#formula_sums[@]} )); then
+              echo "Homebrew formula ${formula} has unpaired URL/checksum entries" >&2
+              exit 1
+            fi
+
+            for index in "${!formula_urls[@]}"; do
+              formula_url="${formula_urls[$index]}"
+              formula_sum="${formula_sums[$index]}"
+              asset="${formula_url##*/}"
+              if [[ "${formula_url}" != *"/releases/download/${tag}/"* ]] ||
+                 [[ "${asset}" != "${formula}_${version}_darwin_"* ]]; then
+                echo "Unexpected Homebrew URL for ${formula}: ${formula_url}" >&2
+                exit 1
+              fi
+              release_sum="$(awk -v asset="${asset}" '$2 == asset { print $1 }' "${verify_dir}/checksums.txt")"
+              if [[ -z "${release_sum}" || "${formula_sum}" != "${release_sum}" ]]; then
+                echo "Homebrew checksum mismatch for ${asset}" >&2
+                exit 1
+              fi
+            done
           done
 
           for image in agenthound agenthound-server; do
-            manifest="$(docker buildx imagetools inspect "ghcr.io/adithyan-ak/${image}:${version}")"
+            version_image="ghcr.io/adithyan-ak/${image}:${version}"
+            latest_image="ghcr.io/adithyan-ak/${image}:latest"
+            manifest="$(docker buildx imagetools inspect "${version_image}")"
             grep -Fq 'linux/amd64' <<<"${manifest}"
             grep -Fq 'linux/arm64' <<<"${manifest}"
 
-            version_output="$(docker run --rm "ghcr.io/adithyan-ak/${image}:${version}" --version)"
-            expected_output="${image} version ${version} (commit: ${GITHUB_SHA})"
+            version_digest="$(docker buildx imagetools inspect --raw "${version_image}" | sha256sum | awk '{print $1}')"
+            latest_digest="$(docker buildx imagetools inspect --raw "${latest_image}" | sha256sum | awk '{print $1}')"
+            if [[ "${version_digest}" != "${latest_digest}" ]]; then
+              echo "GHCR ${image}:latest and :${version} resolve to different manifests" >&2
+              exit 1
+            fi
+
+            version_output="$(docker run --rm "${version_image}" --version)"
+            expected_output="${image} version ${version} (commit: ${tag_commit})"
             if [[ "${version_output}" != "${expected_output}" ]]; then
               echo "Unexpected ${image} container version: ${version_output}" >&2
+              exit 1
+            fi
+          done
+          if ! grep -Eq '^[[:space:]]*image:[[:space:]]*ghcr\.io/adithyan-ak/agenthound-server:latest[[:space:]]*$' \
+            docker/docker-compose.public.yml; then
+            echo "Public Docker Compose no longer defaults to agenthound-server:latest" >&2
+            exit 1
+          fi
+
+          installer_dir="$(mktemp -d)"
+          curl -sSfL "https://raw.githubusercontent.com/${repo}/main/install.sh" |
+            env -u AGENTHOUND_VERSION AGENTHOUND_INSTALL_DIR="${installer_dir}" sh
+          installer_output="$("${installer_dir}/agenthound" --version)"
+          expected_installer_output="agenthound version ${version} (commit: ${tag_commit})"
+          if [[ "${installer_output}" != "${expected_installer_output}" ]]; then
+            echo "Default installer resolved unexpected build: ${installer_output}" >&2
+            exit 1
+          fi
+
+          go_verify_dir="$(mktemp -d)"
+          latest_json=""
+          for attempt in $(seq 1 12); do
+            attempt_modcache="${go_verify_dir}/mod-${attempt}"
+            candidate="$(GOWORK=off GOMODCACHE="${attempt_modcache}" GOPROXY=https://proxy.golang.org \
+              GOSUMDB=sum.golang.org timeout 60s go list -m -json "${module}@latest" 2>&1 || true)"
+            candidate_version="$(jq -r '.Version // empty' <<<"${candidate}" 2>/dev/null || true)"
+            if [[ "${candidate_version}" == "${tag}" ]]; then
+              latest_json="${candidate}"
+              break
+            fi
+            echo "Go proxy latest is ${candidate_version:-unavailable}; waiting for ${tag} (${attempt}/12)"
+            sleep 10
+          done
+          if [[ -z "${latest_json}" ]]; then
+            echo "Go proxy did not resolve ${module}@latest to ${tag}" >&2
+            exit 1
+          fi
+
+          origin_hash="$(jq -r '.Origin.Hash // "not reported"' <<<"${latest_json}")"
+          echo "Go latest Origin.Hash (diagnostic only): ${origin_hash}"
+
+          versions_modcache="${go_verify_dir}/versions-modcache"
+          normal_versions="$(GOWORK=off GOMODCACHE="${versions_modcache}" GOPROXY=https://proxy.golang.org \
+            GOSUMDB=sum.golang.org timeout 60s go list -m -versions -json "${module}@latest")"
+          all_versions="$(GOWORK=off GOMODCACHE="${versions_modcache}" GOPROXY=https://proxy.golang.org \
+            GOSUMDB=sum.golang.org timeout 60s go list -m -versions -retracted -json "${module}@latest")"
+          if ! jq -e --arg latest "${tag}" \
+            '.Version == $latest and (.Versions | index($latest) != null)' <<<"${normal_versions}" >/dev/null; then
+            echo "Normal Go version listing does not select and include ${tag}" >&2
+            exit 1
+          fi
+
+          retracted_versions=(v0.5.0 v0.6.0 v0.6.1 v0.7.0 v0.8.0 v0.9.0 v1.0.0)
+          for retracted in "${retracted_versions[@]}"; do
+            if jq -e --arg version "${retracted}" '.Versions | index($version) != null' \
+              <<<"${normal_versions}" >/dev/null; then
+              echo "Normal Go version listing still includes retracted ${retracted}" >&2
+              exit 1
+            fi
+            if ! jq -e --arg version "${retracted}" '.Versions | index($version) != null' \
+              <<<"${all_versions}" >/dev/null; then
+              echo "Go -retracted version listing omits published ${retracted}" >&2
+              exit 1
+            fi
+          done
+
+          download_json="$(GOWORK=off GOMODCACHE="${go_verify_dir}/download-modcache" \
+            GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
+            timeout 60s go mod download -json "${module}@${tag}")"
+          if ! jq -e --arg version "${tag}" '.Version == $version' <<<"${download_json}" >/dev/null; then
+            echo "go mod download did not resolve ${module}@${tag}" >&2
+            exit 1
+          fi
+
+          mkdir -p "${go_verify_dir}/bin" "${go_verify_dir}/install-modcache" "${go_verify_dir}/build-cache"
+          for command_path in collector/cmd/agenthound server/cmd/agenthound-server; do
+            GOWORK=off GOBIN="${go_verify_dir}/bin" GOMODCACHE="${go_verify_dir}/install-modcache" \
+              GOCACHE="${go_verify_dir}/build-cache" GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
+              timeout 10m go install "${module}/${command_path}@latest"
+          done
+          for binary in agenthound agenthound-server; do
+            source_output="$("${go_verify_dir}/bin/${binary}" --version)"
+            expected_source_output="${binary} version ${version} (commit: none)"
+            if [[ "${source_output}" != "${expected_source_output}" ]]; then
+              echo "Unexpected go install provenance for ${binary}: ${source_output}" >&2
               exit 1
             fi
           done

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -13,7 +13,14 @@ on:
       - "install.sh"
       - "README.md"
       - "CHANGELOG.md"
+      - "go.mod"
+      - ".goreleaser.yml"
+      - "Makefile"
+      - "scripts/release-notes.sh"
+      - "scripts/release-process-test.sh"
+      - "scripts/sync-version.sh"
       - "scripts/version-check.sh"
+      - ".github/workflows/release.yml"
       - ".github/workflows/version-check.yml"
 
 concurrency:
@@ -28,5 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - name: Version pins match the CHANGELOG
-        run: bash scripts/version-check.sh
+      - name: Release metadata checks
+        run: make version-check
+      - name: Check GoReleaser configuration
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
+        with:
+          version: 'v2.15.4'
+          args: check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,157 @@
 
 ## Unreleased
 
-- Replace configured host/network realms with automatic ingest-v4 collection
-  points and network contexts. Ambiguous graph IDs, coverage ownership, and
-  cross-observation processors are scoped per vantage; weak identities remain
-  analyzable under artifact-local additive-only scope.
-- Generate PostgreSQL/Neo4j storage pairing internally, accept valid artifacts
-  from multiple vantages, expose identity recognition in ingest results, and
-  define v4 as a clean database boundary without unsafe per-point purge.
-- Correct documentation and source comments against the v1 implementation,
-  including credential-material semantics, graph variants, CLI workflows,
-  contributor paths, environment requirements, and historical version labels.
-- Align the legacy `EdgeRiskWeight` helper with the canonical v1 risk table for
-  Basic, OIDC, and unknown/custom authentication.
-- Upgrade `golang.org/x/text` to 0.39.0 to address the reachable
+## v1.0.1 — 🚀 First Supported Public Release (2026-07-22)
+
+AgentHound v1.0.1 is the first supported public release of an offensive
+security framework built specifically for AI agent infrastructure. It brings
+the relationship-driven analysis of an attack graph to MCP, A2A, agent
+configuration, model infrastructure, credentials, tools, resources, and
+instruction supply chains—then lets operators validate predicted paths against
+real systems with evidence-backed, reversible workflows.
+
+> **From observation to proof.** Discover the agentic estate, reveal the paths
+> that matter, and validate them against real infrastructure.
+
+| 🗺️ Discover | 🧠 Correlate | 🎯 Validate | 🔎 Investigate | 📦 Ship |
+|---|---|---|---|---|
+| MCP, A2A, configs, AI services | Temporal attack graph | Reversible campaigns | Evidence-backed UI | Signed multi-platform artifacts |
+
+### 🗺️ Map the agentic attack surface
+
+- **One graph across the agentic stack.** Model agents, MCP servers, tools,
+  prompts, resources, A2A agents, AI services, credentials, instruction files,
+  hosts, models, and their trust relationships in one temporal attack graph.
+- **Broad local configuration coverage.** Discover MCP and agent configuration
+  across Claude Desktop, Claude Code, VS Code, Windsurf, Continue, Zed, Cline,
+  JetBrains, Kiro, Amazon Q, and Augment, including nested project rules and
+  instruction files.
+- **Protocol-aware MCP and A2A collection.** Enumerate live MCP capabilities
+  through the official SDK and ingest A2A v0.3 and v1.0.1 Agent Cards with
+  schema-aware parsing, interface preservation, authentication requirements,
+  and bounded JWS verification.
+- **Port-neutral AI service discovery.** Fingerprint Ollama, Open WebUI,
+  LiteLLM, vLLM, LangServe, MLflow, Qdrant, and Jupyter from observed protocol
+  behavior rather than assuming a service from its port number.
+- **Evidence-backed inventory.** Read-only looters cover LiteLLM, Ollama,
+  Open WebUI, MLflow, Qdrant, and Jupyter while distinguishing verified
+  anonymous access, authenticated access, partial inventory, and unknown state.
+
+### 🧠 Turn observations into defensible attack paths
+
+- **Deterministic cross-collector identity.** Content-addressed node IDs merge
+  the same infrastructure across collectors, while stable credential hashes
+  correlate a secret observed in configuration with the service that accepts
+  or exposes it—without persisting the raw value by default.
+- **Vantage-aware temporal ingestion.** Ingest v4 derives collection-point and
+  network-context provenance automatically. Ambiguous identities, lifecycle
+  ownership, and cross-observation processing remain scoped per vantage, while
+  weak identity stays analyzable under artifact-local additive-only scope.
+- **Coverage-aware temporal ingestion.** Collection domains declare what they
+  observed completely, partially, or not at all. Complete epochs retire stale
+  truth and rebuild derived relationships; incomplete scans cannot silently
+  present an authoritative clean posture.
+- **Ordered graph reasoning.** Post-processors derive access, execution,
+  shadowing, poisoned content, reachability, credential chains, exfiltration,
+  impersonation, cross-protocol paths, and risk scores from the retained raw
+  evidence.
+- **Canonical risk semantics.** The legacy `EdgeRiskWeight` helper and the v1
+  risk table now agree for Basic, OIDC, and unknown or custom authentication.
+- **Evidence-first findings.** Prebuilt attack paths, finding detail,
+  remediation guidance, graph evidence, and stable witness export keep each
+  security conclusion tied to the nodes, edges, provenance, and publication
+  revision that produced it.
+- **Rules with provenance.** Built-in detection and fingerprint rules cover
+  agent capabilities, credentials, prompt and instruction injection, exposed
+  services, and supply-chain risk. Each collection records the effective rule
+  manifest so reviewers can identify the semantics behind an observation.
+
+### 🎯 Validate the graph against real infrastructure
+
+- **Predicted-to-verified campaigns.** `agenthound campaign` converts a graph
+  hypothesis into observed evidence. Credential-reach campaigns compare an
+  anonymous control with a hash-matched authenticated probe and upgrade the
+  existing predicted finding when gated access is proven.
+- **ContextForge MCP round trips.** Provider-aware MCP tool-description
+  campaigns bind a live MCP tool to its exact ContextForge row, apply a benign
+  run-specific marker, verify it through management and MCP surfaces, restore
+  the original value, and independently report mutation and cleanup outcomes.
+- **Reversible offensive primitives.** Authorized extraction, poisoning,
+  implantation, campaign, and recovery workflows are dry-run-first. Mutating
+  operations persist typed recovery receipts before the write, use bounded
+  verification, and retain the receipt whenever cleanup is incomplete.
+- **Truthful runtime evidence.** A2A authentication probes, MCP observations,
+  Jupyter access checks, looter authentication results, and campaign outcomes
+  record only states proven by protocol-correct responses; ambiguity remains
+  visible instead of being promoted into a security claim.
+
+### 🛡️ Built for trustworthy field use
+
+- **Lean collector boundary.** `agenthound` is a static field binary with no
+  Neo4j, PostgreSQL, web-server, or `server/internal` dependency. Dependency
+  and stripped-size gates enforce that boundary on every release.
+- **Local-first analysis.** `agenthound-server` combines PostgreSQL, Neo4j,
+  post-processing, the REST API, and an embedded React UI while binding to
+  `127.0.0.1:8080` by default.
+- **Automatic storage pairing.** The server generates and validates the
+  PostgreSQL/Neo4j storage pairing internally, accepts artifacts from multiple
+  recognized vantages, and reports identity recognition in ingest results.
+- **Clean ingest-v4 boundary.** Version 4 artifacts require a fresh database,
+  avoiding unsafe per-point purge while the retained projection moves from the
+  former single-realm model to automatic vantage-aware ownership.
+- **Strict transport defaults.** MCP and A2A TLS verification is on by default;
+  insecure transport requires an explicit operator choice. Active operations
+  require an `AUTHORIZED` acknowledgement and record engagement provenance.
+- **Dependency remediation.** `golang.org/x/text` 0.39.0 closes the reachable
   `GO-2026-5970` invalid-input infinite loop reported by `govulncheck`.
 
+### 🔎 Investigation-ready frontend
+
+- **Dashboard and triage.** Review exposure, risk distribution, credential
+  posture, chokepoints, cross-protocol reach, high-risk entities, and current
+  findings from the same published graph revision.
+- **Interactive graph explorer.** Navigate the React Flow + ELK graph through
+  security lenses, search, evidence drawers, relationship semantics, attack
+  paths, and exportable investigation context.
+- **Reviewer-friendly findings.** Finding pages expose the supporting path,
+  verification status, remediation, property evidence, and copy-ready reports
+  without flattening predicted and observed claims into the same state.
+- **Operator-guided collection.** Scan Manager generates origin-correct,
+  copyable commands for configuration, MCP, A2A, discovery, and service
+  collection workflows.
+
+### 📦 Verifiable multi-platform release
+
+- ✅ Collector and server archives for macOS, Linux, and Windows on amd64 and
+  arm64.
+- ✅ Multi-architecture `agenthound` and `agenthound-server` images on GHCR.
+- ✅ SHA-256 checksums, keyless Sigstore verification bundles, and per-archive
+  software bills of materials.
+- ✅ Homebrew formulas for the collector and analysis server.
+- ✅ Public Docker Compose deployment with health-checked PostgreSQL, Neo4j, and
+  the loopback-bound AgentHound server.
+- ✅ Tagged archives and containers carry the GoReleaser-injected source commit;
+  `go install ...@latest` derives its module version from Go build metadata and
+  truthfully reports `commit: none` when no linker commit was injected.
+- ✅ Release gates reject drift across every installer pin and require an empty
+  Unreleased section on tag builds. Publication verification covers the latest
+  GitHub release, GHCR tag digests, Homebrew URLs and checksums, the default
+  installer, Go module retractions, and fresh source installs.
+
+### ✅ Release confidence
+
+This release was validated end to end against the project’s real disposable
+infrastructure: collection, ingest lifecycle, database binding, derived graph,
+API responses, browser representation, recovery paths, upgrades, release
+gates, and distribution configuration. Documentation and source comments were
+also reconciled against the shipped v1 implementation and release process.
+
 ## v1.0.0 — 🚀 First Supported Public Release (2026-07-20)
+
+> **Retracted historical publication.** This section preserves the original
+> v1.0.0 notes. That publication is unsupported because GitHub and the Go
+> module proxy resolved it to different source commits. v1.0.1 is the first
+> supported public release.
 
 AgentHound v1.0.0 is the first supported public release of an offensive
 security framework built specifically for AI agent infrastructure. It brings

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: build build-collector build-server build-all test lint docker docker-collector docker-server docker-standard up down clean seed release ui-build ui-dev ui-test standard standard-run standard-stop deps-check size-check slop-check version-check sync-version docs-check prerelease preflight-build preflight-collector preflight-server preflight-docker preflight-docker-compose preflight-server-running
 
+# Release tooling is pinned independently of the project's Go version.
+# Go may download the tool's newer required toolchain on the first local run.
+GORELEASER := go run github.com/goreleaser/goreleaser/v2@v2.15.4
+
 # Preflight gates. Verify required tools are present and at the expected
 # major versions BEFORE attempting a build, so newcomers get a friendly
 # error instead of a cryptic "command not found" deep in the chain.
@@ -81,7 +85,8 @@ seed: preflight-server-running
 	@bash scripts/seed-test-data.sh
 
 release: ui-build
-	goreleaser release --clean --snapshot
+	$(GORELEASER) check
+	$(GORELEASER) release --clean --snapshot
 
 standard: preflight-docker
 	docker build -f docker/Dockerfile.standard -t agenthound:latest .
@@ -119,6 +124,7 @@ slop-check:
 # it at tag time too.
 version-check:
 	@bash scripts/version-check.sh
+	@bash scripts/release-process-test.sh
 
 # Rewrite the install.sh + README version pins from the CHANGELOG top header
 # (or VERSION=). Usage: make sync-version   or   make sync-version VERSION=0.7.1
@@ -138,6 +144,7 @@ docs-check:
 prerelease:
 	@echo "=== [1/13] version-check ==="
 	@bash scripts/version-check.sh
+	@bash scripts/release-process-test.sh
 	@echo "=== [2/13] gofmt ==="
 	@test -z "$$(gofmt -l .)" || (echo "FAIL: gofmt found unformatted files:" && gofmt -l . && exit 1)
 	@echo "=== [3/13] golangci-lint ==="

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ ingest. The derived IDs are provenance, not authentication.
 Prefer a reproducible, pinned install? Every release is cosign-signed with an SBOM:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v1.0.0/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v1.0.1/install.sh | sh
 ```
 
 Also available via Homebrew (`brew tap adithyan-ak/agenthound`, then

--- a/collector/cmd/agenthound/main.go
+++ b/collector/cmd/agenthound/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/adithyan-ak/agenthound/collector/cli"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 
 	// Blank-import modules so their init() registers them with sdk/module.
 	_ "github.com/adithyan-ak/agenthound/modules/a2a"
@@ -39,6 +40,7 @@ var (
 )
 
 func main() {
+	version, commit = common.ResolveBuildInfo(version, commit)
 	cli.SetVersion(version, commit)
 	if cli.HandleUnknownCommand() {
 		return

--- a/docs/operator/discover.md
+++ b/docs/operator/discover.md
@@ -47,7 +47,7 @@ The output file is a standard ingest envelope. `discover` emits raw `:MCPServer`
     "version": 4,
     "type": "agenthound-ingest",
     "collector": "scan",
-    "collector_version": "1.0.0",
+    "collector_version": "1.0.1",
     "timestamp": "2026-07-11T20:00:00Z",
     "scan_id": "...",
     "identity": {

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -269,7 +269,7 @@ credential material.
     "version": 4,
     "type": "agenthound-ingest",
     "collector": "mcp",
-    "collector_version": "1.0.0",
+    "collector_version": "1.0.1",
     "timestamp": "2026-07-11T00:00:00Z",
     "scan_id": "scan-abc123",
     "identity": {

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -592,7 +592,7 @@ New modules emit nodes and edges via the `sdk/ingest` wire format:
     "version": 4,
     "type": "agenthound-ingest",
     "collector": "mcp|a2a|config|scan",
-    "collector_version": "1.0.0",
+    "collector_version": "1.0.1",
     "timestamp": "2025-01-15T10:30:00Z",
     "scan_id": "scan-abc123",
     "identity": {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/adithyan-ak/agenthound
 
 go 1.25.12
 
+// v0.5.0 through v1.0.0 are superseded unsupported publications; v1.0.0 is
+// inconsistent across GitHub and the Go module proxy. Use v1.0.1 or later.
+retract [v0.5.0, v1.0.0]
+
 require (
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/cors v1.2.2

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # AgentHound collector installer.
 #
 # Pin to a release tag for integrity:
-#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v1.0.0/install.sh | sh
+#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v1.0.1/install.sh | sh
 #
 # Verifies the downloaded archive against checksums.txt before extracting,
 # and against cosign signatures if cosign is available on $PATH.

--- a/modules/protoscan/scanner.go
+++ b/modules/protoscan/scanner.go
@@ -302,7 +302,7 @@ func (s *Scanner) probeMCP(ctx context.Context, baseURL string) (string, bool) {
 			"capabilities":    map[string]any{},
 			"clientInfo": map[string]any{
 				"name":    "agenthound-protoscan",
-				"version": "0.3.0-dev",
+				"version": common.CollectorVersion(),
 			},
 		},
 	})

--- a/modules/protoscan/scanner_test.go
+++ b/modules/protoscan/scanner_test.go
@@ -2,6 +2,7 @@ package protoscan
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
@@ -74,6 +76,42 @@ func TestScan_DiscoversMCP(t *testing.T) {
 	}
 	if got := targets[0].Meta["protocol"]; got != "mcp" {
 		t.Errorf("protocol = %q, want mcp", got)
+	}
+}
+
+func TestProbeMCP_UsesCollectorVersion(t *testing.T) {
+	previousVersion := common.CollectorVersion()
+	t.Cleanup(func() { common.SetCollectorVersion(previousVersion) })
+	common.SetCollectorVersion("1.0.1")
+
+	versions := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Params struct {
+				ClientInfo struct {
+					Version string `json:"version"`
+				} `json:"clientInfo"`
+			} `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode initialize request: %v", err)
+		}
+		versions <- request.Params.ClientInfo.Version
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(initializeOK))
+	}))
+	defer srv.Close()
+
+	s := &Scanner{Mode: ModeMCP, MCPPorts: []int{portOf(t, srv)}}
+	targets, err := s.Scan(context.Background(), "127.0.0.1")
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 MCP target, got %d", len(targets))
+	}
+	if got := <-versions; got != "1.0.1" {
+		t.Errorf("clientInfo.version = %q, want %q", got, "1.0.1")
 	}
 }
 

--- a/scripts/collector-allowlist.txt
+++ b/scripts/collector-allowlist.txt
@@ -253,6 +253,7 @@ regexp
 regexp/syntax
 runtime
 runtime/cgo
+runtime/debug
 slices
 sort
 strconv

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
 # Print the changelog title and newest version section for GoReleaser.
-# This keeps public release notes curated while CHANGELOG.md remains the SSOT.
 
 set -eu
 
 changelog=${1:-CHANGELOG.md}
+expected=${2:-}
+expected=${expected#v}
 
 if [ ! -f "$changelog" ]; then
   echo "release-notes: changelog not found: $changelog" >&2
   exit 1
 fi
+if [ -n "$expected" ] && ! printf '%s\n' "$expected" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "release-notes: invalid expected version: $expected" >&2
+  exit 1
+fi
 
-awk '
+awk -v expected="$expected" '
   NR == 1 && /^# / {
     title = $0
     next
@@ -23,6 +28,13 @@ awk '
       exit
     }
 
+    version = $0
+    sub(/^## v/, "", version)
+    sub(/[[:space:]].*$/, "", version)
+    if (expected != "" && version != expected) {
+      print "release-notes: newest version v" version " does not match expected v" expected > "/dev/stderr"
+      exit 2
+    }
     if (title != "") {
       print title
       print ""
@@ -32,11 +44,18 @@ awk '
 
   emit {
     print
+    if ($0 !~ /^## / && $0 ~ /[^[:space:]]/) {
+      body = 1
+    }
   }
 
   END {
     if (sections == 0) {
       print "release-notes: no version section found" > "/dev/stderr"
+      exit 1
+    }
+    if (!body) {
+      print "release-notes: newest version section is empty" > "/dev/stderr"
       exit 1
     }
   }

--- a/scripts/release-process-test.sh
+++ b/scripts/release-process-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+test_root=$(mktemp -d)
+pin_base=https://raw.githubusercontent.com/adithyan-ak/agenthound
+trap 'rm -rf "$test_root"' EXIT
+
+new_fixture() {
+  local name=$1 root="$test_root/$1"
+  mkdir -p "$root/scripts"
+  cp "$repo_root/scripts/version-check.sh" "$root/scripts/"
+  cp "$repo_root/scripts/sync-version.sh" "$root/scripts/"
+  cp "$repo_root/scripts/release-notes.sh" "$root/scripts/"
+  cat > "$root/CHANGELOG.md" <<'EOF'
+# AgentHound Changelog
+
+## Unreleased
+
+## v1.0.1 — Release (2026-07-22)
+
+Release body.
+
+## v1.0.0 — Historical (2026-07-20)
+
+Historical body.
+EOF
+  printf '# curl -sSfL %s/v1.0.1/install.sh | sh\n' "$pin_base" > "$root/install.sh"
+  printf 'curl -sSfL %s/v1.0.1/install.sh | sh\n' "$pin_base" > "$root/README.md"
+  printf '%s\n' "$root"
+}
+
+expect_failure() {
+  local description=$1
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "release-process-test: expected failure: $description" >&2
+    exit 1
+  fi
+}
+
+happy=$(new_fixture happy)
+(cd "$happy" && bash scripts/version-check.sh >/dev/null)
+(cd "$happy" && GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.0.1 bash scripts/version-check.sh >/dev/null)
+
+mismatch=$(new_fixture mismatch)
+sed -i.bak 's/v1\.0\.1/v1.0.0/' "$mismatch/README.md"
+rm "$mismatch/README.md.bak"
+expect_failure "mismatched installer pin" bash "$mismatch/scripts/version-check.sh"
+
+duplicate=$(new_fixture duplicate)
+printf '%s/v1.0.1/install.sh\n' "$pin_base" >> "$duplicate/README.md"
+expect_failure "duplicate installer pin" bash "$duplicate/scripts/version-check.sh"
+before_sync=$(cksum "$duplicate/install.sh" "$duplicate/README.md")
+expect_failure "sync with duplicate installer pin" bash "$duplicate/scripts/sync-version.sh" 1.0.2
+after_sync=$(cksum "$duplicate/install.sh" "$duplicate/README.md")
+if [ "$before_sync" != "$after_sync" ]; then
+  echo "release-process-test: failed sync mutated a fixture" >&2
+  exit 1
+fi
+
+unreleased=$(new_fixture unreleased)
+sed -i.bak '/## Unreleased/a\
+Pending change.' "$unreleased/CHANGELOG.md"
+rm "$unreleased/CHANGELOG.md.bak"
+expect_failure "non-empty Unreleased on tag" env GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.0.1 \
+  bash "$unreleased/scripts/version-check.sh"
+
+sync=$(new_fixture sync)
+(cd "$sync" && bash scripts/sync-version.sh 1.0.2 >/dev/null)
+if [ "$(grep -RhoE 'agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh' "$sync/install.sh" "$sync/README.md" | sort -u)" != "agenthound/v1.0.2/install.sh" ]; then
+  echo "release-process-test: sync did not update both pins" >&2
+  exit 1
+fi
+
+notes=$(new_fixture notes)
+rendered=$(cd "$notes" && sh scripts/release-notes.sh CHANGELOG.md v1.0.1)
+printf '%s\n' "$rendered" | grep -Fq '## v1.0.1 — Release'
+if printf '%s\n' "$rendered" | grep -Fq '## v1.0.0'; then
+  echo "release-process-test: release notes included a historical section" >&2
+  exit 1
+fi
+expect_failure "release-notes version mismatch" sh "$notes/scripts/release-notes.sh" "$notes/CHANGELOG.md" v1.0.2
+
+echo "release-process-test: all checks passed"

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
-# sync-version.sh [X.Y.Z] — rewrite the install.sh + README install-pin
-# examples so they match a version. With no argument the version is taken from
-# the first "## vX.Y.Z" header in CHANGELOG.md (the source of truth).
-#
-# Release prep:
-#   1. write the new "## vX.Y.Z" section in CHANGELOG.md
-#   2. make sync-version
-#   3. make version-check   (or make prerelease)
+# Rewrite the repository's two tagged installer URLs to a release version.
 
 set -euo pipefail
 
@@ -15,26 +8,34 @@ cd "$(dirname "$0")/.."
 ver="${1:-}"
 ver="${ver#v}"
 if [ -z "$ver" ]; then
-  ver=$(grep -m1 -oE '^## v[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | sed 's/^## v//' || true)
+  ver=$(grep -m1 -E '^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' CHANGELOG.md \
+    | sed -nE 's/^## v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' || true)
 fi
-if [ -z "$ver" ]; then
-  echo "sync-version: no version given and no '## vX.Y.Z' header in CHANGELOG.md"
-  exit 1
-fi
-# Guard the substitution: a non-X.Y.Z value (typo'd VERSION= or sed-special
-# characters like & or #) would otherwise mutate / corrupt the pins in place.
-if ! echo "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "sync-version: '$ver' is not a valid X.Y.Z version"
+if ! printf '%s\n' "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "sync-version: '${ver:-<empty>}' is not a valid X.Y.Z version"
   exit 1
 fi
 
-# Portable in-place sed (GNU uses -i; BSD/macOS needs -i '').
+pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh'
+files=(install.sh README.md)
+
+# Validate both files before mutating either one. This prevents a duplicate or
+# missing URL from producing a partially synchronized release-prep diff.
+for file in "${files[@]}"; do
+  count=$(grep -oE "$pin_pattern" "$file" | wc -l | tr -d '[:space:]' || true)
+  if [ "$count" -ne 1 ]; then
+    echo "sync-version: $file has $count tagged installer URLs, expected exactly 1"
+    exit 1
+  fi
+done
+
 sedi() {
   if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi
 }
 
-for f in install.sh README.md; do
-  sedi -E "s#agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh#agenthound/v${ver}/install.sh#g" "$f"
-  echo "sync-version: set v${ver} pin in $f"
+replacement="https://raw.githubusercontent.com/adithyan-ak/agenthound/v${ver}/install.sh"
+for file in "${files[@]}"; do
+  sedi -E "s#${pin_pattern}#${replacement}#g" "$file"
+  echo "sync-version: set v${ver} pin in $file"
 done
-echo "sync-version: done. Run 'make version-check' to confirm."
+echo "sync-version: updated exactly 2 tagged installer URLs. Run 'make version-check' to confirm."

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -1,52 +1,49 @@
 #!/usr/bin/env bash
-# version-check.sh — assert the hand-maintained version pins agree with the
-# CHANGELOG, the single source of truth (SSOT). GoReleaser injects the
-# binary / Docker / Homebrew versions from the git tag, so the only strings
-# that can silently drift are the install.sh + README curl examples.
-#
-# SSOT: the first "## vX.Y.Z" header in CHANGELOG.md. "## Unreleased" sits
-# above it during a cycle and is skipped, so mid-cycle this resolves to the
-# last released version — which the pins already match.
-#
-# Run via `make version-check`; also runs inside `make prerelease`, so the
-# release pipeline (release.yml -> make prerelease) cannot publish a release
-# whose pins disagree with the CHANGELOG. On a tag build it additionally
-# asserts the pushed tag equals the CHANGELOG version.
-#
-# Blocking gate: returns non-zero on any mismatch.
+# Assert that release metadata agrees with CHANGELOG.md, the version SSOT.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-ver=$(grep -m1 -oE '^## v[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | sed 's/^## v//' || true)
+fail=0
+release_header=$(grep -m1 -E '^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' CHANGELOG.md || true)
+ver=$(printf '%s\n' "$release_header" | sed -nE 's/^## v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
 if [ -z "$ver" ]; then
   echo "version-check: FAIL — no '## vX.Y.Z' release header found in CHANGELOG.md"
   exit 1
 fi
 echo "version-check: CHANGELOG source of truth = v$ver"
 
-fail=0
-check_pin() {
-  local file="$1" found
-  found=$(grep -oE 'agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh' "$file" \
-            | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
-  if [ -z "$found" ]; then
-    echo "  FAIL: no 'agenthound/vX.Y.Z/install.sh' pin found in $file"
+unreleased_count=$(grep -cE '^## Unreleased[[:space:]]*$' CHANGELOG.md || true)
+unreleased_line=$(grep -n -m1 -E '^## Unreleased[[:space:]]*$' CHANGELOG.md | cut -d: -f1 || true)
+release_line=$(grep -n -m1 -E '^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' CHANGELOG.md | cut -d: -f1 || true)
+if [ "$unreleased_count" -ne 1 ] || [ -z "$unreleased_line" ] || [ "$unreleased_line" -ge "$release_line" ]; then
+  echo "  FAIL: CHANGELOG.md must contain exactly one '## Unreleased' before the newest release"
+  fail=1
+fi
+
+pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh'
+for file in install.sh README.md; do
+  matches=$(grep -oE "$pin_pattern" "$file" || true)
+  count=$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d '[:space:]')
+  if [ "$count" -ne 1 ]; then
+    echo "  FAIL: $file has $count tagged installer URLs, expected exactly 1"
     fail=1
-  elif [ "$found" != "v$ver" ]; then
+    continue
+  fi
+
+  found=$(printf '%s\n' "$matches" | sed -nE 's#^.*/(v[0-9]+\.[0-9]+\.[0-9]+)/install\.sh$#\1#p')
+  if [ "$found" != "v$ver" ]; then
     echo "  FAIL: $file pins $found, expected v$ver"
     fail=1
   else
     echo "  ok: $file -> $found"
   fi
-}
-check_pin install.sh
-check_pin README.md
+done
 
-# Release context: the pushed tag must also match the CHANGELOG. GitHub Actions
-# sets GITHUB_REF_TYPE / GITHUB_REF_NAME automatically; locally they are unset
-# and this block is skipped.
+# GitHub supplies these variables for a tag-triggered workflow. A release tag
+# must name the CHANGELOG version, and Unreleased must already be empty so the
+# published notes cannot omit last-minute changes.
 if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
   if [ "${GITHUB_REF_NAME:-}" != "v$ver" ]; then
     echo "  FAIL: tag ${GITHUB_REF_NAME:-<none>} != CHANGELOG v$ver"
@@ -54,10 +51,22 @@ if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
   else
     echo "  ok: tag ${GITHUB_REF_NAME} matches CHANGELOG"
   fi
+
+  unreleased_body=$(awk '
+    /^## Unreleased[[:space:]]*$/ { in_unreleased = 1; next }
+    in_unreleased && /^## / { exit }
+    in_unreleased && /[^[:space:]]/ { print }
+  ' CHANGELOG.md)
+  if [ -n "$unreleased_body" ]; then
+    echo "  FAIL: CHANGELOG.md Unreleased section must be empty on a tag build"
+    fail=1
+  else
+    echo "  ok: Unreleased is empty for tag build"
+  fi
 fi
 
 if [ "$fail" -ne 0 ]; then
-  echo "version-check: FAILED — write the CHANGELOG section, then run 'make sync-version' (or fix the tag)."
+  echo "version-check: FAILED — prepare CHANGELOG.md, then run 'make sync-version' (or fix the tag)."
   exit 1
 fi
-echo "version-check: all version references consistent (v$ver)."
+echo "version-check: all release metadata is consistent (v$ver)."

--- a/sdk/common/output.go
+++ b/sdk/common/output.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -10,7 +11,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const DefaultCollectorVersion = "0.9.0-dev"
+const DefaultCollectorVersion = "dev"
 
 var collectorVersion atomic.Value
 
@@ -30,6 +31,35 @@ func SetCollectorVersion(version string) {
 	if version = strings.TrimSpace(version); version != "" {
 		collectorVersion.Store(version)
 	}
+}
+
+// ResolveBuildInfo returns the version and commit reported by the binaries.
+// GoReleaser's linker values take precedence. A go install build has the
+// development linker defaults but records its module version in Go build
+// metadata, so use that version when available and leave the commit unknown.
+func ResolveBuildInfo(version, commit string) (string, string) {
+	return resolveBuildInfo(version, commit, debug.ReadBuildInfo)
+}
+
+func resolveBuildInfo(version, commit string, readBuildInfo func() (*debug.BuildInfo, bool)) (string, string) {
+	version = strings.TrimSpace(version)
+	commit = strings.TrimSpace(commit)
+	if version == "" {
+		version = DefaultCollectorVersion
+	}
+	if commit == "" {
+		commit = "none"
+	}
+
+	if version != DefaultCollectorVersion || commit != "none" {
+		return strings.TrimPrefix(version, "v"), commit
+	}
+
+	info, ok := readBuildInfo()
+	if !ok || info == nil || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return version, commit
+	}
+	return strings.TrimPrefix(info.Main.Version, "v"), commit
 }
 
 func NewIngestData(collector, scanID string) *ingest.IngestData {

--- a/sdk/common/output_test.go
+++ b/sdk/common/output_test.go
@@ -1,12 +1,87 @@
 package common
 
 import (
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
+
+func TestResolveBuildInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		commit      string
+		buildInfo   *debug.BuildInfo
+		buildInfoOK bool
+		wantVersion string
+		wantCommit  string
+	}{
+		{
+			name:        "go install version",
+			version:     "dev",
+			commit:      "none",
+			buildInfo:   &debug.BuildInfo{Main: debug.Module{Version: "v1.0.1"}},
+			buildInfoOK: true,
+			wantVersion: "1.0.1",
+			wantCommit:  "none",
+		},
+		{
+			name:        "unavailable build info",
+			version:     "dev",
+			commit:      "none",
+			buildInfoOK: false,
+			wantVersion: "dev",
+			wantCommit:  "none",
+		},
+		{
+			name:        "development build info",
+			version:     "dev",
+			commit:      "none",
+			buildInfo:   &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}},
+			buildInfoOK: true,
+			wantVersion: "dev",
+			wantCommit:  "none",
+		},
+		{
+			name:        "goreleaser linker values take precedence",
+			version:     "v1.2.3",
+			commit:      "abc123",
+			buildInfo:   &debug.BuildInfo{Main: debug.Module{Version: "v1.0.1"}},
+			buildInfoOK: true,
+			wantVersion: "1.2.3",
+			wantCommit:  "abc123",
+		},
+		{
+			name:        "partial linker override prevents fallback",
+			version:     "dev",
+			commit:      "abc123",
+			buildInfo:   &debug.BuildInfo{Main: debug.Module{Version: "v1.0.1"}},
+			buildInfoOK: true,
+			wantVersion: "dev",
+			wantCommit:  "abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			readCalled := false
+			gotVersion, gotCommit := resolveBuildInfo(tt.version, tt.commit, func() (*debug.BuildInfo, bool) {
+				readCalled = true
+				return tt.buildInfo, tt.buildInfoOK
+			})
+			if gotVersion != tt.wantVersion || gotCommit != tt.wantCommit {
+				t.Errorf("resolveBuildInfo() = (%q, %q), want (%q, %q)", gotVersion, gotCommit, tt.wantVersion, tt.wantCommit)
+			}
+			wantRead := tt.version == "dev" && tt.commit == "none"
+			if readCalled != wantRead {
+				t.Errorf("ReadBuildInfo called = %v, want %v", readCalled, wantRead)
+			}
+		})
+	}
+}
 
 func TestNewIngestData(t *testing.T) {
 	t.Run("with explicit scan ID", func(t *testing.T) {

--- a/server/cmd/agenthound-server/main.go
+++ b/server/cmd/agenthound-server/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/server/cli"
 )
 
@@ -13,6 +14,7 @@ var (
 )
 
 func main() {
+	version, commit = common.ResolveBuildInfo(version, commit)
 	cli.SetVersion(version, commit)
 	if cli.HandleUnknownCommand() {
 		return


### PR DESCRIPTION
Prepares v1.0.1 as the first supported public release while retaining v1.0.0 as retracted history.

Includes Go build provenance, release retractions, exact version synchronization, serialized monotonic release publishing, pinned GoReleaser validation, and post-publication checks across GitHub, GHCR, Homebrew, the default installer, Compose, and the Go proxy.

Validated locally with make prerelease, strict MkDocs, GoReleaser v2.15.4 check and snapshot, release-process fixtures, and independent code review.