### PR TITLE
Speed up empty ingests and add direct scan upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
             -run '^TestIntegrationLiteLLM(FingerprintThenLootPreservesGatewayProperties|FirstPartyProducerSatisfiesMasterExposureQuery|QueryRejectsUnobservedMasterMaterial)$'
       # Dedicated, serialized step for the destructive fresh-schema integration.
       # It runs AFTER the ordinary suite has finished (so nothing else is
-      # touching the shared DB), targets only that single test, and pins
+      # touching the shared DB), targets only the fresh-schema tests, and pins
       # `-p 1` to forbid any parallel package execution. Together with the
       # storage-binding and LiteLLM steps above, this is the only other place
       # where the reset opt-in is enabled.
@@ -191,7 +191,7 @@ jobs:
           AGENTHOUND_FRESH_DB_INTEGRATION: "1"
         run: |
           go test ./server/internal/ingest -race -p 1 \
-            -run '^TestIntegrationFreshSchemaCompleteIngestPublishes$'
+            -run '^TestIntegrationFreshSchema(CompleteIngestPublishes|EmptyIngestPublishesUnderThreeSeconds)$'
 
   govulncheck:
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **First-class scan upload.** `agenthound scan --ingest <server-url>` saves the
+  normal local JSON artifact before uploading those exact bytes,
+  rejects redirects, and prints a correlated ingest receipt with finding
+  counts. Normal and `--deep` config scans use the same explicit workflow.
+- **Fast fully observed empty ingests.** A complete empty collection against an
+  empty projection skips no-op reconciliation, analysis, duplicate graph
+  statistics, and finding queries. Limited or incomplete collections retain
+  the full v5 lifecycle path and cannot enter this optimization.
 - **Bounded instruction discovery by default.** Config scans now check the
   registered Claude, Cursor, GitHub Copilot, `AGENTS.md`, and `CLAUDE.md`
   sources at the canonical user and project roots. `--deep` adds a bounded

--- a/README.md
+++ b/README.md
@@ -152,28 +152,27 @@ export PATH="$HOME/.local/bin:$PATH"
 ```
 
 **3. Scan local configs** - offline, read-only, raw credential values omitted.
-Choose one coverage level and stream the result in.
+Choose one coverage level and ingest the saved artifact.
 
 Normal scan — recommended first run:
 
 ```bash
-agenthound scan --config --output - |
-  curl -sS --fail-with-body --data-binary @- -H "Content-Type: application/json" \
-    http://127.0.0.1:8080/api/v1/ingest
+agenthound scan --config --ingest http://127.0.0.1:8080
 ```
 
 Deep scan — adds bounded nested-project instruction discovery:
 
 ```bash
