### PR TITLE
Fix auth provenance ownership across collectors

### DIFF
--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -174,12 +174,16 @@ Checks performed:
 - Every node must have a non-empty `id` and at least one `kind` from `AllowedNodeKinds` (23 kinds)
 - Every edge must have non-empty `source`/`target` and a `kind` from `RawEdgeKinds` (20 kinds)
 - v1 property aliases are rejected; canonical status/evidence fields are
-  required for credentials, hosts, MCP servers, and A2A agents
-- configured MCP/A2A method, assurance, and evidence must form a
-  producer-compatible tuple
-- MCP observed auth must be a complete protocol-valid tuple; A2A observed auth
-  is accepted only for the exact bounded nonexistent-task positive probe with
-  its method and status metadata
+  required for credentials and hosts
+- configured MCP/A2A method, assurance, and evidence are optional as a channel,
+  but any present channel must be a complete producer-compatible tuple
+- MCP observed auth is optional and atomic; any present tuple must be
+  protocol-valid
+- A2A probe method/status/detail are optional and atomic; only the exact bounded
+  nonexistent-task positive probe may add the exact observed anonymous tuple,
+  while non-positive diagnostics must omit observed auth
+- A2A signature status/source/trust/`is_signed` are either all absent or all
+  present and mutually consistent
 
 Validation errors are structured (`FieldError` with JSON path + message) and returned as a `ValidationError` to the caller. On failure, the pipeline aborts -- no partial writes.
 

--- a/docs/architecture/post-processors.md
+++ b/docs/architecture/post-processors.md
@@ -105,6 +105,12 @@ read-only observation `auth_probe_method=get_task_nonexistent`,
 inconclusive probe diagnostics, missing metadata, and every other A2A observed
 tuple retain configured-derived behavior.
 
+Both raw provenance channels are optional and atomic. A valid known observed
+tuple can therefore materialize effective authentication without a configured
+tuple. If neither a valid known observed tuple nor a complete valid configured
+tuple remains, the pass sets every derived `effective_auth_*` property and
+`auth_strength` to null so retired owners cannot leave stale posture behind.
+
 The evidence-aware policy is none=100/unauthenticated only for an
 `effective_auth_source=observed` tuple carrying
 `anonymous_probe_succeeded`, basic=85/weak, apiKey=70/weak,

--- a/docs/operator/discover.md
+++ b/docs/operator/discover.md
@@ -39,7 +39,17 @@ agenthound discover 198.51.100.0/24 \
 
 ## Output
 
