### PR TITLE
Fix Linuxbrew release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,36 +182,12 @@ jobs:
           gh release download --repo "${repo}" "${tag}" --pattern checksums.txt --dir "${verify_dir}"
 
           for formula in agenthound agenthound-server; do
-            formula_body="$(GH_TOKEN="${HOMEBREW_TAP_GITHUB_TOKEN}" gh api \
+            formula_file="${verify_dir}/${formula}.rb"
+            GH_TOKEN="${HOMEBREW_TAP_GITHUB_TOKEN}" gh api \
               -H 'Accept: application/vnd.github.raw+json' \
-              "repos/adithyan-ak/homebrew-agenthound/contents/Formula/${formula}.rb")"
-            if ! grep -Fq "version \"${version}\"" <<<"${formula_body}"; then
-              echo "Homebrew formula ${formula} does not declare version ${version}" >&2
-              exit 1
-            fi
-
-            mapfile -t formula_urls < <(sed -nE 's/^[[:space:]]*url "([^"]+)".*/\1/p' <<<"${formula_body}")
-            mapfile -t formula_sums < <(sed -nE 's/^[[:space:]]*sha256 "([0-9a-f]{64})".*/\1/p' <<<"${formula_body}")
-            if (( ${#formula_urls[@]} == 0 || ${#formula_urls[@]} != ${#formula_sums[@]} )); then
-              echo "Homebrew formula ${formula} has unpaired URL/checksum entries" >&2
-              exit 1
-            fi
-
-            for index in "${!formula_urls[@]}"; do
-              formula_url="${formula_urls[$index]}"
-              formula_sum="${formula_sums[$index]}"
-              asset="${formula_url##*/}"
-              if [[ "${formula_url}" != *"/releases/download/${tag}/"* ]] ||
-                 [[ "${asset}" != "${formula}_${version}_darwin_"* ]]; then
-                echo "Unexpected Homebrew URL for ${formula}: ${formula_url}" >&2
-                exit 1
-              fi
-              release_sum="$(awk -v asset="${asset}" '$2 == asset { print $1 }' "${verify_dir}/checksums.txt")"
-              if [[ -z "${release_sum}" || "${formula_sum}" != "${release_sum}" ]]; then
-                echo "Homebrew checksum mismatch for ${asset}" >&2
-                exit 1
-              fi
-            done
+              "repos/adithyan-ak/homebrew-agenthound/contents/Formula/${formula}.rb" > "${formula_file}"
+            ./scripts/verify-homebrew-formula.sh \
+              "${formula}" "${version}" "${tag}" "${formula_file}" "${verify_dir}/checksums.txt"
           done
 
           for image in agenthound agenthound-server; do

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -19,6 +19,7 @@ on:
       - "scripts/release-notes.sh"
       - "scripts/release-process-test.sh"
       - "scripts/sync-version.sh"
+      - "scripts/verify-homebrew-formula.sh"
       - "scripts/version-check.sh"
       - ".github/workflows/release.yml"
       - ".github/workflows/version-check.yml"

--- a/scripts/release-process-test.sh
+++ b/scripts/release-process-test.sh
@@ -83,4 +83,28 @@ if printf '%s\n' "$rendered" | grep -Fq '## v1.0.0'; then
 fi
 expect_failure "release-notes version mismatch" sh "$notes/scripts/release-notes.sh" "$notes/CHANGELOG.md" v1.0.2
 
+formula_fixture="$test_root/agenthound.rb"
+checksums_fixture="$test_root/checksums.txt"
+for platform in darwin linux; do
+  for arch in amd64 arm64; do
+    asset="agenthound_1.0.1_${platform}_${arch}.tar.gz"
+    checksum=$(printf '%064d' "$(( ${#platform} + ${#arch} ))")
+    printf '  url "https://github.com/adithyan-ak/AgentHound/releases/download/v1.0.1/%s"\n' "$asset" >> "$formula_fixture"
+    printf '  sha256 "%s"\n' "$checksum" >> "$formula_fixture"
+    printf '%s  %s\n' "$checksum" "$asset" >> "$checksums_fixture"
+  done
+done
+sed -i.bak '1i\
+  version "1.0.1"' "$formula_fixture"
+rm "$formula_fixture.bak"
+bash "$repo_root/scripts/verify-homebrew-formula.sh" \
+  agenthound 1.0.1 v1.0.1 "$formula_fixture" "$checksums_fixture"
+
+bad_formula="$test_root/agenthound-bad.rb"
+cp "$formula_fixture" "$bad_formula"
+sed -i.bak 's/linux_arm64/windows_arm64/' "$bad_formula"
+rm "$bad_formula.bak"
+expect_failure "unexpected Homebrew archive" bash "$repo_root/scripts/verify-homebrew-formula.sh" \
+  agenthound 1.0.1 v1.0.1 "$bad_formula" "$checksums_fixture"
+
 echo "release-process-test: all checks passed"

--- a/scripts/verify-homebrew-formula.sh
+++ b/scripts/verify-homebrew-formula.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+  echo "usage: $0 <formula> <version> <tag> <formula-file> <checksums-file>" >&2
+  exit 2
+fi
+
+formula=$1
+version=$2
+tag=$3
+formula_file=$4
+checksums_file=$5
+
+if [ ! -r "$formula_file" ] || [ ! -r "$checksums_file" ]; then
+  echo "Homebrew verification inputs are not readable" >&2
+  exit 1
+fi
+
+if ! grep -Fq "version \"${version}\"" "$formula_file"; then
+  echo "Homebrew formula ${formula} does not declare version ${version}" >&2
+  exit 1
+fi
+
+formula_urls=()
+while IFS= read -r formula_url; do
+  formula_urls[${#formula_urls[@]}]=$formula_url
+done < <(sed -nE 's/^[[:space:]]*url "([^"]+)".*/\1/p' "$formula_file")
+formula_sums=()
+while IFS= read -r formula_sum; do
+  formula_sums[${#formula_sums[@]}]=$formula_sum
+done < <(sed -nE 's/^[[:space:]]*sha256 "([0-9a-f]{64})".*/\1/p' "$formula_file")
+if (( ${#formula_urls[@]} != 4 || ${#formula_urls[@]} != ${#formula_sums[@]} )); then
+  echo "Homebrew formula ${formula} must contain four paired URL/checksum entries" >&2
+  exit 1
+fi
+
+expected_assets=$(printf '%s\n' \
+  "${formula}_${version}_darwin_amd64.tar.gz" \
+  "${formula}_${version}_darwin_arm64.tar.gz" \
+  "${formula}_${version}_linux_amd64.tar.gz" \
+  "${formula}_${version}_linux_arm64.tar.gz" | sort)
+actual_assets=$(
+  for formula_url in "${formula_urls[@]}"; do
+    printf '%s\n' "${formula_url##*/}"
+  done | sort
+)
+if [ "$actual_assets" != "$expected_assets" ]; then
+  echo "Homebrew formula ${formula} does not reference the expected macOS/Linux archives" >&2
+  exit 1
+fi
+
+for index in "${!formula_urls[@]}"; do
+  formula_url=${formula_urls[$index]}
+  formula_sum=${formula_sums[$index]}
+  asset=${formula_url##*/}
+  expected_url="https://github.com/adithyan-ak/AgentHound/releases/download/${tag}/${asset}"
+  if [ "$formula_url" != "$expected_url" ]; then
+    echo "Unexpected Homebrew URL for ${formula}: ${formula_url}" >&2
+    exit 1
+  fi
+
+  release_sum=$(awk -v asset="$asset" '$2 == asset { print $1 }' "$checksums_file")
+  if [ -z "$release_sum" ] || [ "$formula_sum" != "$release_sum" ]; then
+    echo "Homebrew checksum mismatch for ${asset}" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- accept and require the four GoReleaser Homebrew/Linuxbrew archives
- verify each exact release URL and checksum through a reusable script
- cover valid Linux archives and an invalid-platform failure fixture

## Why
v1.0.1 published successfully, but the new post-publication check rejected valid Linuxbrew URLs because it only allowed darwin asset names.

## Verification
- make prerelease
- live v1.0.1 Homebrew formulas against published checksums