-agenthound scan --config --deep --output - |
-  curl -sS --fail-with-body --data-binary @- -H "Content-Type: application/json" \
-    http://127.0.0.1:8080/api/v1/ingest
+agenthound scan --config --deep --ingest http://127.0.0.1:8080
 ```
 
 Both commands check registered instruction sources at your home and selected
 project roots. Add `--project-dir /path/to/project` when the target is not the
 current directory. Deep discovery keeps that selected project independently
 covered even inside a normally pruned home subtree.
+
+The collector saves `./scan-<scan_id>.json` before upload, then prints a compact
+ingest receipt. Use `--json` for the full receipt.
 
 **4. Open the graph at
 [http://127.0.0.1:8080](http://127.0.0.1:8080/).**

--- a/collector/cli/collect_helpers.go
+++ b/collector/cli/collect_helpers.go
@@ -22,15 +22,22 @@ func prepareCollectorArtifact(data *ingest.IngestData) error {
 	return data.Meta.Identity.Validate()
 }
 
-func writeCollectorOutput(data *ingest.IngestData, outputPath string) error {
+func marshalCollectorArtifact(data *ingest.IngestData) ([]byte, error) {
 	if err := prepareCollectorArtifact(data); err != nil {
-		return fmt.Errorf("prepare ingest v5 artifact: %w", err)
+		return nil, fmt.Errorf("prepare ingest v5 artifact: %w", err)
 	}
 	encoded, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal JSON: %w", err)
+		return nil, fmt.Errorf("marshal JSON: %w", err)
 	}
+	return encoded, nil
+}
 
+func writeCollectorOutput(data *ingest.IngestData, outputPath string) error {
+	encoded, err := marshalCollectorArtifact(data)
+	if err != nil {
+		return err
+	}
 	if outputPath == "" {
 		_, err = os.Stdout.Write(encoded)
 		if err != nil {

--- a/collector/cli/remote_ingest.go
+++ b/collector/cli/remote_ingest.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,11 +20,17 @@ const (
 	remoteIngestResponseLimit = 16 << 20
 )
 
+type remoteIngestReceipt struct {
+	result          *ingest.IngestResult
+	raw             []byte
+	findingsPresent bool
+}
+
 func postRemoteIngest(
 	ctx context.Context,
 	serverURL string,
 	artifact []byte,
-) (*ingest.IngestResult, error) {
+) (*remoteIngestReceipt, error) {
 	endpoint, err := resolveRemoteIngestEndpoint(serverURL)
 	if err != nil {
 		return nil, err
@@ -66,7 +73,16 @@ func postRemoteIngest(
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("decode ingest response: %w", err)
 	}
-	return &result, nil
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, fmt.Errorf("decode ingest response fields: %w", err)
+	}
+	_, findingsPresent := fields["findings"]
+	return &remoteIngestReceipt{
+		result:          &result,
+		raw:             body,
+		findingsPresent: findingsPresent,
+	}, nil
 }
 
 func resolveRemoteIngestEndpoint(serverURL string) (string, error) {
@@ -112,17 +128,31 @@ func remoteIngestHTTPError(status int, body []byte) error {
 
 func writeRemoteIngestResult(
 	w io.Writer,
-	result *ingest.IngestResult,
+	receipt *remoteIngestReceipt,
 	artifactPath string,
 	fullJSON bool,
 ) error {
-	if result == nil {
+	if receipt == nil || receipt.result == nil {
 		return fmt.Errorf("ingest returned no result")
 	}
+	result := receipt.result
 	if fullJSON {
-		encoder := json.NewEncoder(w)
-		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(result); err != nil {
+		raw := receipt.raw
+		if len(raw) == 0 {
+			var err error
+			raw, err = json.Marshal(result)
+			if err != nil {
+				return fmt.Errorf("encode ingest result: %w", err)
+			}
+		}
+		var formatted bytes.Buffer
+		if err := json.Indent(&formatted, raw, "", "  "); err != nil {
+			return fmt.Errorf("format ingest result: %w", err)
+		}
+		if err := formatted.WriteByte('\n'); err != nil {
+			return fmt.Errorf("format ingest result: %w", err)
+		}
+		if _, err := w.Write(formatted.Bytes()); err != nil {
 			return fmt.Errorf("write ingest result: %w", err)
 		}
 		return nil
@@ -132,18 +162,36 @@ func writeRemoteIngestResult(
 	if !remoteIngestComplete(result) {
 		heading = "Ingest incomplete"
 	}
+	findings := "unknown"
+	if receipt.findingsPresent {
+		findings = strconv.Itoa(result.Findings)
+	}
 	if _, err := fmt.Fprintf(
 		w,
-		"%s:\n\n  Scan ID:   %s\n  Artifact:  %s\n  Nodes:     %d\n  Edges:     %d\n  Findings:  %d\n  Duration:  %s\n",
+		"%s:\n\n  Scan ID:   %s\n  Artifact:  %s\n  Nodes:     %d\n  Edges:     %d\n  Findings:  %s\n  Duration:  %s\n",
 		heading,
 		result.ScanID,
 		artifactPath,
 		result.Submitted.Nodes,
 		result.Submitted.Edges,
-		result.Findings,
+		findings,
 		result.Duration.Round(time.Millisecond),
 	); err != nil {
 		return fmt.Errorf("write ingest result: %w", err)
+	}
+	return nil
+}
+
+func validateRemoteIngestScanID(result *ingest.IngestResult, expectedScanID string) error {
+	if result == nil {
+		return fmt.Errorf("ingest returned no result")
+	}
+	if result.ScanID != expectedScanID {
+		return fmt.Errorf(
+			"ingest receipt scan_id %q does not match submitted scan_id %q",
+			result.ScanID,
+			expectedScanID,
+		)
 	}
 	return nil
 }

--- a/collector/cli/remote_ingest.go
+++ b/collector/cli/remote_ingest.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+)
+
+const (
+	remoteIngestTimeout       = 5 * time.Minute
+	remoteIngestResponseLimit = 16 << 20
+)
+
+func postRemoteIngest(
+	ctx context.Context,
+	serverURL string,
+	artifact []byte,
+) (*ingest.IngestResult, error) {
+	endpoint, err := resolveRemoteIngestEndpoint(serverURL)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		endpoint,
+		bytes.NewReader(artifact),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create ingest request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: remoteIngestTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ingest request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, remoteIngestResponseLimit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read ingest response: %w", err)
+	}
+	if len(body) > remoteIngestResponseLimit {
+		return nil, fmt.Errorf("ingest response exceeds %d bytes", remoteIngestResponseLimit)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, remoteIngestHTTPError(resp.StatusCode, body)
+	}
+
+	var result ingest.IngestResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode ingest response: %w", err)
+	}
+	return &result, nil
+}
+
+func resolveRemoteIngestEndpoint(serverURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(serverURL))
+	if err != nil {
+		return "", fmt.Errorf("invalid --ingest URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid --ingest URL: scheme must be http or https")
+	}
+	if parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("invalid --ingest URL: provide a server base URL without credentials, query, or fragment")
+	}
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	switch path {
+	case "":
+		parsed.Path = "/api/v1/ingest"
+		parsed.RawPath = ""
+	case "/api/v1/ingest":
+		parsed.Path = path
+		parsed.RawPath = ""
+	default:
+		return "", fmt.Errorf("invalid --ingest URL: path must be empty or /api/v1/ingest")
+	}
+	return parsed.String(), nil
+}
+
+func remoteIngestHTTPError(status int, body []byte) error {
+	var response struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &response); err == nil && response.Error.Message != "" {
+		if response.Error.Code != "" {
+			return fmt.Errorf("ingest failed with HTTP %d (%s): %s", status, response.Error.Code, response.Error.Message)
+		}
+		return fmt.Errorf("ingest failed with HTTP %d: %s", status, response.Error.Message)
+	}
+	return fmt.Errorf("ingest failed with HTTP %d", status)
+}
+
+func writeRemoteIngestResult(
+	w io.Writer,
+	result *ingest.IngestResult,
+	artifactPath string,
+	fullJSON bool,
+) error {
+	if result == nil {
+		return fmt.Errorf("ingest returned no result")
+	}
+	if fullJSON {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(result); err != nil {
+			return fmt.Errorf("write ingest result: %w", err)
+		}
+		return nil
+	}
+
+	heading := "Ingest complete"
+	if !remoteIngestComplete(result) {
+		heading = "Ingest incomplete"
+	}
+	if _, err := fmt.Fprintf(
+		w,
+		"%s:\n\n  Scan ID:   %s\n  Artifact:  %s\n  Nodes:     %d\n  Edges:     %d\n  Findings:  %d\n  Duration:  %s\n",
+		heading,
+		result.ScanID,
+		artifactPath,
+		result.Submitted.Nodes,
+		result.Submitted.Edges,
+		result.Findings,
+		result.Duration.Round(time.Millisecond),
+	); err != nil {
+		return fmt.Errorf("write ingest result: %w", err)
+	}
+	return nil
+}
+
+func validateRemoteIngestResult(result *ingest.IngestResult) error {
+	if result == nil {
+		return fmt.Errorf("ingest returned no result")
+	}
+	if remoteIngestComplete(result) {
+		return nil
+	}
+	return fmt.Errorf(
+		"ingest did not publish a complete projection: outcome=%s projection=%s",
+		result.Outcome,
+		result.ProjectionStatus,
+	)
+}
+
+func remoteIngestComplete(result *ingest.IngestResult) bool {
+	return result != nil &&
+		result.Outcome == ingest.OutcomeComplete &&
+		result.ProjectionStatus == "complete" &&
+		result.PublishedRevision != nil
+}

--- a/collector/cli/remote_ingest.go
+++ b/collector/cli/remote_ingest.go
@@ -158,9 +158,12 @@ func writeRemoteIngestResult(
 		return nil
 	}
 
+	complete := remoteIngestComplete(result)
 	heading := "Ingest complete"
-	if !remoteIngestComplete(result) {
+	if !complete {
 		heading = "Ingest incomplete"
+	} else if ingest.InstructionCoverageLimited(&result.Collection) {
+		heading = "Ingest complete with coverage limitations"
 	}
 	findings := "unknown"
 	if receipt.findingsPresent {

--- a/collector/cli/remote_ingest_test.go
+++ b/collector/cli/remote_ingest_test.go
@@ -128,6 +128,47 @@ func TestRunScan_RemoteIngestFailurePreservesArtifact(t *testing.T) {
 	}
 }
 
+func TestRunScan_RemoteIngestRejectsUncorrelatedReceiptBeforeSuccessOutput(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseScanID string
+	}{
+		{name: "different scan", responseScanID: "different-scan"},
+		{name: "missing scan"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			revision := int64(9)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(ingest.IngestResult{
+					ScanID:            test.responseScanID,
+					Outcome:           ingest.OutcomeComplete,
+					ProjectionStatus:  "complete",
+					PublishedRevision: &revision,
+				})
+			}))
+			defer server.Close()
+
+			cmd := newScanCmdForTest()
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(io.Discard)
+			mustSetFlag(t, cmd, "config", "true")
+			mustSetFlag(t, cmd, "path", writeEmptyConfig(t))
+			mustSetFlag(t, cmd, "scan-output", filepath.Join(t.TempDir(), "backup.json"))
+			mustSetFlag(t, cmd, "ingest", server.URL)
+
+			err := runScan(cmd, nil)
+			if err == nil || !strings.Contains(err.Error(), "does not match submitted scan_id") {
+				t.Fatalf("error = %v, want scan correlation failure", err)
+			}
+			if strings.Contains(stdout.String(), "Ingest complete") {
+				t.Fatalf("uncorrelated receipt reported success:\n%s", stdout.String())
+			}
+		})
+	}
+}
+
 func TestPostRemoteIngest_ReturnsSanitizedAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -139,6 +180,42 @@ func TestPostRemoteIngest_ReturnsSanitizedAPIError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "STORAGE_BINDING_UNAVAILABLE") ||
 		!strings.Contains(err.Error(), "storage pair unavailable") {
 		t.Fatalf("error = %v, want sanitized API error", err)
+	}
+}
+
+func TestPostRemoteIngest_OlderReceiptReportsUnknownFindings(t *testing.T) {
+	revision := int64(9)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(
+			w,
+			`{"scan_id":"old-scan","outcome":"complete","projection_status":"complete","submitted":{"nodes":1,"edges":0},"published_revision":%d,"duration":1000000}`,
+			revision,
+		)
+	}))
+	defer server.Close()
+
+	receipt, err := postRemoteIngest(context.Background(), server.URL, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("postRemoteIngest: %v", err)
+	}
+	var compact bytes.Buffer
+	if err := writeRemoteIngestResult(&compact, receipt, "backup.json", false); err != nil {
+		t.Fatalf("compact result: %v", err)
+	}
+	if !strings.Contains(compact.String(), "Findings:  unknown") {
+		t.Fatalf("older receipt summary = %q, want unknown findings", compact.String())
+	}
+
+	var full bytes.Buffer
+	if err := writeRemoteIngestResult(&full, receipt, "backup.json", true); err != nil {
+		t.Fatalf("full result: %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(full.Bytes(), &fields); err != nil {
+		t.Fatalf("decode full result: %v", err)
+	}
+	if _, ok := fields["findings"]; ok {
+		t.Fatalf("full older receipt invented findings: %s", full.String())
 	}
 }
 
@@ -169,8 +246,17 @@ func TestWriteRemoteIngestResult_JSONAndIncompleteValidation(t *testing.T) {
 		ProjectionStatus: "incomplete",
 		Findings:         3,
 	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := &remoteIngestReceipt{
+		result:          result,
+		raw:             raw,
+		findingsPresent: true,
+	}
 	var output bytes.Buffer
-	if err := writeRemoteIngestResult(&output, result, "backup.json", true); err != nil {
+	if err := writeRemoteIngestResult(&output, receipt, "backup.json", true); err != nil {
 		t.Fatalf("writeRemoteIngestResult: %v", err)
 	}
 	var decoded ingest.IngestResult

--- a/collector/cli/remote_ingest_test.go
+++ b/collector/cli/remote_ingest_test.go
@@ -1,0 +1,242 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+)
+
+func TestRunScan_RemoteIngestSavesExactArtifactAndPrintsSummary(t *testing.T) {
+	var uploaded []byte
+	var submittedNodes int
+	revision := int64(9)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/ingest" {
+			t.Errorf("request path = %q, want /api/v1/ingest", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("content type = %q, want application/json", got)
+		}
+		var err error
+		uploaded, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request: %v", err)
+		}
+		var artifact ingest.IngestData
+		if err := json.Unmarshal(uploaded, &artifact); err != nil {
+			t.Errorf("decode artifact: %v", err)
+		}
+		submittedNodes = len(artifact.Graph.Nodes)
+		_ = json.NewEncoder(w).Encode(ingest.IngestResult{
+			ScanID:           artifact.Meta.ScanID,
+			Outcome:          ingest.OutcomeComplete,
+			ProjectionStatus: "complete",
+			Submitted: ingest.FactCounts{
+				Nodes: len(artifact.Graph.Nodes),
+				Edges: len(artifact.Graph.Edges),
+			},
+			Findings:          2,
+			PublishedRevision: &revision,
+			Duration:          1500 * time.Millisecond,
+		})
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "backup.json")
+	cmd := newScanCmdForTest()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	mustSetFlag(t, cmd, "config", "true")
+	mustSetFlag(t, cmd, "path", writeEmptyConfig(t))
+	mustSetFlag(t, cmd, "scan-output", outputPath)
+	mustSetFlag(t, cmd, "ingest", server.URL)
+
+	if err := runScan(cmd, nil); err != nil {
+		t.Fatalf("runScan: %v", err)
+	}
+	saved, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read saved artifact: %v", err)
+	}
+	if !bytes.Equal(saved, uploaded) {
+		t.Fatal("uploaded bytes differ from saved artifact")
+	}
+	for _, want := range []string{
+		"Ingest complete:",
+		"Artifact:  " + outputPath,
+		fmt.Sprintf("Nodes:     %d", submittedNodes),
+		"Edges:     0",
+		"Findings:  2",
+		"Duration:  1.5s",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("summary missing %q:\n%s", want, stdout.String())
+		}
+	}
+	for _, want := range []string{"saved artifact:", "ingesting into"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("progress missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestRunScan_RemoteIngestFailurePreservesArtifact(t *testing.T) {
+	var uploaded []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		uploaded, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request: %v", err)
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":{"code":"INGEST_UNAVAILABLE","message":"try again later"}}`)
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "retry.json")
+	cmd := newScanCmdForTest()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	mustSetFlag(t, cmd, "config", "true")
+	mustSetFlag(t, cmd, "path", writeEmptyConfig(t))
+	mustSetFlag(t, cmd, "scan-output", outputPath)
+	mustSetFlag(t, cmd, "ingest", server.URL)
+
+	err := runScan(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "INGEST_UNAVAILABLE") {
+		t.Fatalf("error = %v, want sanitized ingest failure", err)
+	}
+	saved, readErr := os.ReadFile(outputPath)
+	if readErr != nil {
+		t.Fatalf("read preserved artifact: %v", readErr)
+	}
+	if !bytes.Equal(saved, uploaded) {
+		t.Fatal("preserved artifact differs from attempted upload")
+	}
+}
+
+func TestPostRemoteIngest_ReturnsSanitizedAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":{"code":"STORAGE_BINDING_UNAVAILABLE","message":"storage pair unavailable"}}`)
+	}))
+	defer server.Close()
+
+	_, err := postRemoteIngest(context.Background(), server.URL, []byte(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "STORAGE_BINDING_UNAVAILABLE") ||
+		!strings.Contains(err.Error(), "storage pair unavailable") {
+		t.Fatalf("error = %v, want sanitized API error", err)
+	}
+}
+
+func TestPostRemoteIngest_RejectsRedirect(t *testing.T) {
+	destinationCalled := false
+	destination := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		destinationCalled = true
+	}))
+	defer destination.Close()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL, http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+
+	_, err := postRemoteIngest(context.Background(), server.URL, []byte(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "HTTP 307") {
+		t.Fatalf("error = %v, want redirect rejection", err)
+	}
+	if destinationCalled {
+		t.Fatal("ingest payload followed redirect")
+	}
+}
+
+func TestWriteRemoteIngestResult_JSONAndIncompleteValidation(t *testing.T) {
+	result := &ingest.IngestResult{
+		ScanID:           "scan-partial",
+		Outcome:          ingest.OutcomePartial,
+		ProjectionStatus: "incomplete",
+		Findings:         3,
+	}
+	var output bytes.Buffer
+	if err := writeRemoteIngestResult(&output, result, "backup.json", true); err != nil {
+		t.Fatalf("writeRemoteIngestResult: %v", err)
+	}
+	var decoded ingest.IngestResult
+	if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+		t.Fatalf("JSON receipt: %v", err)
+	}
+	if decoded.ScanID != result.ScanID || decoded.Findings != 3 {
+		t.Fatalf("decoded receipt = %+v", decoded)
+	}
+	if err := validateRemoteIngestResult(result); err == nil {
+		t.Fatal("incomplete projection returned success")
+	}
+}
+
+func TestRunScan_RemoteIngestFlagValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		ingest string
+		json   string
+		output string
+		want   string
+	}{
+		{name: "json requires ingest", json: "true", want: "--json requires --ingest"},
+		{name: "stdout conflicts with ingest", ingest: "http://127.0.0.1:8080", output: "-", want: "--output -"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := newScanCmdForTest()
+			if test.ingest != "" {
+				mustSetFlag(t, cmd, "ingest", test.ingest)
+			}
+			if test.json != "" {
+				mustSetFlag(t, cmd, "json", test.json)
+			}
+			if test.output != "" {
+				mustSetFlag(t, cmd, "scan-output", test.output)
+			}
+			err := runScan(cmd, nil)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveRemoteIngestEndpoint(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+		ok   bool
+	}{
+		{raw: "http://127.0.0.1:8080", want: "http://127.0.0.1:8080/api/v1/ingest", ok: true},
+		{raw: "https://agenthound.example/api/v1/ingest", want: "https://agenthound.example/api/v1/ingest", ok: true},
+		{raw: "ftp://agenthound.example", ok: false},
+		{raw: "https://user:pass@agenthound.example", ok: false},
+		{raw: "https://agenthound.example/other", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.raw, func(t *testing.T) {
+			got, err := resolveRemoteIngestEndpoint(test.raw)
+			if test.ok && (err != nil || got != test.want) {
+				t.Fatalf("endpoint = %q, err=%v, want %q", got, err, test.want)
+			}
+			if !test.ok && err == nil {
+				t.Fatalf("endpoint = %q, want error", got)
+			}
+		})
+	}
+}

--- a/collector/cli/remote_ingest_test.go
+++ b/collector/cli/remote_ingest_test.go
@@ -219,6 +219,51 @@ func TestPostRemoteIngest_OlderReceiptReportsUnknownFindings(t *testing.T) {
 	}
 }
 