-The output file is a standard ingest envelope. `discover` emits raw `:MCPServer` and `:A2AAgent` nodes with `discovered_via: "protoscan"` and the discovered base URL. The analysis server ingests those facts but does not enumerate the endpoints. To collect tools, resources, and prompts from MCP or skills and delegation from A2A, rerun the collector with `agenthound scan --mcp --url <url>` or `agenthound scan --a2a --target <url>` against each discovered endpoint and ingest that output.
+The output file is a standard ingest envelope. `discover` emits sparse raw
+`:MCPServer` and `:A2AAgent` nodes with `discovered_via: "protoscan"` and the
+discovered base URL. Discovery does not claim configured/declarative auth,
+runtime auth, A2A probe diagnostics, or A2A signature posture; those properties
+are absent rather than set to `unknown` because this producer does not own those
+assessment channels. The analysis server ingests the discovery facts but does
+not enumerate the endpoints. To collect tools, resources, and prompts from MCP
+or skills and delegation from A2A, rerun the collector with
+`agenthound scan --mcp --url <url>` or
+`agenthound scan --a2a --target <url>` against each discovered endpoint and
+ingest that output.
 
 ```json
 {
@@ -104,10 +114,7 @@ The output file is a standard ingest envelope. `discover` emits raw `:MCPServer`
           "endpoint": "http://10.0.0.42:3000",
           "transport": "http",
           "discovered_via": "protoscan",
-          "protocol": "mcp",
-          "auth_method": "unknown",
-          "auth_assurance": "unknown",
-          "auth_evidence": "unknown"
+          "protocol": "mcp"
         },
         "observation_domains": ["scan:discover:sha256:..."]
       }

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -209,8 +209,10 @@ consistency, and evidence classification rules but cannot prove where the
 collector ran. A database marker that cannot be verified returns sanitized
 `503 STORAGE_BINDING_UNAVAILABLE` before any graph write.
 
-For `MCPServer` and `A2AAgent`, configured method, assurance, and evidence must
-form a producer-compatible tuple. Method-to-assurance mapping is fixed;
+For `MCPServer` and `A2AAgent`, configured method, assurance, and evidence are
+an optional atomic provenance tuple: all three may be absent when the producer
+did not inspect configuration/declarations, but a present tuple must contain
+all three producer-compatible values. Method-to-assurance mapping is fixed;
 anonymous-probe evidence requires `none/unauthenticated`, local-process
 evidence requires `unknown/unknown`, known authenticated/custom methods require
 configured-credential or declared-scheme evidence, and the documented
@@ -243,6 +245,19 @@ and inconclusive results may publish the canonical diagnostic triple but must
 omit `observed_auth_*`; orphan positive status, partial/wrongly typed metadata,
 arbitrary status/detail, generic observed tuples, and observed fields on a
 non-positive status return `400 VALIDATION_ERROR`.
+
+The A2A probe diagnostic fields `auth_probe_method`, `auth_probe_status`, and
+`auth_probe_detail` are themselves optional and atomic. Sparse protocol
+discovery may omit the entire probe/observed set. If any diagnostic is present,
+all three are required. `anonymous_protocol_access` requires the exact observed
+anonymous tuple above; `authentication_required` and `unknown` preserve their
+bounded diagnostic triple and must omit every `observed_auth_*` field.
+
+A2A signature posture is likewise optional and atomic:
+`signature_verification_status`, `signature_key_source`,
+`signature_key_trust`, and `is_signed` must be either all absent or all present
+and mutually consistent. Full A2A card collection emits all four; sparse
+protocol discovery emits none.
 
 Normalization preserves pre-v1 direct-URL MCP artifacts that predate the
 configured/observed split. Only an envelope with `meta.collector=mcp` and a

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -20,11 +20,11 @@ These are the node kinds accepted in ingest input (`sdk/ingest.AllowedNodeKinds`
 
 | Label | Source | Key Properties |
 |-------|--------|----------------|
-| `MCPServer` | Config + MCP | deterministic safe `name`, live `server_name`, `transport` (stdio/http), configured `auth_method`/`auth_assurance`/`auth_evidence`, live `observed_auth_method`/`observed_auth_assurance`/`observed_auth_evidence`, derived paired `effective_auth_method`/`effective_auth_assurance`/`effective_auth_evidence`/`effective_auth_source`, `auth_strength` (numeric weakness only when known, post-processor), `protocol_version`, `instructions`, `instructions_hash` (SHA-256), `capabilities`, `pinning_status`, `is_pinned` (only when known), `id_scheme`; stdio `command`, ordered `arg_hashes`, `arg_count`; HTTP sanitized `endpoint`, `endpoint_userinfo_redacted`, `endpoint_query_redacted`, `endpoint_fragment_redacted` when applicable; MCP-discovery `configured_names`; `has_tasks_capability` (`true` for a non-null raw tasks object, `false` when the raw key is absent, omitted when raw presence is unavailable or ambiguous) |
+| `MCPServer` | Config + MCP + protocol discovery | deterministic safe `name`, live `server_name`, `transport` (stdio/http), optional configured `auth_method`/`auth_assurance`/`auth_evidence`, optional live `observed_auth_method`/`observed_auth_assurance`/`observed_auth_evidence`, derived paired `effective_auth_method`/`effective_auth_assurance`/`effective_auth_evidence`/`effective_auth_source`, `auth_strength` (numeric weakness only when known, post-processor), `protocol_version`, `instructions`, `instructions_hash` (SHA-256), `capabilities`, `pinning_status`, `is_pinned` (only when known), `id_scheme`; stdio `command`, ordered `arg_hashes`, `arg_count`; HTTP sanitized `endpoint`, `endpoint_userinfo_redacted`, `endpoint_query_redacted`, `endpoint_fragment_redacted` when applicable; MCP-discovery `configured_names`; protocol-discovery `discovered_via`; `has_tasks_capability` (`true` for a non-null raw tasks object, `false` when the raw key is absent, omitted when raw presence is unavailable or ambiguous) |
 | `MCPTool` | MCP | `name`, `description`, `input_schema`, `output_schema`, `annotations`, `description_hash` (SHA-256), `input_schema_hash` (SHA-256), `schema_keys[]`, `capability_surface[]`, `source_trust` (untrusted_web/email/fileshare), `has_injection_patterns`, `has_cross_references` |
 | `MCPResource` | MCP | `uri`, `name`, `mime_type`, `size` (bytes; omitted when the SDK reports zero because its scalar model cannot distinguish an omitted size from an explicit zero), `uri_scheme`, `sensitivity` (`critical`/`high`/`medium`/`low`/`none`/`unknown`), `sensitivity_rule_id`, `sensitivity_evidence` |
 | `MCPPrompt` | MCP | `name`, `description`, `arguments` |
-| `A2AAgent` | A2A | `name`, `description`, `url`, `provider`, `version`, `card_schema_version`, `card_present_fields`, `card_conformant`, `card_conformance_errors`, ordered `interfaces`, `protocol_versions`, `capabilities`, `security_schemes`, OR-of-AND `security_requirements`, configured `auth_method`/`auth_assurance`/`auth_evidence`, bounded read-only `auth_probe_method`/`auth_probe_status`/`auth_probe_detail` diagnostics and exact-positive `observed_auth_method`/`observed_auth_assurance`/`observed_auth_evidence`, derived paired `effective_auth_method`/`effective_auth_assurance`/`effective_auth_evidence`/`effective_auth_source`, `auth_strength` (numeric only when known), `is_https`, `is_signed`, `signature_verification_status`, `signature_key_source`, `signature_key_trust`, `card_hash` |
+| `A2AAgent` | A2A + protocol discovery | `name`, `description`, `url`, `provider`, `version`, `card_schema_version`, `card_present_fields`, `card_conformant`, `card_conformance_errors`, ordered `interfaces`, `protocol_versions`, `capabilities`, `security_schemes`, OR-of-AND `security_requirements`, optional declared `auth_method`/`auth_assurance`/`auth_evidence`, optional bounded read-only `auth_probe_method`/`auth_probe_status`/`auth_probe_detail` diagnostics and exact-positive `observed_auth_method`/`observed_auth_assurance`/`observed_auth_evidence`, derived paired `effective_auth_method`/`effective_auth_assurance`/`effective_auth_evidence`/`effective_auth_source`, `auth_strength` (numeric only when known), `is_https`, atomic `is_signed`/`signature_verification_status`/`signature_key_source`/`signature_key_trust` posture, `card_hash`; sparse protocol discovery emits endpoint identity and `discovered_via` without auth, probe, or signature posture |
 | `A2ASkill` | A2A | `id`, `name`, `description`, `input_modes`, `output_modes`, `security_requirements`, `conformant`, `conformance_errors`, `description_hash`, `has_injection_patterns` |
 | `AgentInstance` | Config | `name`, `framework`, `config_path` |
 | `Identity` | Config + A2A | `type` (none/apiKey/oauth/bearer/mtls), server-identity `scope`, `is_static` |
@@ -79,6 +79,12 @@ skill's `ADVERTISES_SKILL` edge and record declared `auth_method=none` where the
 requirements reduce to anonymous access; they are not runtime proof of
 anonymous access.
 
+Absence and `unknown` are distinct provenance states. A missing configured or
+declared auth tuple means that producer did not inspect that channel. A complete
+`unknown/unknown/...` tuple means it did inspect the channel but could not
+reduce the evidence to a known method. Protocol-discovery nodes therefore omit
+authentication fields instead of fabricating configured or declared posture.
+
 `is_signed` records a non-empty signature declaration.
 `signature_verification_status` is:
 
@@ -95,8 +101,10 @@ anonymous access.
 
 `signature_key_source` (`none`/`trusted_store`/`jku`) and
 `signature_key_trust` (`unknown`/`untrusted`/`trusted`) keep cryptographic
-validity separate from identity trust. Ingest rejects contradictory
-status/source/trust/`is_signed` tuples. v1.0.1 verification applies pinned
+validity separate from identity trust. These fields and `is_signed` are an
+atomic four-field posture: all are absent when no signature assessment was
+performed, otherwise all are present. Ingest rejects partial or contradictory
+tuples. v1.0.1 verification applies pinned
 ProtoJSON presence/default metadata, removes `signatures`, bounds signed-card
 size/depth/object width, then uses RFC 8785 JCS and object-form JWS. Compact
 strings, duplicate protected/unprotected JOSE parameters, inline `jwks`, and

--- a/docs/reference/risk-scoring.md
+++ b/docs/reference/risk-scoring.md
@@ -43,6 +43,11 @@ to every agent. Weighted traversal, direct `CAN_REACH` confidence, exact
 finding-path cost, and AgentInstance auth risk consume the effective fields;
 raw configured values remain available as provenance.
 
+An observed-only server or agent receives an exact auth factor when its runtime
+tuple satisfies the protocol evidence contract. A discovery-only or otherwise
+auth-evidence-free node has no effective auth tuple and contributes the existing
+bounded unknown auth factor; absence is not treated as anonymous or safe.
+
 ### Campaign verification evidence
 
 The [campaign runner](../operator/offensive-actions.md#campaign-runner-verify-and-validate) does not add new scored risk:

--- a/modules/config/collector.go
+++ b/modules/config/collector.go
@@ -436,13 +436,7 @@ func ServerNodeProperties(srv ServerDef, engine *rules.Engine) map[string]any {
 }
 
 func serverNodeProperties(srv ServerDef, creds []CredentialInfo) map[string]any {
-	identity := serverIdentityFor(srv)
-	displayName := stdioServerDisplayName(srv.Command, identity.ObjectID)
-	var safeHTTP ingest.SanitizedHTTPEndpoint
-	if srv.Transport == "http" {
-		safeHTTP = ingest.SanitizeHTTPEndpoint(srv.URL)
-		displayName = safeHTTP.Display
-	}
+	props := ServerIdentityProperties(srv)
 	authMethod := deriveAuthMethod(srv.Transport, creds)
 	authAssessment := common.AssessAuth(string(authMethod))
 	authEvidence := common.AuthEvidenceConfiguredCredential
@@ -452,6 +446,24 @@ func serverNodeProperties(srv ServerDef, creds []CredentialInfo) map[string]any 
 			authEvidence = common.AuthEvidenceLocalProcess
 		}
 	}
+
+	props["auth_method"] = string(authMethod)
+	props["auth_assurance"] = string(authAssessment.Assurance)
+	props["auth_evidence"] = authEvidence
+	return props
+}
+
+// ServerIdentityProperties returns only transport identity and non-auth posture.
+// Direct live MCP observations use this boundary because they have no client
+// configuration claim to author; configured collectors add auth_* separately.
+func ServerIdentityProperties(srv ServerDef) map[string]any {
+	identity := serverIdentityFor(srv)
+	displayName := stdioServerDisplayName(srv.Command, identity.ObjectID)
+	var safeHTTP ingest.SanitizedHTTPEndpoint
+	if srv.Transport == "http" {
+		safeHTTP = ingest.SanitizeHTTPEndpoint(srv.URL)
+		displayName = safeHTTP.Display
+	}
 	pinningStatus := common.PinningNotApplicable
 	if srv.Transport == "stdio" {
 		pinningStatus = AssessPinning(srv.Command, srv.Args)
@@ -460,9 +472,6 @@ func serverNodeProperties(srv ServerDef, creds []CredentialInfo) map[string]any 
 	props := map[string]any{
 		"name":           displayName,
 		"transport":      srv.Transport,
-		"auth_method":    string(authMethod),
-		"auth_assurance": string(authAssessment.Assurance),
-		"auth_evidence":  authEvidence,
 		"pinning_status": string(pinningStatus),
 		"id_scheme":      identity.Scheme,
 	}

--- a/modules/mcp/collector_test.go
+++ b/modules/mcp/collector_test.go
@@ -778,6 +778,42 @@ func TestMCPCollectorAmbiguousAliasesDoNotExecuteOrLeak(t *testing.T) {
 	}
 }
 
+func TestMCPCollectorMixedDirectAndConfiguredProfilesRemainFailClosed(t *testing.T) {
+	var requests atomic.Int64
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer httpServer.Close()
+
+	configPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
+	document := fmt.Sprintf(
+		`{"mcpServers":{"configured":{"url":%q,"headers":{"Authorization":"Bearer synthetic-canary"}}}}`,
+		httpServer.URL,
+	)
+	if err := os.WriteFile(configPath, []byte(document), 0o600); err != nil {
+		t.Fatalf("write mixed-profile config: %v", err)
+	}
+
+	result, err := NewMCPCollector().Collect(context.Background(), collector.CollectOptions{
+		TargetURL:  httpServer.URL,
+		ConfigPath: configPath,
+		ScanID:     "mixed-direct-config",
+	})
+	if err != nil {
+		t.Fatalf("Collect should retain a typed failed outcome: %v", err)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("mixed direct/config profiles reached the network: requests=%d", requests.Load())
+	}
+	if len(result.Graph.Nodes) != 0 || len(result.Graph.Edges) != 0 {
+		t.Fatalf("mixed direct/config ambiguity emitted arbitrary graph facts: %+v", result.Graph)
+	}
+	if result.Meta.Collection == nil || result.Meta.Collection.State == ingest.OutcomeComplete {
+		t.Fatalf("mixed direct/config ambiguity reported complete: %+v", result.Meta.Collection)
+	}
+}
+
 func TestMCPCollectorSanitizesLiveHTTPURLSecretsAcrossEntireEnvelope(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "safe-server", Version: "1.0.0"}, nil)
 	const userinfoSecret = "sk-RAW-LIVE-USERINFO-SECRET-123456789"

--- a/modules/mcp/enumerate.go
+++ b/modules/mcp/enumerate.go
@@ -519,7 +519,7 @@ func buildServerNode(serverID string, spec ServerSpec, initResult *mcpsdk.Initia
 
 	authMethod, authEvidence := observedServerAuth(spec)
 	authAssessment := common.AssessAuth(string(authMethod))
-	props := config.ServerNodeProperties(serverDefForSpec(spec), engine)
+	props := serverNodePropertiesForSpec(spec, engine)
 	if serverName != "" {
 		props["server_name"] = serverName
 	}
@@ -559,7 +559,7 @@ func buildUnreachableServerNode(
 	errMsg string,
 	engine *rules.Engine,
 ) ingest.Node {
-	props := config.ServerNodeProperties(serverDefForSpec(spec), engine)
+	props := serverNodePropertiesForSpec(spec, engine)
 	props["status"] = "unreachable"
 	props["error"] = safeStoredMCPError(errMsg)
 	props["observed_auth_method"] = string(common.AuthUnknown)
@@ -586,6 +586,14 @@ func serverDefForSpec(spec ServerSpec) config.ServerDef {
 		Args: append([]string(nil), spec.Args...), Env: spec.Env, URL: spec.URL,
 		Headers: spec.Headers,
 	}
+}
+
+func serverNodePropertiesForSpec(spec ServerSpec, engine *rules.Engine) map[string]any {
+	server := serverDefForSpec(spec)
+	if spec.Configured {
+		return config.ServerNodeProperties(server, engine)
+	}
+	return config.ServerIdentityProperties(server)
 }
 
 type hostResult struct {

--- a/modules/mcp/enumerate_test.go
+++ b/modules/mcp/enumerate_test.go
@@ -331,6 +331,62 @@ func TestBuildConfiguredServerNodeSeparatesConfiguredAndObservedClaims(t *testin
 	}
 }
 
+func TestBuildDirectServerNodePublishesOnlyObservedAuth(t *testing.T) {
+	engine := testEnumerateEngine(t)
+	node := buildServerNode(
+		"sha256:direct",
+		ServerSpec{
+			Name: "direct", Transport: "http", URL: "http://mcp.example/mcp",
+		},
+		&mcpsdk.InitializeResult{
+			ProtocolVersion: "2025-06-18",
+			ServerInfo:      &mcpsdk.Implementation{Name: "direct", Version: "1.0"},
+		},
+		engine,
+	)
+
+	for _, property := range []string{"auth_method", "auth_assurance", "auth_evidence"} {
+		if _, present := node.Properties[property]; present {
+			t.Errorf("direct MCP observation authored configured %s: %+v", property, node.Properties)
+		}
+	}
+	for property, want := range map[string]any{
+		"observed_auth_method":    string(common.AuthNone),
+		"observed_auth_assurance": string(common.AuthAssuranceUnauthenticated),
+		"observed_auth_evidence":  common.AuthEvidenceAnonymousProbeSucceeded,
+	} {
+		if got := node.Properties[property]; got != want {
+			t.Errorf("%s = %v, want %v; properties=%+v", property, got, want, node.Properties)
+		}
+	}
+}
+
+func TestBuildDirectUnreachableServerNodePublishesOnlyObservedUnknown(t *testing.T) {
+	node := buildUnreachableServerNode(
+		"sha256:direct-unreachable",
+		ServerSpec{
+			Name: "direct", Transport: "http", URL: "http://mcp.example/mcp",
+		},
+		"connection failed",
+		testEnumerateEngine(t),
+	)
+
+	for _, property := range []string{"auth_method", "auth_assurance", "auth_evidence"} {
+		if _, present := node.Properties[property]; present {
+			t.Errorf("unreachable direct MCP observation authored configured %s: %+v", property, node.Properties)
+		}
+	}
+	for property, want := range map[string]any{
+		"observed_auth_method":    string(common.AuthUnknown),
+		"observed_auth_assurance": string(common.AuthAssuranceUnknown),
+		"observed_auth_evidence":  common.AuthEvidenceUnknown,
+	} {
+		if got := node.Properties[property]; got != want {
+			t.Errorf("%s = %v, want %v; properties=%+v", property, got, want, node.Properties)
+		}
+	}
+}
+
 func TestBuildServerNodeEmptyConfiguredHeadersRemainExactAnonymousObservation(t *testing.T) {
 	engine := testEnumerateEngine(t)
 	node := buildServerNode(

--- a/modules/protoscan/scanner.go
+++ b/modules/protoscan/scanner.go
@@ -439,9 +439,6 @@ func EmitDiscoveryNodes(targets []action.Target) ingest.GraphData {
 					"transport":      "http",
 					"discovered_via": "protoscan",
 					"protocol":       "mcp",
-					"auth_method":    string(common.AuthUnknown),
-					"auth_assurance": string(common.AuthAssuranceUnknown),
-					"auth_evidence":  common.AuthEvidenceUnknown,
 				},
 			})
 		case "a2a":
@@ -455,17 +452,11 @@ func EmitDiscoveryNodes(targets []action.Target) ingest.GraphData {
 				ID:    id,
 				Kinds: []string{"A2AAgent"},
 				Properties: map[string]any{
-					"objectid":                      id,
-					"agent_card_url":                cardURL,
-					"endpoint":                      idInput,
-					"discovered_via":                "protoscan",
-					"protocol":                      "a2a",
-					"auth_method":                   string(common.AuthUnknown),
-					"auth_assurance":                string(common.AuthAssuranceUnknown),
-					"auth_evidence":                 common.AuthEvidenceUnknown,
-					"signature_verification_status": "unknown",
-					"signature_key_source":          "none",
-					"signature_key_trust":           "unknown",
+					"objectid":       id,
+					"agent_card_url": cardURL,
+					"endpoint":       idInput,
+					"discovered_via": "protoscan",
+					"protocol":       "a2a",
 				},
 			})
 		}

--- a/modules/protoscan/scanner_test.go
+++ b/modules/protoscan/scanner_test.go
@@ -189,8 +189,13 @@ func TestEmitDiscoveryNodes_MCP(t *testing.T) {
 	if got, _ := n.Properties["discovered_via"].(string); got != "protoscan" {
 		t.Errorf("discovered_via = %q, want protoscan", got)
 	}
-	if n.Properties["auth_method"] != "unknown" || n.Properties["auth_assurance"] != "unknown" {
-		t.Errorf("sparse discovery claimed auth absence: %+v", n.Properties)
+	for _, property := range []string{
+		"auth_method", "auth_assurance", "auth_evidence",
+		"observed_auth_method", "observed_auth_assurance", "observed_auth_evidence",
+	} {
+		if _, present := n.Properties[property]; present {
+			t.Errorf("sparse MCP discovery authored %s: %+v", property, n.Properties)
+		}
 	}
 }
 
@@ -283,9 +288,16 @@ func TestEmitDiscoveryNodes_A2AUsesBaseURLID(t *testing.T) {
 	if got, _ := g.Nodes[0].Properties["endpoint"].(string); got != "https://agent.example.com" {
 		t.Errorf("endpoint = %q, want normalized base URL", got)
 	}
-	if g.Nodes[0].Properties["auth_method"] != "unknown" ||
-		g.Nodes[0].Properties["signature_verification_status"] != "unknown" {
-		t.Errorf("sparse A2A discovery claimed assessed posture: %+v", g.Nodes[0].Properties)
+	for _, property := range []string{
+		"auth_method", "auth_assurance", "auth_evidence",
+		"observed_auth_method", "observed_auth_assurance", "observed_auth_evidence",
+		"auth_probe_method", "auth_probe_status", "auth_probe_detail",
+		"is_signed", "signature_verification_status", "signature_key_source",
+		"signature_key_trust",
+	} {
+		if _, present := g.Nodes[0].Properties[property]; present {
+			t.Errorf("sparse A2A discovery authored %s: %+v", property, g.Nodes[0].Properties)
+		}
 	}
 }
 

--- a/server/internal/analysis/processors/auth_strength.go
+++ b/server/internal/analysis/processors/auth_strength.go
@@ -17,7 +17,8 @@ import (
 // auth_* properties remain immutable collection provenance. A valid, known
 // MCP or A2A runtime observation wins for node posture only under its strict
 // protocol-specific evidence contract; unknown/unavailable runtime
-// observations fall back to the complete configured tuple.
+// observations fall back to the complete configured tuple. When neither
+// provenance channel has a usable tuple, derived properties are cleared.
 //
 // The pre-pass also materializes derived effective_* properties on incoming
 // TRUSTS_SERVER relationships. Only confirmed observed anonymous access can
@@ -63,20 +64,57 @@ func (p *AuthStrength) Process(ctx context.Context, db graph.GraphDB, _ string) 
    n.observed_auth_evidence = 'anonymous_probe_succeeded')
 )`
 
+	validConfigured := `(
+  (n.auth_method = 'unknown' AND
+   n.auth_assurance = 'unknown' AND
+   n.auth_evidence IN ['unknown', 'declared_security_scheme', 'configured_credential', 'local_process']) OR
+  (n.auth_method = 'none' AND
+   n.auth_assurance = 'unauthenticated' AND
+   n.auth_evidence IN ['unknown', 'declared_security_scheme', 'anonymous_probe_succeeded']) OR
+  (n.auth_method IN ['basic', 'apiKey'] AND
+   n.auth_assurance = 'weak' AND
+   n.auth_evidence IN ['configured_credential', 'declared_security_scheme']) OR
+  (n.auth_method = 'bearer' AND
+   n.auth_assurance = 'moderate' AND
+   n.auth_evidence IN ['configured_credential', 'declared_security_scheme']) OR
+  (n.auth_method IN ['oauth', 'oidc', 'mtls'] AND
+   n.auth_assurance = 'strong' AND
+   n.auth_evidence IN ['configured_credential', 'declared_security_scheme']) OR
+  (n.auth_method = 'custom' AND
+   n.auth_assurance = 'unknown' AND
+   n.auth_evidence IN ['configured_credential', 'declared_security_scheme'])
+)`
+
 	nodeCypher := fmt.Sprintf(`MATCH (n)
-WHERE (n:MCPServer OR n:A2AAgent) AND n.auth_method IS NOT NULL
-WITH n, %s AS use_observed
+WHERE n:MCPServer OR n:A2AAgent
+WITH n, %s AS use_observed, %s AS use_configured
 WITH n,
-     CASE WHEN use_observed THEN n.observed_auth_method ELSE n.auth_method END AS effective_method,
-     CASE WHEN use_observed THEN n.observed_auth_evidence ELSE n.auth_evidence END AS effective_evidence,
-     CASE WHEN use_observed THEN 'observed' ELSE 'configured' END AS effective_source
+     CASE
+       WHEN use_observed THEN n.observed_auth_method
+       WHEN use_configured THEN n.auth_method
+       ELSE null
+     END AS effective_method,
+     CASE
+       WHEN use_observed THEN n.observed_auth_evidence
+       WHEN use_configured THEN n.auth_evidence
+       ELSE null
+     END AS effective_evidence,
+     CASE
+       WHEN use_observed THEN 'observed'
+       WHEN use_configured THEN 'configured'
+       ELSE null
+     END AS effective_source
 SET n.effective_auth_method = effective_method,
-    n.effective_auth_assurance = %s,
+    n.effective_auth_assurance = CASE
+      WHEN effective_source IS NULL THEN null
+      ELSE %s
+    END,
     n.effective_auth_evidence = effective_evidence,
     n.effective_auth_source = effective_source,
     n.auth_strength = %s
 RETURN count(n) AS updated`,
 		validKnownObserved,
+		validConfigured,
 		authAssuranceCase("effective_method", "effective_evidence", "effective_source"),
 		authStrengthCase("effective_method", "effective_evidence", "effective_source"))
 