+func TestWriteRemoteIngestResult_LimitedCoverageRemainsSuccessful(t *testing.T) {
+	revision := int64(10)
+	root := ingest.CanonicalCoverageKey(
+		"config",
+		"instruction-exact-project",
+		"/workspace/project",
+	)
+	contract := ingest.CurrentInstructionRegistryContract()
+	result := &ingest.IngestResult{
+		ScanID:            "scan-limited",
+		Outcome:           ingest.OutcomeComplete,
+		ProjectionStatus:  "complete",
+		PublishedRevision: &revision,
+		Collection: ingest.CollectionReport{
+			State:        ingest.OutcomeTruncated,
+			CoverageKeys: []string{root},
+			AuthoritativeRoots: []ingest.CoverageRoot{{
+				CoverageKey:      root,
+				RegistryContract: &contract,
+			}},
+			Outcomes: []ingest.CollectionOutcome{{
+				Collector:   "config",
+				CoverageKey: root,
+				Method:      ingest.InstructionMethodExactProject,
+				State:       ingest.OutcomeTruncated,
+			}},
+		},
+	}
+	receipt := &remoteIngestReceipt{result: result, findingsPresent: true}
+
+	var output bytes.Buffer
+	if err := writeRemoteIngestResult(&output, receipt, "backup.json", false); err != nil {
+		t.Fatalf("writeRemoteIngestResult: %v", err)
+	}
+	if !strings.Contains(
+		output.String(),
+		"Ingest complete with coverage limitations:",
+	) {
+		t.Fatalf("limited receipt did not disclose coverage:\n%s", output.String())
+	}
+	if err := validateRemoteIngestResult(result); err != nil {
+		t.Fatalf("published limited receipt returned failure: %v", err)
+	}
+}
+
 func TestPostRemoteIngest_RejectsRedirect(t *testing.T) {
 	destinationCalled := false
 	destination := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -60,6 +59,13 @@ Output goes to a file: pass --output <path> to choose the path, or pass
 'agenthound-server ingest -'). When --output is unset, the scan is written
 to ./scan-<scan_id>.json in the current working directory.
 
+Local scans can save and ingest in one command:
+
+  agenthound scan --config --ingest http://127.0.0.1:8080
+
+The artifact is saved before upload. A compact receipt is printed by default;
+pass --json for the full server receipt.
+
 Operators ingest the resulting JSON on their analysis box via either:
 
   agenthound-server ingest scan.json
@@ -96,6 +102,8 @@ func init() {
 	scanCmd.Flags().Bool("insecure", false, "Skip TLS verification")
 
 	scanCmd.Flags().String("scan-output", "", "Write scan JSON to this path. Use '-' for stdout. Defaults to ./scan-<scan_id>.json in CWD.")
+	scanCmd.Flags().String("ingest", "", "Save and ingest the scan into an AgentHound server base URL")
+	scanCmd.Flags().Bool("json", false, "Print the full remote ingest receipt as JSON (requires --ingest)")
 
 	// Network-scan mode flags.
 	scanCmd.Flags().IntSlice("ports", nil, "Override the default AI-service port set (network mode only). Default: 11434, 8000, 6333, 5000, 4000, 8888, 3000.")
@@ -110,10 +118,16 @@ func init() {
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
+	remoteURL, _ := cmd.Flags().GetString("ingest")
+	fullReceipt, _ := cmd.Flags().GetBool("json")
+
 	// Network-mode dispatch: when a positional CIDR/host/@file is supplied,
 	// the scanner runs instead of the legacy collector flow. The network path
 	// performs the port sweep and then dispatches every registered fingerprinter.
 	if len(args) == 1 {
+		if remoteURL != "" || fullReceipt {
+			return fmt.Errorf("--ingest and --json are supported only for local scans")
+		}
 		return runNetworkScan(cmd, args[0])
 	}
 
@@ -161,6 +175,17 @@ func runScan(cmd *cobra.Command, args []string) error {
 			output = v
 		}
 	}
+	if fullReceipt && remoteURL == "" {
+		return fmt.Errorf("--json requires --ingest")
+	}
+	if remoteURL != "" && output == "-" {
+		return fmt.Errorf("--ingest cannot be combined with --output -; use a file path for the backup artifact")
+	}
+	if remoteURL != "" {
+		if _, err := resolveRemoteIngestEndpoint(remoteURL); err != nil {
+			return err
+		}
+	}
 
 	if !runConfig && !runMCP && !runA2A {
 		if url != "" {
@@ -206,7 +231,37 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	stderr := cmd.ErrOrStderr()
-	_, _ = fmt.Fprintf(stderr, "Collected %d nodes, %d edges\n", len(merged.Graph.Nodes), len(merged.Graph.Edges))
+	if !quietEnabled(cmd) {
+		_, _ = fmt.Fprintf(stderr, "Collected %d nodes, %d edges\n", len(merged.Graph.Nodes), len(merged.Graph.Edges))
+	}
+
+	if remoteURL != "" {
+		artifact, err := marshalCollectorArtifact(merged)
+		if err != nil {
+			return err
+		}
+		if err := writeOutputAtomic(output, artifact); err != nil {
+			return fmt.Errorf("write file: %w", err)
+		}
+		writeInstructionCoverageWarnings(stderr, merged.Meta.Collection)
+		if !quietEnabled(cmd) {
+			_, _ = fmt.Fprintf(stderr, "[scan] saved artifact: %s\n", output)
+		}
+		if allCollectorsFailed(enabled, failed) {
+			return fmt.Errorf("all %d enabled collector(s) failed", enabled)
+		}
+		if !quietEnabled(cmd) {
+			_, _ = fmt.Fprintf(stderr, "[scan] ingesting into %s\n", remoteURL)
+		}
+		result, err := postRemoteIngest(ctx, remoteURL, artifact)
+		if err != nil {
+			return err
+		}
+		if err := writeRemoteIngestResult(cmd.OutOrStdout(), result, output, fullReceipt); err != nil {
+			return err
+		}
+		return validateRemoteIngestResult(result)
+	}
 
 	// Write the (possibly empty) artifact before deciding the exit code so
 	// the operator keeps the envelope and logs even on total failure.
@@ -271,12 +326,9 @@ func allCollectorsFailed(enabled, failed int) bool {
 // os.Stdout. Used for piping into 'agenthound-server ingest -'. No atomic
 // write semantics; stdout is the operator's responsibility (e.g., via SSH).
 func writeCollectorOutputStdout(data *ingest.IngestData) error {
-	if err := prepareCollectorArtifact(data); err != nil {
-		return fmt.Errorf("prepare ingest v5 artifact: %w", err)
-	}
-	encoded, err := json.MarshalIndent(data, "", "  ")
+	encoded, err := marshalCollectorArtifact(data)
 	if err != nil {
-		return fmt.Errorf("marshal JSON: %w", err)
+		return err
 	}
 	if _, err := os.Stdout.Write(encoded); err != nil {
 		return fmt.Errorf("write stdout: %w", err)

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -253,14 +253,17 @@ func runScan(cmd *cobra.Command, args []string) error {
 		if !quietEnabled(cmd) {
 			_, _ = fmt.Fprintf(stderr, "[scan] ingesting into %s\n", remoteURL)
 		}
-		result, err := postRemoteIngest(ctx, remoteURL, artifact)
+		receipt, err := postRemoteIngest(ctx, remoteURL, artifact)
 		if err != nil {
 			return err
 		}
-		if err := writeRemoteIngestResult(cmd.OutOrStdout(), result, output, fullReceipt); err != nil {
+		if err := validateRemoteIngestScanID(receipt.result, merged.Meta.ScanID); err != nil {
 			return err
 		}
-		return validateRemoteIngestResult(result)
+		if err := writeRemoteIngestResult(cmd.OutOrStdout(), receipt, output, fullReceipt); err != nil {
+			return err
+		}
+		return validateRemoteIngestResult(receipt.result)
 	}
 
 	// Write the (possibly empty) artifact before deciding the exit code so

--- a/collector/cli/scan_test.go
+++ b/collector/cli/scan_test.go
@@ -34,6 +34,8 @@ func newScanCmdForTest() *cobra.Command {
 	cmd.Flags().Duration("timeout", 0, "")
 	cmd.Flags().Bool("insecure", false, "")
 	cmd.Flags().String("scan-output", "", "")
+	cmd.Flags().String("ingest", "", "")
+	cmd.Flags().Bool("json", false, "")
 	cmd.Flags().Bool("verbose", false, "")
 	return cmd
 }

--- a/docs/adr/0001-two-binary-split.md
+++ b/docs/adr/0001-two-binary-split.md
@@ -34,8 +34,10 @@ A SharpHound/BloodHound-style split addresses both:
 
 - A lean **collector** drops on the target. Static binary, no DB clients,
   ~9 MiB stripped on linux/amd64. Outputs JSON for the operator to transfer or
-  explicitly pipe to the server ingest API/CLI; it has no built-in upload or
-  server control channel.
+  explicitly pipe to the server ingest API/CLI. When the operator supplies an
+  ingest endpoint, it may instead perform a one-shot upload of the completed
+  scan. It has no server-initiated control channel and no dependency on server
+  or database packages; the two-binary trust boundary remains unchanged.
 - A **server** runs on the operator's laptop or on a hardened host they
   fully control. Single user, localhost-bound by default, no auth at the
   application layer.

--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -110,7 +110,7 @@ declared coverage keys. The server never infers fact ownership from a
 single-domain report. A node may set `property_semantics: "reference_only"` to
 assert only its ID and kinds; that mode requires an empty `properties` object.
 Omitting `property_semantics` remains an authoritative property observation.
-Edge endpoint kinds are likewise explicit in v4.
+Edge endpoint kinds are likewise explicit in the current wire contract.
 
 ### Eligible-rule semantic digest boundary
 
@@ -161,7 +161,7 @@ inventory counts, search, or collector wire format.
 `Validator.Validate()` rejects malformed payloads before any graph writes.
 
 Checks performed:
-- `meta.version` must be `4`; v1, v2, and v3 are rejected
+- `meta.version` must be `5`; v1, v2, v3, and v4 are rejected
 - `meta.identity` must have the current scheme/version, canonical HMAC evidence,
   internally consistent IDs, independently derived collection-point and
   network quality classifications, and bounded non-authoritative display labels
@@ -286,6 +286,12 @@ successful scan of target B therefore cannot retire target A. Published
 comparison keys also include the scan revisions of every *other* active
 coverage head, so global graph deltas are withheld when an intervening target
 or config scope changed.
+
+A fully observed empty collection against an empty public graph uses a
+pristine-empty fast path: reconciliation, post-processing, duplicate graph
+statistics, property-completeness queries, and finding queries are known
+no-ops. Limited or otherwise incomplete collection reports cannot enter this
+path; they retain the full v5 lifecycle and analysis checks.
 
 ## Stages 8–12: Analyze, Snapshot, and Publish
 

--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -376,6 +376,7 @@ Dependency validation runs before the first processor executes. If a processor a
 - `Submitted` -- literal artifact contribution counts
 - `WriteRows` -- unique logical nodes/relationships affected by successful
   Neo4j writes, including matches of facts that already existed
+- `Findings` -- findings captured in the published scan snapshot
 - `GraphTotals` -- frozen public inventory totals before and after processing
 - `Warnings` -- operator-facing timestamp, normalization, and coverage
   limitation warnings

--- a/docs/architecture/post-processors.md
+++ b/docs/architecture/post-processors.md
@@ -42,7 +42,7 @@ can_impersonate
 
 ## Scope compatibility policy
 
-Ingest v4 permits evidence from many collection points in one graph. Any
+The ingest v5 model permits evidence from many collection points in one graph. Any
 processor that compares otherwise unrelated observations must use the shared
 exact predicate below; a prose judgment at each call site is not sufficient.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -49,36 +49,36 @@ agenthound --version
 
 The config scan is offline and read-only. It parses all 12 supported MCP
 client config formats on the local machine and reports trust relationships,
-credentials, and instruction files. Choose one coverage level and stream the
-artifact straight into the running server.
+credentials, and instruction files. Choose one coverage level:
 
 **Normal scan — recommended first run.** Checks client configs and registered
 instruction sources at the canonical home and selected project roots without
 recursively searching unrelated directories:
 
 ```bash
-agenthound scan --config --output - \
-  | curl -sS --fail-with-body --data-binary @- -H "Content-Type: application/json" \
-         http://127.0.0.1:8080/api/v1/ingest
+agenthound scan --config --ingest http://127.0.0.1:8080
 ```
 
 **Deep scan — nested project investigation.** Adds bounded discovery of
 registered instruction sources below both home and the selected project:
 
 ```bash
-agenthound scan --config --deep --output - \
-  | curl -sS --fail-with-body --data-binary @- -H "Content-Type: application/json" \
-         http://127.0.0.1:8080/api/v1/ingest
+agenthound scan --config --deep --ingest http://127.0.0.1:8080
 ```
 
 Add `--project-dir /path/to/project` to either command when the target project
 is not the current directory. Deep discovery gives that selected project its
 own scope even when it is inside a normally pruned home subtree.
 
-Or write to disk and ingest in two steps. The collector prints the
-exact filename (`./scan-<scan_id>.json`); use that, not a glob, since
-later scans accumulate alongside it. Add `--deep` to the scan command for the
-same nested-project coverage:
+The collector first saves `./scan-<scan_id>.json` as a backup, uploads those
+exact bytes, then prints a compact receipt with the scan ID, artifact path,
+node, edge, and finding counts, and duration. Pass `--json` for the full server
+receipt or `--output <path>` to choose the backup path. If upload fails, the
+artifact remains available for retry.
+
+You can also scan and ingest manually. The collector prints the exact filename;
+use that, not a glob, since later scans accumulate alongside it. Add `--deep`
+for the same nested-project coverage:
 
 ```bash
 agenthound scan --config                     # prints ./scan-<scan_id>.json

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -174,16 +174,32 @@ The collector makes outbound network calls to:
    collection uses `--insecure`, refuses link-local/cloud-metadata addresses,
    rejects fragments, is response- and per-card-work-bounded, and receives no
    target authorization header.
+3. **An analysis server explicitly selected by the operator** —
+   `agenthound scan --ingest <server-url>` uploads the exact scan artifact
+   already saved on disk to that server's `/api/v1/ingest` endpoint. Redirects
+   are rejected.
 
 There is no telemetry, phone-home, version-check ping, crash reporting, or
-upload to a central server.
+automatic upload to a central service. Direct ingest is an explicit one-shot
+operator action, not a server-to-collector control channel.
 
 Scan output is written to a local file (or to stdout via `--output -`).
 Transport to the operator's analysis box is the operator's
 responsibility — typically a file copy, an SSH pipe
 (`agenthound scan --output - | ssh op-box 'agenthound-server ingest -'`),
-or a drag-drop into the UI's `Scan Manager → Import scan` dialog. The
-collector does not initiate any connection back to a server.
+direct ingest, or a drag-drop into the UI's `Scan Manager → Import scan`
+dialog. Without `--ingest`, the collector does not connect to an analysis
+server.
+
+Direct ingest accepts `http://` and `https://`. Plain HTTP is supported only
+for the default loopback server or an endpoint already protected by an
+operator-controlled VPN/SSH tunnel; it adds no application-layer
+confidentiality and must not cross an untrusted network. Use HTTPS or map the
+remote server to loopback through a trusted tunnel. HTTPS certificate
+verification is strict, and the collection-target `--insecure` flag does not
+weaken ingest TLS. A scan created with `--include-credential-values` can contain
+raw secrets, so its upload requires the same custody and transport protections
+as the saved artifact.
 
 `scripts/deps-check.sh` enforces the dependency boundary: the
 collector binary cannot link `chi`, `pgx`, `neo4j-go-driver`, or any
@@ -468,6 +484,8 @@ output stored on Windows as readable by every local user account.
   card-controlled A2A `jku` always requires HTTPS with certificate and server
   identity validation. Operators assessing internal/self-signed issuers must
   pin their keys with `--a2a-trusted-keys` instead.
+- `--insecure` does not apply to `scan --ingest`. Direct-ingest HTTPS always
+  validates the server certificate and refuses redirects.
 - A regression test in `modules/{mcp,a2a}/*_test.go` asserts strict
   default verification — a code change that silently weakens this
   fails CI.

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -234,9 +234,12 @@ behaviour:
   duplicate canonical names with distinct values, or aliases with different
   argv, environment, URL, or headers, produce a fixed ambiguity outcome before
   any subprocess or network transport is constructed.
-- `--include-credential-values` opts into raw values. Use this only
-  for offline audit work. The output file (containing raw secrets)
-  has no transport-layer protection — protect the file at rest. This opt-in may
+- `--include-credential-values` opts into raw values. Use it only when an
+  authorized workflow explicitly requires them. The output file (containing raw
+  secrets) has no transport-layer protection — protect it at rest. If the
+  artifact is transferred or uploaded with `--ingest`, use HTTPS or a loopback
+  endpoint protected by an operator-controlled VPN/SSH tunnel as described
+  above; never send it over plaintext on an untrusted network. This opt-in may
   include values extracted from argv or URL components on Config Collector
   Credential nodes, but it never restores a raw MCPServer `args` array or raw
   public endpoint.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -314,6 +314,7 @@ credential material.
   "projection_status": "complete",
   "submitted": { "nodes": 47, "edges": 82 },
   "write_rows": { "nodes": 47, "edges": 82 },
+  "findings": 6,
   "graph_totals": {
     "before": { "node_counts": {}, "edge_counts": {}, "total_nodes": 0, "total_edges": 0 },
     "after": { "node_counts": {}, "edge_counts": {}, "total_nodes": 47, "total_edges": 82 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,8 +23,10 @@ The collector has no DB clients, server control channel, telemetry, or
 phone-home behavior. Commands that assess configured or operator-selected
 targets do make target-scoped network requests: MCP/A2A collection, active scan
 and discovery, looters, poisoners, and campaigns use the protocols documented
-for those commands. Move resulting JSON to the analysis box via file copy, SSH
-pipe, an explicit curl pipeline, or the UI's drag-drop import.
+for those commands. `scan --ingest` also makes an explicit one-shot upload to
+the operator-selected analysis server; it is not an automatic central-service
+upload or control channel. Move resulting JSON via direct ingest, file copy,
+SSH pipe, an explicit curl pipeline, or the UI's drag-drop import.
 
 Every artifact-emitting command automatically derives versioned collection-point
 and network-context provenance from native OS, principal, execution-scope, and
@@ -277,6 +279,12 @@ Concurrency precedence for local-mode `scan`: an explicit `--scan-concurrency` a
 default path is `./scan-<scan_id>.json`; use `--output <path>` to choose another
 backup path. `--output -` is incompatible because direct ingest requires a
 recoverable artifact. Redirects are not followed.
+
+Direct-ingest HTTP is supported only for the default loopback server or an
+endpoint already protected by an operator-controlled VPN/SSH tunnel. Use HTTPS
+or a trusted tunnel for any non-loopback route; `--insecure` applies to
+collection targets, not ingest TLS. Artifacts produced with
+`--include-credential-values` can contain raw secrets.
 
 #### Example
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -268,14 +268,24 @@ partial, preventing lifecycle reconciliation from deleting prior service facts.
 | `--timeout` | `120s` | Timeout per server/agent (local MCP/A2A mode). In **network mode**, an explicit positive value applies independently to each TCP probe and HTTP fingerprint task. When omitted/non-positive, TCP defaults to `3s` and HTTP fingerprinting to `5s`; queue wait does not consume the task deadline. |
 | `--insecure` | `false` | Skip TLS verification (both MCP and A2A). |
 | `--scan-output` | | Explicit output path (overrides `--output`). |
+| `--ingest` | | Local mode only. Save the scan artifact, then upload those exact bytes to this AgentHound server base URL. |
+| `--json` | `false` | Print the full remote ingest receipt instead of the compact summary. Requires `--ingest`. |
 
 Concurrency precedence for local-mode `scan`: an explicit `--scan-concurrency` always wins; otherwise the root `--concurrency` / `AGENTHOUND_CONCURRENCY` value is used when positive; otherwise the `--scan-concurrency` default (`5`) holds. `--network-scan-concurrency` is a separate knob and is not affected.
+
+`--ingest` preserves the normal JSON artifact before making the request. The
+default path is `./scan-<scan_id>.json`; use `--output <path>` to choose another
+backup path. `--output -` is incompatible because direct ingest requires a
+recoverable artifact. Redirects are not followed.
 
 #### Example
 
 ```bash
 # Full local scan: config + MCP enumeration
 agenthound scan
+
+# Scan local configs, save a backup artifact, and ingest it
+agenthound scan --config --ingest http://127.0.0.1:8080
 
 # Network sweep of a /24 for exposed AI services
 agenthound scan 10.0.0.0/24 --allow-large-cidr

--- a/sdk/ingest/result.go
+++ b/sdk/ingest/result.go
@@ -26,6 +26,7 @@ type IngestResult struct {
 	ProjectionStatus      string                 `json:"projection_status"`
 	Submitted             FactCounts             `json:"submitted"`
 	WriteRows             FactCounts             `json:"write_rows"`
+	Findings              int                    `json:"findings"`
 	GraphTotals           FrozenGraphTotals      `json:"graph_totals"`
 	Warnings              []string               `json:"warnings,omitempty"`
 	NormalizationStatus   NormalizationStatus    `json:"normalization_status"`

--- a/sdk/ingest/result_test.go
+++ b/sdk/ingest/result_test.go
@@ -31,7 +31,7 @@ func TestIngestResultUsesCanonicalNestedCounts(t *testing.T) {
 	if err := json.Unmarshal(encoded, &body); err != nil {
 		t.Fatal(err)
 	}
-	for _, field := range []string{"submitted", "write_rows", "graph_totals", "collection"} {
+	for _, field := range []string{"submitted", "write_rows", "findings", "graph_totals", "collection"} {
 		if _, ok := body[field]; !ok {
 			t.Errorf("missing %q in %s", field, encoded)
 		}

--- a/server/internal/api/handlers/docs_test.go
+++ b/server/internal/api/handlers/docs_test.go
@@ -65,7 +65,7 @@ func TestOpenAPIProjectionAwareResponseContracts(t *testing.T) {
 	requireSchemaFields(t, schemas, "IngestMetaV5", "identity", "collection")
 	requireSchemaFields(t, schemas, "CollectionIdentityV5", "collection_point_id", "network_context_id", "quality", "network_quality", "network_class", "evidence", "network_evidence")
 	requireSchemaFields(t, schemas, "IngestCollectionV5", "state", "coverage_keys", "outcomes")
-	requireSchemaFields(t, schemas, "IngestResult", "collection", "identity")
+	requireSchemaFields(t, schemas, "IngestResult", "collection", "identity", "findings")
 	ingestResponses := nestedMap(t, spec, "paths", "/ingest", "post", "responses")
 	for _, status := range []string{"200", "400", "403", "500", "503"} {
 		if _, ok := ingestResponses[status]; !ok {

--- a/server/internal/api/handlers/openapi.yaml
+++ b/server/internal/api/handlers/openapi.yaml
@@ -1289,7 +1289,7 @@ components:
     IngestResult:
       type: object
       additionalProperties: false
-      required: [scan_id, outcome, projection_status, submitted, write_rows, graph_totals, normalization_status, collection, identity, duration]
+      required: [scan_id, outcome, projection_status, submitted, write_rows, findings, graph_totals, normalization_status, collection, identity, duration]
       properties:
         scan_id:
           type: string
@@ -1302,6 +1302,9 @@ components:
           $ref: "#/components/schemas/FactCounts"
         write_rows:
           $ref: "#/components/schemas/FactCounts"
+        findings:
+          type: integer
+          minimum: 0
         graph_totals:
           $ref: "#/components/schemas/FrozenGraphTotals"
         warnings:

--- a/server/internal/ingest/pipeline.go
+++ b/server/internal/ingest/pipeline.go
@@ -383,7 +383,9 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	appendStage(result, "write_edges", sdkingest.OutcomeComplete, true, stageStart, nil)
 	slog.Info("edges written", "count", edgesWritten)
 
-	pristineEmptyProjection := graphBefore != nil &&
+	pristineEmptyProjection := coverageComplete &&
+		sdkingest.CollectionCoverageComplete(data.Meta.Collection) &&
+		graphBefore != nil &&
 		graphBefore.TotalNodes == 0 &&
 		graphBefore.TotalEdges == 0 &&
 		len(writeGraph.Nodes) == 0 &&

--- a/server/internal/ingest/pipeline.go
+++ b/server/internal/ingest/pipeline.go
@@ -383,6 +383,17 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	appendStage(result, "write_edges", sdkingest.OutcomeComplete, true, stageStart, nil)
 	slog.Info("edges written", "count", edgesWritten)
 
+	pristineEmptyProjection := graphBefore != nil &&
+		graphBefore.TotalNodes == 0 &&
+		graphBefore.TotalEdges == 0 &&
+		len(writeGraph.Nodes) == 0 &&
+		len(writeGraph.Edges) == 0 &&
+		result.WriteRows.Nodes == 0 &&
+		result.WriteRows.Edges == 0
+	if pristineEmptyProjection {
+		slog.Info("using pristine empty projection fast path")
+	}
+
 	// Stage 7: Promote explicitly complete raw-observation domains. Unknown or
 	// partial coverage is retained without retirement.
 	var (
@@ -390,7 +401,9 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		reconcileErr   error
 	)
 	stageStart = time.Now()
-	if len(reconciliationDomains) == 0 {
+	if pristineEmptyProjection {
+		appendStage(result, "reconcile_observations", sdkingest.OutcomeComplete, true, stageStart, nil)
+	} else if len(reconciliationDomains) == 0 {
 		appendStage(result, "reconcile_observations", sdkingest.OutcomeUnknown, true, stageStart, nil)
 	} else {
 		reconciliation, reconcileErr = graph.ReconcileObservations(
@@ -414,7 +427,9 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	// composite epoch, rebuilt from the retained current raw projection.
 	var ppErr error
 	stageStart = time.Now()
-	if p.graphDB != nil && p.runPP != nil {
+	if pristineEmptyProjection && p.graphDB != nil && p.runPP != nil {
+		appendStage(result, "analysis", sdkingest.OutcomeComplete, true, stageStart, nil)
+	} else if p.graphDB != nil && p.runPP != nil {
 		var ppStats []graph.ProcessingStats
 		ppStats, ppErr = p.runPP(
 			ctx,
@@ -447,7 +462,9 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	// composite epoch during the first reconciliation pass.
 	var pruneErr error
 	stageStart = time.Now()
-	if ppErr == nil && len(promotedDomains) > 0 {
+	if pristineEmptyProjection && ppErr == nil && len(promotedDomains) > 0 {
+		appendStage(result, "prune_observations", sdkingest.OutcomeComplete, true, stageStart, nil)
+	} else if ppErr == nil && len(promotedDomains) > 0 {
 		var deleted int
 		deleted, pruneErr = graph.PruneUnownedObservationNodes(ctx, p.graphDB)
 		reconciliation.NodesDeleted += deleted
@@ -479,7 +496,17 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		observationStatus        string
 	)
 	stageStart = time.Now()
-	if p.graphDB == nil {
+	if pristineEmptyProjection {
+		observationStatus = model.LifecycleComplete
+		appendStage(
+			result,
+			"observation_completeness",
+			sdkingest.OutcomeComplete,
+			true,
+			stageStart,
+			nil,
+		)
+	} else if p.graphDB == nil {
 		observationQueryErr = fmt.Errorf("graph database unavailable")
 		observationStatus = model.LifecycleFailed
 		appendStage(
@@ -542,7 +569,14 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		graphAfterErr error
 	)
 	stageStart = time.Now()
-	if p.graphDB == nil {
+	if pristineEmptyProjection {
+		graphAfter = &model.GraphSnapshot{
+			NodeCounts: map[string]int64{},
+			EdgeCounts: map[string]int64{},
+		}
+		result.GraphTotals.After = sdkGraphTotals(graphAfter)
+		appendStage(result, "graph_stats_after", sdkingest.OutcomeComplete, true, stageStart, nil)
+	} else if p.graphDB == nil {
 		appendStage(result, "graph_stats_after", sdkingest.OutcomeNotApplicable, false, stageStart, nil)
 	} else {
 		stats, err := p.graphDB.GetStats(ctx)
@@ -574,6 +608,9 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	case ppErr != nil:
 		snapshotErr = fmt.Errorf("analysis incomplete: %w", ppErr)
 		appendStage(result, "snapshot", sdkingest.OutcomeFailed, true, stageStart, snapshotErr)
+	case pristineEmptyProjection:
+		snapshot = []model.Finding{}
+		appendStage(result, "snapshot", sdkingest.OutcomeComplete, true, stageStart, nil)
 	default:
 		snapshot, snapshotErr = analysis.QueryFindings(ctx, p.graphDB, "")
 		if snapshotErr != nil {
@@ -588,6 +625,7 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	if snapshot == nil {
 		snapshot = []model.Finding{}
 	}
+	result.Findings = len(snapshot)
 
 	publicationDomains := finalizedDomains
 	if observationQueryErr != nil || observationIncompleteErr != nil {

--- a/server/internal/ingest/pipeline_test.go
+++ b/server/internal/ingest/pipeline_test.go
@@ -1211,11 +1211,16 @@ func TestPipeline_CompleteEmptyRootClearsFailedUnheadedChild(t *testing.T) {
 	}
 	publisher := &fakePublisher{lifecycle: lifecycle}
 	writer := &fakeWriter{}
+	db := &graph.MockGraphDB{}
+	var ppCalls int
 	p := newTestPipeline(
 		writer,
-		&graph.MockGraphDB{},
+		db,
 		lifecycle,
-		noOpRunPP,
+		func(context.Context, graph.GraphDB, string, []string) ([]graph.ProcessingStats, error) {
+			ppCalls++
+			return nil, nil
+		},
 	)
 	p.findingStore = publisher
 
@@ -1240,6 +1245,49 @@ func TestPipeline_CompleteEmptyRootClearsFailedUnheadedChild(t *testing.T) {
 	}
 	if len(lifecycle.dirtyCoverage) != 0 {
 		t.Fatalf("dirty coverage after recovery = %v, want none", lifecycle.dirtyCoverage)
+	}
+	if ppCalls != 0 {
+		t.Fatalf("pristine empty projection ran post-processors %d time(s), want 0", ppCalls)
+	}
+	if got := len(db.CallsTo("GetStats")); got != 1 {
+		t.Fatalf("pristine empty projection queried graph stats %d time(s), want 1", got)
+	}
+	if calls := db.CallsTo("Query"); len(calls) != 0 {
+		t.Fatalf("pristine empty projection ran graph queries: %+v", calls)
+	}
+	if calls := db.CallsTo("ExecuteWrite"); len(calls) != 0 {
+		t.Fatalf("pristine empty projection ran graph writes: %+v", calls)
+	}
+}
+
+func TestPipeline_EmptySubmissionAgainstExistingProjectionRunsPostProcessors(t *testing.T) {
+	data := validIngestDataFor("scan-empty-existing-projection")
+	data.Graph = sdkingest.GraphData{
+		Nodes: []sdkingest.Node{},
+		Edges: []sdkingest.Edge{},
+	}
+	db := &graph.MockGraphDB{
+		StatsResult: &graph.GraphStats{
+			NodeCounts: map[string]int64{"MCPServer": 1},
+			TotalNodes: 1,
+		},
+	}
+	var ppCalls int
+	p := newTestPipeline(
+		&fakeWriter{},
+		db,
+		&fakeScanStore{},
+		func(context.Context, graph.GraphDB, string, []string) ([]graph.ProcessingStats, error) {
+			ppCalls++
+			return nil, nil
+		},
+	)
+
+	if _, err := p.Ingest(context.Background(), data); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if ppCalls != 1 {
+		t.Fatalf("empty submission against existing projection ran post-processors %d time(s), want 1", ppCalls)
 	}
 }
 

--- a/server/internal/ingest/publication_integration_test.go
+++ b/server/internal/ingest/publication_integration_test.go
@@ -436,6 +436,44 @@ INSERT INTO posture_state (singleton) VALUES (TRUE);`); err != nil {
 	}
 }
 
+func TestIntegrationFreshSchemaEmptyIngestPublishesUnderThreeSeconds(t *testing.T) {
+	ctx, pipeline, _, _, _ := freshPublicationIntegrationHarness(t)
+	root := sdkingest.CollectorRootCoverageKey("config")
+	data := newPublicationIntegrationData("config", "fresh-empty-publication")
+	data.Meta.Collection = &sdkingest.CollectionReport{
+		State:        sdkingest.OutcomeComplete,
+		CoverageKeys: []string{root},
+		AuthoritativeRoots: []sdkingest.CoverageRoot{{
+			CoverageKey: root,
+		}},
+		Outcomes: []sdkingest.CollectionOutcome{{
+			Collector:   "config",
+			CoverageKey: root,
+			Target:      "config",
+			Method:      "collect",
+			State:       sdkingest.OutcomeComplete,
+		}},
+	}
+
+	start := time.Now()
+	result, err := pipeline.Ingest(ctx, data)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("empty ingest: %v", err)
+	}
+	if result.Outcome != sdkingest.OutcomeComplete ||
+		result.ProjectionStatus != "complete" ||
+		result.PublishedRevision == nil {
+		t.Fatalf("empty ingest result = %+v, want complete published projection", result)
+	}
+	if len(result.PostProcessingStats) != 0 {
+		t.Fatalf("empty ingest ran post-processors: %+v", result.PostProcessingStats)
+	}
+	if elapsed >= 3*time.Second {
+		t.Fatalf("empty ingest took %s, want under 3s", elapsed)
+	}
+}
+
 func TestIntegrationExhaustiveRootRemovesMissingChildAcrossGraphAndPublication(t *testing.T) {
 	ctx, pipeline, db, _, pool := freshPublicationIntegrationHarness(t)
 	root := sdkingest.CanonicalCoverageKey("mcp", "root", "collect")

--- a/server/internal/ingest/publication_integration_test.go
+++ b/server/internal/ingest/publication_integration_test.go
@@ -439,20 +439,54 @@ INSERT INTO posture_state (singleton) VALUES (TRUE);`); err != nil {
 func TestIntegrationFreshSchemaEmptyIngestPublishesUnderThreeSeconds(t *testing.T) {
 	ctx, pipeline, _, _, _ := freshPublicationIntegrationHarness(t)
 	root := sdkingest.CollectorRootCoverageKey("config")
+	userInstructionRoot := sdkingest.CanonicalCoverageKey(
+		"config",
+		"instruction-exact-user",
+		"/tmp/agenthound-empty-user",
+	)
+	projectInstructionRoot := sdkingest.CanonicalCoverageKey(
+		"config",
+		"instruction-exact-project",
+		"/tmp/agenthound-empty-project",
+	)
+	registryContract := sdkingest.CurrentInstructionRegistryContract()
 	data := newPublicationIntegrationData("config", "fresh-empty-publication")
 	data.Meta.Collection = &sdkingest.CollectionReport{
-		State:        sdkingest.OutcomeComplete,
-		CoverageKeys: []string{root},
-		AuthoritativeRoots: []sdkingest.CoverageRoot{{
-			CoverageKey: root,
-		}},
-		Outcomes: []sdkingest.CollectionOutcome{{
-			Collector:   "config",
-			CoverageKey: root,
-			Target:      "config",
-			Method:      "collect",
-			State:       sdkingest.OutcomeComplete,
-		}},
+		State: sdkingest.OutcomeComplete,
+		CoverageKeys: []string{
+			root,
+			userInstructionRoot,
+			projectInstructionRoot,
+		},
+		AuthoritativeRoots: []sdkingest.CoverageRoot{
+			{CoverageKey: root},
+			{
+				CoverageKey:      userInstructionRoot,
+				RegistryContract: &registryContract,
+			},
+			{
+				CoverageKey:      projectInstructionRoot,
+				RegistryContract: &registryContract,
+			},
+		},
+		Outcomes: []sdkingest.CollectionOutcome{
+			{
+				Collector: "config", CoverageKey: root, Target: "config",
+				Method: "collect", State: sdkingest.OutcomeComplete,
+			},
+			{
+				Collector: "config", CoverageKey: userInstructionRoot,
+				Target: "/tmp/agenthound-empty-user",
+				Method: sdkingest.InstructionMethodExactUser,
+				State:  sdkingest.OutcomeComplete,
+			},
+			{
+				Collector: "config", CoverageKey: projectInstructionRoot,
+				Target: "/tmp/agenthound-empty-project",
+				Method: sdkingest.InstructionMethodExactProject,
+				State:  sdkingest.OutcomeComplete,
+			},
+		},
 	}
 
 	start := time.Now()


### PR DESCRIPTION
## Problem

The documented first-run workflow required operators to pipe collector output
through `curl`, while a valid empty scan still paid the full cost of graph
reconciliation, post-processing, duplicate statistics, property-completeness,
and finding queries.

The collector should offer an explicit, recoverable upload workflow, and the
server should avoid provably empty work without weakening the v5 coverage and
publication contract introduced by #115.

## Product decisions

- Direct ingest is explicit operator intent, not telemetry or a server control
  channel.
- The normal JSON artifact remains the durable handoff. It is saved before
  upload, and the exact saved bytes are sent.
- Normal and `--deep` config scans use the same first-class workflow.
- A fast path is valid only when the submitted collection is fully observed,
  the current public graph is empty, and the submitted graph is empty.
- Limited or incomplete instruction coverage always retains the full v5
  lifecycle and analysis path.

## What changed

### Collector UX

- Add `agenthound scan --config --ingest http://127.0.0.1:8080`.
- Preserve `./scan-<scan_id>.json` (or `--output <path>`) before upload.
- Print progress and a compact correlated receipt containing scan ID, artifact,
  submitted nodes/edges, findings, and duration.
- Add `--json` for the full server receipt.
- Keep normal versus `--deep` discovery and `--project-dir` behavior from #115.
- Surface collector coverage warnings and label a published limited result
  `Ingest complete with coverage limitations`.
- Reject redirects, malformed endpoint shapes, `--output -` with direct ingest,
  and uncorrelated or unpublished receipts.
- Retain the artifact when collection or upload fails.

### Server ingest

- Return the current published finding count in `IngestResult` and OpenAPI.
- Skip no-op reconciliation, analysis, second graph statistics,
  property-completeness, and finding queries only for a fully observed empty
  collection against an empty graph.
- Continue processing coverage heads and dirty-state recovery through the
  normal PostgreSQL lifecycle.
- Never apply the optimization to partial, truncated, failed, or otherwise
  limited collection reports.

## Security and transport

- HTTPS verification remains strict; collection-target `--insecure` does not
  affect ingest TLS.
- Plain HTTP is documented only for loopback or an operator-protected VPN/SSH
  route.
- Artifacts containing `--include-credential-values` retain their existing raw
  credential custody requirements.
- The collector still links no server, Neo4j, PostgreSQL, or HTTP-server
  dependencies.

## v5 integration

This branch is rebased onto merged PR #115. The integration preserves v5
registry-backed exact/deep ownership, limited-publication warnings, and
mandatory exact-root validation. The pristine-empty optimization is explicitly
gated on complete registered-source coverage, and its fresh-schema integration
fixture declares the current exact-user and exact-project registry roots.

## Verification

- Focused race tests:
  `go test -race ./collector/cli ./sdk/ingest ./server/internal/ingest ./server/internal/api/handlers`
- `make docs-check` — strict documentation build passes.
- `make prerelease` — all 13 release gates pass.
- CI exercises the fresh-schema empty path against both Neo4j 4.4 and Neo4j 5.