--- a/server/internal/analysis/processors/auth_strength_integration_test.go
+++ b/server/internal/analysis/processors/auth_strength_integration_test.go
@@ -82,9 +82,43 @@ func TestIntegrationAuthStrengthEffectiveTuple(t *testing.T) {
 			},
 		},
 		{
+			ID: "auth-server-observed-only", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name": "observed-only anonymous runtime", "transport": "http", "status": "reachable",
+				"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+				"observed_auth_evidence": "anonymous_probe_succeeded", "scan_id": scanID,
+			},
+		},
+		{
+			ID: "auth-server-inconclusive-only", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name": "observed-only unreachable runtime", "transport": "http", "status": "unreachable",
+				"observed_auth_method": "unknown", "observed_auth_assurance": "unknown",
+				"observed_auth_evidence": "unknown", "scan_id": scanID,
+				"effective_auth_method": "bearer", "effective_auth_assurance": "moderate",
+				"effective_auth_evidence": "configured_credential",
+				"effective_auth_source":   "configured", "auth_strength": 50,
+			},
+		},
+		{
+			ID: "auth-server-discovery-only", Kinds: []string{"MCPServer"}, Properties: map[string]any{
+				"name": "discovery only", "transport": "http", "scan_id": scanID,
+				"effective_auth_method": "apiKey", "effective_auth_assurance": "weak",
+				"effective_auth_evidence": "configured_credential",
+				"effective_auth_source":   "configured", "auth_strength": 70,
+			},
+		},
+		{
 			ID: "auth-a2a", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
 				"name": "A2A fallback", "auth_method": "mtls", "auth_assurance": "strong",
 				"auth_evidence": "declared_security_scheme", "scan_id": scanID,
+			},
+		},
+		{
+			ID: "auth-a2a-observed-only", Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+				"name": "A2A observed-only anonymous", "scan_id": scanID,
+				"auth_probe_method": "get_task_nonexistent", "auth_probe_status": "anonymous_protocol_access",
+				"auth_probe_detail":    "task_not_found_v1",
+				"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+				"observed_auth_evidence": "anonymous_probe_succeeded",
 			},
 		},
 		{
@@ -142,8 +176,9 @@ RETURN n.objectid AS id,
        n.effective_auth_source AS source,
        n.auth_strength AS strength`, map[string]any{"ids": []string{
 		"auth-server-anon", "auth-server-bearer", "auth-server-fallback",
-		"auth-server-stdio", "auth-a2a", "auth-a2a-observed", "auth-a2a-forged",
-		"auth-a2a-raw-anon",
+		"auth-server-stdio", "auth-server-observed-only", "auth-server-inconclusive-only",
+		"auth-server-discovery-only", "auth-a2a", "auth-a2a-observed",
+		"auth-a2a-observed-only", "auth-a2a-forged", "auth-a2a-raw-anon",
 	}})
 	if err != nil {
 		t.Fatalf("query effective nodes: %v", err)
@@ -157,8 +192,12 @@ RETURN n.objectid AS id,
 	assertEffectiveAuthRow(t, byID["auth-server-bearer"], "strong", "bearer", "moderate", "configured_credential", "observed", 50)
 	assertEffectiveAuthRow(t, byID["auth-server-fallback"], "weak", "apiKey", "weak", "configured_credential", "configured", 70)
 	assertEffectiveAuthRow(t, byID["auth-server-stdio"], "unknown", "unknown", "unknown", "local_process", "configured", nil)
+	assertEffectiveAuthRow(t, byID["auth-server-observed-only"], nil, "none", "unauthenticated", "anonymous_probe_succeeded", "observed", 100)
+	assertEffectiveAuthRow(t, byID["auth-server-inconclusive-only"], nil, nil, nil, nil, nil, nil)
+	assertEffectiveAuthRow(t, byID["auth-server-discovery-only"], nil, nil, nil, nil, nil, nil)
 	assertEffectiveAuthRow(t, byID["auth-a2a"], "strong", "mtls", "strong", "declared_security_scheme", "configured", 10)
 	assertEffectiveAuthRow(t, byID["auth-a2a-observed"], "weak", "none", "unauthenticated", "anonymous_probe_succeeded", "observed", 100)
+	assertEffectiveAuthRow(t, byID["auth-a2a-observed-only"], nil, "none", "unauthenticated", "anonymous_probe_succeeded", "observed", 100)
 	assertEffectiveAuthRow(t, byID["auth-a2a-forged"], "moderate", "bearer", "moderate", "declared_security_scheme", "configured", 50)
 	assertEffectiveAuthRow(t, byID["auth-a2a-raw-anon"], "unauthenticated", "none", "unknown", "anonymous_probe_succeeded", "configured", nil)
 
@@ -205,7 +244,7 @@ func authTestTrust(source, target string, weight float64, complete bool) ingest.
 func assertEffectiveAuthRow(
 	t *testing.T,
 	row map[string]any,
-	configuredAssurance, method, assurance, evidence, source string,
+	configuredAssurance, method, assurance, evidence, source any,
 	strength any,
 ) {
 	t.Helper()
@@ -213,7 +252,7 @@ func assertEffectiveAuthRow(
 		row["configured_assurance"] != configuredAssurance ||
 		row["method"] != method || row["assurance"] != assurance ||
 		row["evidence"] != evidence || row["source"] != source {
-		t.Fatalf("effective auth row = %+v, want configured=%s effective=%s/%s/%s source=%s", row, configuredAssurance, method, assurance, evidence, source)
+		t.Fatalf("effective auth row = %+v, want configured=%v effective=%v/%v/%v source=%v", row, configuredAssurance, method, assurance, evidence, source)
 	}
 	if strength == nil {
 		if row["strength"] != nil {

--- a/server/internal/analysis/processors/auth_strength_test.go
+++ b/server/internal/analysis/processors/auth_strength_test.go
@@ -83,12 +83,19 @@ func TestAuthStrength_ProcessSuccess(t *testing.T) {
 		"n.auth_probe_method = 'get_task_nonexistent'",
 		"n.auth_probe_status = 'anonymous_protocol_access'",
 		"n.auth_probe_detail IN ['task_not_found_v1', 'task_not_found_v0_3']",
-		"CASE WHEN use_observed THEN n.observed_auth_method ELSE n.auth_method END",
-		"CASE WHEN use_observed THEN n.observed_auth_evidence ELSE n.auth_evidence END",
+		"WHEN use_observed THEN n.observed_auth_method",
+		"WHEN use_configured THEN n.auth_method",
+		"WHEN use_observed THEN n.observed_auth_evidence",
+		"WHEN use_configured THEN n.auth_evidence",
+		"WHEN effective_source IS NULL THEN null",
+		"WHEN use_configured THEN 'configured'",
 	} {
 		if !contains(cypher, guard) {
 			t.Errorf("effective tuple query missing %q; query:\n%s", guard, cypher)
 		}
+	}
+	if contains(cypher, "AND n.auth_method IS NOT NULL") {
+		t.Errorf("observed-only nodes must not require configured auth; query:\n%s", cypher)
 	}
 
 	trustCypher, _ := calls[1].Args[0].(string)

--- a/server/internal/analysis/riskscore/a2a_import_test.go
+++ b/server/internal/analysis/riskscore/a2a_import_test.go
@@ -154,6 +154,7 @@ func strictV5A2AImport(authEvidence string, observed bool) *sdkingest.IngestData
 					"signature_verification_status": "unknown",
 					"signature_key_source":          "none",
 					"signature_key_trust":           "unknown",
+					"is_signed":                     false,
 				},
 			}},
 			Edges: []sdkingest.Edge{},

--- a/server/internal/graph/integration_test.go
+++ b/server/internal/graph/integration_test.go
@@ -1940,6 +1940,161 @@ func TestIntegrationCompatibleDistinctOwnersRemainCompleteUntilOneRetires(t *tes
 	}
 }
 
+func TestIntegrationAuthProvenanceOwnersMergeInEitherOrder(t *testing.T) {
+	ctx := testDriver(t)
+	driver, err := NewDriver(
+		os.Getenv("AGENTHOUND_NEO4J_URI"),
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+
+	writer := NewWriter(driver)
+	db := NewDB(NewReader(driver), writer)
+	tests := []struct {
+		name       string
+		kind       string
+		leftProps  map[string]any
+		rightProps map[string]any
+		want       map[string]any
+	}{
+		{
+			name: "configured MCP and direct live MCP",
+			kind: "MCPServer",
+			leftProps: map[string]any{
+				"name": "https://mcp.example/mcp", "endpoint": "https://mcp.example/mcp",
+				"transport": "http", "auth_method": "bearer", "auth_assurance": "moderate",
+				"auth_evidence": "configured_credential",
+			},
+			rightProps: map[string]any{
+				"name": "https://mcp.example/mcp", "endpoint": "https://mcp.example/mcp",
+				"transport": "http", "status": "reachable",
+				"observed_auth_method": "none", "observed_auth_assurance": "unauthenticated",
+				"observed_auth_evidence": "anonymous_probe_succeeded",
+			},
+			want: map[string]any{
+				"auth_method": "bearer", "observed_auth_method": "none",
+			},
+		},
+		{
+			name: "configured MCP and protocol discovery",
+			kind: "MCPServer",
+			leftProps: map[string]any{
+				"name": "https://mcp.example/discovered", "endpoint": "https://mcp.example/discovered",
+				"transport": "http", "auth_method": "bearer", "auth_assurance": "moderate",
+				"auth_evidence": "configured_credential",
+			},
+			rightProps: map[string]any{
+				"endpoint": "https://mcp.example/discovered", "transport": "http",
+				"discovered_via": "protoscan", "protocol": "mcp",
+			},
+			want: map[string]any{
+				"auth_method": "bearer", "discovered_via": "protoscan",
+			},
+		},
+		{
+			name: "full A2A and protocol discovery",
+			kind: "A2AAgent",
+			leftProps: map[string]any{
+				"name": "agent", "url": "https://agent.example",
+				"auth_method": "oauth", "auth_assurance": "strong",
+				"auth_evidence": "declared_security_scheme",
+				"is_signed":     true, "signature_verification_status": "valid_trusted",
+				"signature_key_source": "trusted_store", "signature_key_trust": "trusted",
+			},
+			rightProps: map[string]any{
+				"endpoint":       "https://agent.example",
+				"agent_card_url": "https://agent.example/.well-known/agent-card.json",
+				"discovered_via": "protoscan", "protocol": "a2a",
+			},
+			want: map[string]any{
+				"auth_method": "oauth", "signature_verification_status": "valid_trusted",
+				"discovered_via": "protoscan",
+			},
+		},
+	}
+
+	for testIndex, test := range tests {
+		for _, reverse := range []bool{false, true} {
+			order := "left-first"
+			if reverse {
+				order = "right-first"
+			}
+			t.Run(test.name+"/"+order, func(t *testing.T) {
+				nodeID := fmt.Sprintf("auth-owner-merge-%d-%t", testIndex, reverse)
+				leftScope := fmt.Sprintf("config:path:sha256:auth-owner-%d-%t", testIndex, reverse)
+				rightScope := fmt.Sprintf("scan:discover:sha256:auth-owner-%d-%t", testIndex, reverse)
+				if test.kind == "MCPServer" && test.rightProps["status"] == "reachable" {
+					rightScope = fmt.Sprintf("mcp:target:sha256:auth-owner-%d-%t", testIndex, reverse)
+				}
+				cleanup := func() {
+					_, _ = db.ExecuteWrite(ctx,
+						"MATCH (n {objectid: $id}) DETACH DELETE n",
+						map[string]any{"id": nodeID})
+				}
+				cleanup()
+				defer cleanup()
+
+				left := ingest.Node{
+					ID: nodeID, Kinds: []string{test.kind},
+					ObservationDomains: []string{leftScope},
+					Properties:         cloneProperties(test.leftProps),
+				}
+				right := ingest.Node{
+					ID: nodeID, Kinds: []string{test.kind},
+					ObservationDomains: []string{rightScope},
+					Properties:         cloneProperties(test.rightProps),
+				}
+				ordered := []struct {
+					node  ingest.Node
+					scope string
+					scan  string
+				}{
+					{node: left, scope: leftScope, scan: "left"},
+					{node: right, scope: rightScope, scan: "right"},
+				}
+				if reverse {
+					ordered[0], ordered[1] = ordered[1], ordered[0]
+				}
+				for _, item := range ordered {
+					if _, err := writer.WriteObservationNodes(
+						ctx, []ingest.Node{item.node}, item.scan, []string{item.scope},
+					); err != nil {
+						t.Fatalf("write %s owner: %v", item.scan, err)
+					}
+					if _, err := ReconcileObservations(
+						ctx, db, item.scan, []string{item.scope},
+					); err != nil {
+						t.Fatalf("reconcile %s owner: %v", item.scan, err)
+					}
+				}
+
+				rows, err := db.Query(ctx, `MATCH (n {objectid: $id})
+RETURN properties(n) AS props,
+       n.observation_properties_complete AS complete,
+       size(n.observation_fact_fingerprints) AS fingerprints`,
+					map[string]any{"id": nodeID})
+				if err != nil {
+					t.Fatalf("query merged auth owners: %v", err)
+				}
+				if len(rows) != 1 || rows[0]["complete"] != true ||
+					rows[0]["fingerprints"] != int64(2) {
+					t.Fatalf("auth owners did not remain complete: %+v", rows)
+				}
+				properties, _ := rows[0]["props"].(map[string]any)
+				for key, want := range test.want {
+					if properties[key] != want {
+						t.Fatalf("%s = %v, want %v; properties=%+v", key, properties[key], want, properties)
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestIntegrationCompleteObservationReplacesOnlyManagedLabels(t *testing.T) {
 	ctx := testDriver(t)
 	driver, err := NewDriver(

--- a/server/internal/ingest/a2a_signature_test.go
+++ b/server/internal/ingest/a2a_signature_test.go
@@ -43,6 +43,47 @@ func TestA2ASignatureTrustStatesAreCanonical(t *testing.T) {
 	}
 }
 
+func TestA2ASignaturePostureMayBeEntirelyAbsent(t *testing.T) {
+	if errors := validateA2ASignatureProperties(map[string]any{}, 0); len(errors) != 0 {
+		t.Fatalf("absent sparse-discovery signature posture rejected: %+v", errors)
+	}
+}
+
+func TestA2ASignaturePostureRejectsPartialTuple(t *testing.T) {
+	complete := map[string]any{
+		"signature_verification_status": "valid_trusted",
+		"signature_key_source":          "trusted_store",
+		"signature_key_trust":           "trusted",
+		"is_signed":                     true,
+	}
+	for _, missing := range []string{
+		"signature_verification_status",
+		"signature_key_source",
+		"signature_key_trust",
+		"is_signed",
+	} {
+		t.Run(missing, func(t *testing.T) {
+			properties := make(map[string]any, len(complete)-1)
+			for key, value := range complete {
+				if key != missing {
+					properties[key] = value
+				}
+			}
+			errors := validateA2ASignatureProperties(properties, 0)
+			if len(errors) == 0 {
+				t.Fatal("partial A2A signature posture was accepted")
+			}
+			wantPath := "graph.nodes[0].properties." + missing
+			for _, fieldErr := range errors {
+				if fieldErr.Path == wantPath {
+					return
+				}
+			}
+			t.Fatalf("errors = %+v, want path %q", errors, wantPath)
+		})
+	}
+}
+
 func TestA2ASignatureTrustStateRejectsContradictoryTuple(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/server/internal/ingest/validator.go
+++ b/server/internal/ingest/validator.go
@@ -1392,82 +1392,125 @@ func validateCanonicalNodeProperties(node ingest.Node, index int) []FieldError {
 	}
 	if hasKind(node.Kinds, "A2AAgent") {
 		errs = append(errs, validateObservedA2AAuthProperties(node.Properties, index)...)
-		status, _ := node.Properties["signature_verification_status"].(string)
-		switch status {
-		case "unknown",
-			"unsigned",
-			"unsupported_version",
-			"malformed",
-			"key_unavailable",
-			"invalid",
-			"valid_untrusted",
-			"valid_trusted":
-		default:
+		errs = append(errs, validateA2ASignatureProperties(node.Properties, index)...)
+	}
+	return errs
+}
+
+func validateA2ASignatureProperties(properties map[string]any, index int) []FieldError {
+	const (
+		statusKey = "signature_verification_status"
+		sourceKey = "signature_key_source"
+		trustKey  = "signature_key_trust"
+		signedKey = "is_signed"
+	)
+	_, statusPresent := properties[statusKey]
+	_, sourcePresent := properties[sourceKey]
+	_, trustPresent := properties[trustKey]
+	_, signedPresent := properties[signedKey]
+	if !statusPresent && !sourcePresent && !trustPresent && !signedPresent {
+		return nil
+	}
+
+	basePath := fmt.Sprintf("graph.nodes[%d].properties.", index)
+	status, statusOK := properties[statusKey].(string)
+	source, sourceOK := properties[sourceKey].(string)
+	trust, trustOK := properties[trustKey].(string)
+	signed, signedOK := properties[signedKey].(bool)
+	var errs []FieldError
+	for _, field := range []struct {
+		key     string
+		present bool
+		valid   bool
+	}{
+		{key: statusKey, present: statusPresent, valid: statusOK},
+		{key: sourceKey, present: sourcePresent, valid: sourceOK},
+		{key: trustKey, present: trustPresent, valid: trustOK},
+		{key: signedKey, present: signedPresent, valid: signedOK},
+	} {
+		switch {
+		case !field.present:
 			errs = append(errs, FieldError{
-				Path:    fmt.Sprintf("graph.nodes[%d].properties.signature_verification_status", index),
-				Message: fmt.Sprintf("invalid canonical signature status %q", status),
+				Path:    basePath + field.key,
+				Message: "is required when any A2A signature posture field is present",
+			})
+		case !field.valid:
+			errs = append(errs, FieldError{
+				Path:    basePath + field.key,
+				Message: "must have the canonical signature posture type",
 			})
 		}
-		source, _ := node.Properties["signature_key_source"].(string)
-		switch source {
-		case "none", "trusted_store", "jku":
-		default:
-			errs = append(errs, FieldError{
-				Path:    fmt.Sprintf("graph.nodes[%d].properties.signature_key_source", index),
-				Message: fmt.Sprintf("invalid signature key source %q", source),
-			})
-		}
-		trust, _ := node.Properties["signature_key_trust"].(string)
-		switch trust {
-		case "unknown", "untrusted", "trusted":
-		default:
-			errs = append(errs, FieldError{
-				Path:    fmt.Sprintf("graph.nodes[%d].properties.signature_key_trust", index),
-				Message: fmt.Sprintf("invalid signature key trust %q", trust),
-			})
-		}
-		if status == "valid_trusted" && (source != "trusted_store" || trust != "trusted") {
-			errs = append(errs, FieldError{
-				Path:    fmt.Sprintf("graph.nodes[%d].properties.signature_key_trust", index),
-				Message: "valid_trusted requires trusted_store source and trusted key",
-			})
-		}
-		if status == "valid_untrusted" && (source != "jku" || trust != "untrusted") {
-			errs = append(errs, FieldError{
-				Path:    fmt.Sprintf("graph.nodes[%d].properties.signature_key_trust", index),
-				Message: "valid_untrusted requires jku source and untrusted key",
-			})
-		}
-		if !validA2ASignatureProvenancePair(source, trust) ||
-			!validA2ASignatureStatusProvenance(status, source, trust) {
-			errs = append(errs, FieldError{
-				Path: fmt.Sprintf(
-					"graph.nodes[%d].properties.signature_key_source",
-					index,
-				),
-				Message: "signature status, key source, and key trust are contradictory",
-			})
-		}
-		if signed, exists := node.Properties["is_signed"]; exists {
-			signedValue, ok := signed.(bool)
-			if !ok {
-				errs = append(errs, FieldError{
-					Path:    fmt.Sprintf("graph.nodes[%d].properties.is_signed", index),
-					Message: "must be boolean when present",
-				})
-			} else {
-				expectedSigned := status != "unknown" && status != "unsigned"
-				if signedValue != expectedSigned {
-					errs = append(errs, FieldError{
-						Path: fmt.Sprintf(
-							"graph.nodes[%d].properties.is_signed",
-							index,
-						),
-						Message: "is_signed contradicts signature verification status",
-					})
-				}
-			}
-		}
+	}
+	if !statusOK || !sourceOK || !trustOK || !signedOK {
+		return errs
+	}
+
+	statusCanonical := false
+	switch status {
+	case "unknown",
+		"unsigned",
+		"unsupported_version",
+		"malformed",
+		"key_unavailable",
+		"invalid",
+		"valid_untrusted",
+		"valid_trusted":
+		statusCanonical = true
+	default:
+		errs = append(errs, FieldError{
+			Path:    basePath + statusKey,
+			Message: fmt.Sprintf("invalid canonical signature status %q", status),
+		})
+	}
+	sourceCanonical := false
+	switch source {
+	case "none", "trusted_store", "jku":
+		sourceCanonical = true
+	default:
+		errs = append(errs, FieldError{
+			Path:    basePath + sourceKey,
+			Message: fmt.Sprintf("invalid signature key source %q", source),
+		})
+	}
+	trustCanonical := false
+	switch trust {
+	case "unknown", "untrusted", "trusted":
+		trustCanonical = true
+	default:
+		errs = append(errs, FieldError{
+			Path:    basePath + trustKey,
+			Message: fmt.Sprintf("invalid signature key trust %q", trust),
+		})
+	}
+	if !statusCanonical || !sourceCanonical || !trustCanonical {
+		return errs
+	}
+
+	if status == "valid_trusted" && (source != "trusted_store" || trust != "trusted") {
+		errs = append(errs, FieldError{
+			Path:    basePath + trustKey,
+			Message: "valid_trusted requires trusted_store source and trusted key",
+		})
+	}
+	if status == "valid_untrusted" && (source != "jku" || trust != "untrusted") {
+		errs = append(errs, FieldError{
+			Path:    basePath + trustKey,
+			Message: "valid_untrusted requires jku source and untrusted key",
+		})
+	}
+	if !validA2ASignatureProvenancePair(source, trust) ||
+		!validA2ASignatureStatusProvenance(status, source, trust) {
+		errs = append(errs, FieldError{
+			Path:    basePath + sourceKey,
+			Message: "signature status, key source, and key trust are contradictory",
+		})
+	}
+	expectedSigned := status != "unknown" && status != "unsigned"
+	if signed != expectedSigned {
+		errs = append(errs, FieldError{
+			Path:    basePath + signedKey,
+			Message: "is_signed contradicts signature verification status",
+		})
 	}
 	return errs
 }
@@ -1623,26 +1666,66 @@ func stringSlice(value any) ([]string, bool) {
 }
 
 func validateAuthProperties(properties map[string]any, index int) []FieldError {
+	const (
+		methodKey    = "auth_method"
+		assuranceKey = "auth_assurance"
+		evidenceKey  = "auth_evidence"
+	)
+	_, methodPresent := properties[methodKey]
+	_, assurancePresent := properties[assuranceKey]
+	_, evidencePresent := properties[evidenceKey]
+	if !methodPresent && !assurancePresent && !evidencePresent {
+		return nil
+	}
+
 	var errs []FieldError
-	method, _ := properties["auth_method"].(string)
+	basePath := fmt.Sprintf("graph.nodes[%d].properties.", index)
+	method, methodOK := properties[methodKey].(string)
+	assurance, assuranceOK := properties[assuranceKey].(string)
+	evidence, evidenceOK := properties[evidenceKey].(string)
+	for _, field := range []struct {
+		key     string
+		present bool
+		valid   bool
+	}{
+		{key: methodKey, present: methodPresent, valid: methodOK},
+		{key: assuranceKey, present: assurancePresent, valid: assuranceOK},
+		{key: evidenceKey, present: evidencePresent, valid: evidenceOK},
+	} {
+		switch {
+		case !field.present:
+			errs = append(errs, FieldError{
+				Path:    basePath + field.key,
+				Message: "is required when any configured authentication field is present",
+			})
+		case !field.valid:
+			errs = append(errs, FieldError{
+				Path:    basePath + field.key,
+				Message: "must be a canonical string",
+			})
+		}
+	}
+	if !methodOK || !assuranceOK || !evidenceOK {
+		return errs
+	}
+
 	methodCanonical := false
 	switch method {
 	case "unknown", "none", "basic", "apiKey", "bearer", "oauth", "oidc", "mtls", "custom":
 		methodCanonical = true
 	default:
 		errs = append(errs, FieldError{
-			Path:    fmt.Sprintf("graph.nodes[%d].properties.auth_method", index),
+			Path:    basePath + methodKey,
 			Message: fmt.Sprintf("invalid canonical auth method %q", method),
 		})
 	}
-	assurance, _ := properties["auth_assurance"].(string)
 	assuranceCanonical := false
 	switch assurance {
 	case "unknown", "unauthenticated", "weak", "moderate", "strong":
 		assuranceCanonical = true
 	default:
 		errs = append(errs, FieldError{
-			Path:    fmt.Sprintf("graph.nodes[%d].properties.auth_assurance", index),
+			Path:    basePath + assuranceKey,
 			Message: fmt.Sprintf("invalid canonical auth assurance %q", assurance),
 		})
 	}
@@ -1650,7 +1733,7 @@ func validateAuthProperties(properties map[string]any, index int) []FieldError {
 		expectedAssurance := string(common.AssessAuth(method).Assurance)
 		if assurance != expectedAssurance {
 			errs = append(errs, FieldError{
-				Path: fmt.Sprintf("graph.nodes[%d].properties.auth_assurance", index),
+				Path: basePath + assuranceKey,
 				Message: fmt.Sprintf(
 					"must be %q for auth method %q",
 					expectedAssurance,
@@ -1659,7 +1742,6 @@ func validateAuthProperties(properties map[string]any, index int) []FieldError {
 			})
 		}
 	}
-	evidence, _ := properties["auth_evidence"].(string)
 	evidenceCanonical := false
 	switch evidence {
 	case "unknown", "declared_security_scheme", "configured_credential",
@@ -1667,7 +1749,7 @@ func validateAuthProperties(properties map[string]any, index int) []FieldError {
 		evidenceCanonical = true
 	default:
 		errs = append(errs, FieldError{
-			Path:    fmt.Sprintf("graph.nodes[%d].properties.auth_evidence", index),
+			Path:    basePath + evidenceKey,
 			Message: fmt.Sprintf("invalid canonical auth evidence %q", evidence),
 		})
 	}
@@ -1675,7 +1757,7 @@ func validateAuthProperties(properties map[string]any, index int) []FieldError {
 	if methodCanonical && assuranceCanonical && evidenceCanonical &&
 		!configuredAuthEvidenceCompatible(method, evidence) {
 		errs = append(errs, FieldError{
-			Path: fmt.Sprintf("graph.nodes[%d].properties.auth_evidence", index),
+			Path: basePath + evidenceKey,
 			Message: fmt.Sprintf(
 				"auth evidence %q is incompatible with configured auth method %q",
 				evidence,

--- a/server/internal/ingest/validator_test.go
+++ b/server/internal/ingest/validator_test.go
@@ -93,6 +93,36 @@ func TestValidatorAcceptsValid(t *testing.T) {
 	}
 }
 
+func TestValidatorAcceptsAuthFreeMCPDiscovery(t *testing.T) {
+	data := validIngestData()
+	for _, property := range []string{"auth_method", "auth_assurance", "auth_evidence"} {
+		delete(data.Graph.Nodes[0].Properties, property)
+	}
+	data.Graph.Nodes[0].Properties["discovered_via"] = "protoscan"
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("auth-free MCP discovery rejected: %v", err)
+	}
+}
+
+func TestValidatorAcceptsPostureFreeA2ADiscovery(t *testing.T) {
+	data := validIngestData()
+	scope := data.Meta.Collection.CoverageKeys[0]
+	data.Graph.Nodes = []ingest.Node{{
+		ID: "sha256:a2a-discovery", Kinds: []string{"A2AAgent"},
+		Properties: map[string]any{
+			"endpoint":       "https://agent.example",
+			"agent_card_url": "https://agent.example/.well-known/agent-card.json",
+			"discovered_via": "protoscan",
+			"protocol":       "a2a",
+		},
+		ObservationDomains: []string{scope},
+	}}
+	data.Graph.Edges = []ingest.Edge{}
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("posture-free A2A discovery rejected: %v", err)
+	}
+}
+
 func TestValidatorRejectsInconsistentCollectionIdentity(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -425,6 +455,29 @@ func TestValidatorRejectsConfiguredAuthMethodAssuranceMismatch(t *testing.T) {
 	}
 }
 
+func TestValidatorRejectsPartialConfiguredAuthTuple(t *testing.T) {
+	for _, missing := range []string{"auth_method", "auth_assurance", "auth_evidence"} {
+		t.Run(missing, func(t *testing.T) {
+			properties := map[string]any{
+				"auth_method": "bearer", "auth_assurance": "moderate",
+				"auth_evidence": "configured_credential",
+			}
+			delete(properties, missing)
+			errs := validateAuthProperties(properties, 0)
+			if len(errs) == 0 {
+				t.Fatal("partial configured auth tuple was accepted")
+			}
+			wantPath := "graph.nodes[0].properties." + missing
+			for _, fieldErr := range errs {
+				if fieldErr.Path == wantPath {
+					return
+				}
+			}
+			t.Fatalf("errors = %+v, want path %q", errs, wantPath)
+		})
+	}
+}
+
 func TestValidatorAcceptsObservedMCPAuthTupleMatrix(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -561,6 +614,13 @@ func TestValidatorEnforcesObservedMCPAuthTupleAtIngestBoundary(t *testing.T) {
 	data.Graph.Nodes[0].Properties["observed_auth_evidence"] = "anonymous_probe_succeeded"
 	if err := NewValidator().Validate(data); err != nil {
 		t.Fatalf("valid observed anonymous tuple rejected: %v", err)
+	}
+
+	for _, property := range []string{"auth_method", "auth_assurance", "auth_evidence"} {
+		delete(data.Graph.Nodes[0].Properties, property)
+	}
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("observed-only MCP tuple rejected: %v", err)
 	}
 
 	delete(data.Graph.Nodes[0].Properties, "observed_auth_assurance")


### PR DESCRIPTION
## Summary

- separate neutral MCP server identity from configuration-backed authentication claims
- stop direct MCP scans and MCP/A2A protocol discovery from publishing properties they did not observe or own
- accept independent, optional, atomic authentication channels while preserving A2A's probe state machine and four-field signature contract
- derive effective authentication from known live evidence first, then configured evidence, and clear stale derived state when neither remains
- add order-independent collector merge, sparse discovery, observed-only, retirement, and validation regressions
- document absence versus `unknown` and the provenance ownership rules

## Root cause

MCP server IDs intentionally match across collectors so configuration trust/credentials join the live server attack surface. Direct MCP and protocol-discovery producers were also emitting configured authentication placeholders, even though those producers did not own that provenance channel. When their values differed from the config collector's real declaration, the graph writer correctly treated the same property as conflicting and withheld the observation.

This change keeps the shared ID and both sources of evidence. It fixes the producer contracts instead of weakening generic conflict detection.

## Resulting contract

- Config collector: configured/declarative auth only
- Config-backed MCP scan: configured auth plus live observed auth
- Direct MCP scan: live observed auth only
- MCP protocol discovery: neither auth channel
- Full A2A collector: configured auth, optional validated probe/observation, and complete signature posture
- A2A protocol discovery: no auth, probe, or signature claims
- Reference-only nodes: no auth or signature claims

Configured and MCP observed auth tuples are zero-or-three. A2A probe validation retains its existing six-field state machine. First-party A2A signature posture is zero-or-four, including `is_signed`.

## Validation

Passed locally:

- `gofmt -l .` (no output)
- `go build ./...`
- `go vet ./...`
- `go test ./... -race -timeout=15m`
- `make docs-check` using a disposable environment with the repository-pinned documentation requirements
- focused config, MCP, protocol-scan, ingest, graph, auth processor, and risk-score tests

A Neo4j order-independence integration regression was added. It remains environment-gated and did not execute against a live Neo4j instance in the local unit/race run because `AGENTHOUND_NEO4J_URI` was not configured.

## Known unrelated release gate

`make prerelease` was attempted and stopped at its first step on the repository's pre-existing Homebrew formula validation failure:

```text
Homebrew formula agenthound must contain four paired URL/checksum entries
make: *** [prerelease] Error 1
```

This branch does not modify the Homebrew formula or release-process scripts; that separate release blocker is intentionally not folded into this provenance fix.