### PR TITLE
Fix release portability and partial scan guidance

### DIFF
--- a/collector/cli/collect_helpers.go
+++ b/collector/cli/collect_helpers.go
@@ -34,24 +34,39 @@ func marshalCollectorArtifact(data *ingest.IngestData) ([]byte, error) {
 }
 
 func writeCollectorOutput(data *ingest.IngestData, outputPath string) error {
-	encoded, err := marshalCollectorArtifact(data)
-	if err != nil {
-		return err
-	}
 	if outputPath == "" {
-		_, err = os.Stdout.Write(encoded)
+		encoded, err := marshalCollectorArtifact(data)
 		if err != nil {
+			return err
+		}
+		if _, err := os.Stdout.Write(encoded); err != nil {
 			return fmt.Errorf("write stdout: %w", err)
 		}
 		fmt.Println()
 		return nil
 	}
 
+	if err := writeCollectorOutputFile(data, outputPath); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "Next: agenthound-server ingest %s\n", outputPath)
+	return nil
+}
+
+// writeCollectorOutputFile persists an artifact without printing workflow
+// guidance. The scan command uses this path so it can qualify or suppress its
+// ingest hint based on collection completeness. Other collector verbs retain
+// writeCollectorOutput's existing unconditional hint.
+func writeCollectorOutputFile(data *ingest.IngestData, outputPath string) error {
+	encoded, err := marshalCollectorArtifact(data)
+	if err != nil {
+		return err
+	}
+
 	if err := writeOutputAtomic(outputPath, encoded); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 	slog.Info("output written", "path", outputPath, "nodes", len(data.Graph.Nodes), "edges", len(data.Graph.Edges))
-	_, _ = fmt.Fprintf(os.Stderr, "Next: agenthound-server ingest %s\n", outputPath)
 	return nil
 }
 

--- a/collector/cli/remote_ingest_test.go
+++ b/collector/cli/remote_ingest_test.go
@@ -93,6 +93,57 @@ func TestRunScan_RemoteIngestSavesExactArtifactAndPrintsSummary(t *testing.T) {
 	}
 }
 
+func TestRunScan_RemoteIngestWarnsBeforeUploadingPartialArtifact(t *testing.T) {
+	dir := t.TempDir()
+	malformed := filepath.Join(dir, "malformed.json")
+	if err := os.WriteFile(malformed, []byte(`{"mcpServers":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	uploaded := false
+	warnedBeforeUpload := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploaded = true
+		warnedBeforeUpload = strings.Contains(
+			stderr.String(),
+			"WARNING: Scan artifact is partial",
+		)
+		var artifact ingest.IngestData
+		if err := json.NewDecoder(r.Body).Decode(&artifact); err != nil {
+			t.Errorf("decode artifact: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(ingest.IngestResult{
+			ScanID:           artifact.Meta.ScanID,
+			Outcome:          ingest.OutcomePartial,
+			ProjectionStatus: "incomplete",
+		})
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(dir, "partial-backup.json")
+	cmd := newScanCmdForTest()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(&stderr)
+	mustSetFlag(t, cmd, "config", "true")
+	mustSetFlag(t, cmd, "path", malformed)
+	mustSetFlag(t, cmd, "project-dir", dir)
+	mustSetFlag(t, cmd, "scan-output", outputPath)
+	mustSetFlag(t, cmd, "ingest", server.URL)
+
+	if err := runScan(cmd, nil); err == nil {
+		t.Fatal("partial server receipt must remain a non-zero --ingest result")
+	}
+	if !uploaded {
+		t.Fatal("explicit --ingest did not upload the partial artifact")
+	}
+	if !warnedBeforeUpload {
+		t.Fatalf("partial artifact was uploaded before its warning:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "may withhold graph publication") {
+		t.Fatalf("partial ingest warning omitted publication consequence:\n%s", stderr.String())
+	}
+}
+
 func TestRunScan_RemoteIngestFailurePreservesArtifact(t *testing.T) {
 	var uploaded []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -243,11 +243,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 		if err := writeOutputAtomic(output, artifact); err != nil {
 			return fmt.Errorf("write file: %w", err)
 		}
-		writeInstructionCoverageWarnings(stderr, merged.Meta.Collection)
+		assessment := assessScanCoverage(merged.Meta.Collection)
+		writeScanCoverageWarnings(stderr, merged.Meta.Collection, assessment)
 		if !quietEnabled(cmd) {
 			_, _ = fmt.Fprintf(stderr, "[scan] saved artifact: %s\n", output)
 		}
 		if allCollectorsFailed(enabled, failed) {
+			writeScanNextStep(stderr, output, assessment, true)
 			return fmt.Errorf("all %d enabled collector(s) failed", enabled)
 		}
 		if !quietEnabled(cmd) {
@@ -272,21 +274,262 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if output == "-" {
 		writeErr = writeCollectorOutputStdout(merged)
 	} else {
-		writeErr = writeCollectorOutput(merged, output)
+		writeErr = writeCollectorOutputFile(merged, output)
 	}
 	if writeErr != nil {
 		return writeErr
 	}
-	writeInstructionCoverageWarnings(stderr, merged.Meta.Collection)
+	assessment := assessScanCoverage(merged.Meta.Collection)
+	writeScanCoverageWarnings(stderr, merged.Meta.Collection, assessment)
+	totalFailure := allCollectorsFailed(enabled, failed)
+	writeScanNextStep(stderr, output, assessment, totalFailure)
 
 	// Total-failure exit code: when every enabled collector errored, exit
 	// non-zero. Partial success (>=1 collector succeeded) and a legitimately
 	// empty-but-successful scan both exit 0 — the decision keys on collector
 	// errors, not node count.
-	if allCollectorsFailed(enabled, failed) {
+	if totalFailure {
 		return fmt.Errorf("all %d enabled collector(s) failed", enabled)
 	}
 	return nil
+}
+
+const maxDisplayedScanOutcomes = 10
+
+type scanCoverageAssessment struct {
+	state               ingest.OutcomeState
+	incomplete          bool
+	blocking            bool
+	blockingOutcomes    []ingest.CollectionOutcome
+	omittedOutcomeCount int
+}
+
+func assessScanCoverage(report *ingest.CollectionReport) scanCoverageAssessment {
+	assessment := scanCoverageAssessment{state: ingest.OutcomeUnknown}
+	if report == nil {
+		assessment.incomplete = true
+		assessment.blocking = true
+		return assessment
+	}
+	assessment.state = report.State
+	if assessment.state == "" {
+		assessment.state = ingest.AggregateOutcomeState(report.Outcomes)
+	}
+	assessment.incomplete = assessment.state != ingest.OutcomeComplete
+	if !assessment.incomplete {
+		return assessment
+	}
+
+	// The server uses this predicate to decide whether collection coverage can
+	// publish. Reusing it keeps recognized instruction-only limitations
+	// non-blocking instead of reinterpreting the aggregate report state.
+	assessment.blocking = !ingest.AuthoritativeCoverageComplete(report)
+	if !assessment.blocking {
+		return assessment
+	}
+
+	nonBlocking := make(map[string]bool)
+	for _, key := range ingest.NonBlockingInstructionCoverageDomains(report) {
+		nonBlocking[key] = true
+	}
+	hasSpecificOutcome := make(map[string]bool)
+	for _, outcome := range report.Outcomes {
+		if scanOutcomeIncomplete(outcome.State) &&
+			!nonBlocking[outcome.CoverageKey] &&
+			outcome.Method != "collect" {
+			hasSpecificOutcome[outcome.Collector] = true
+		}
+	}
+
+	seen := make(map[string]bool)
+	for _, outcome := range report.Outcomes {
+		if !scanOutcomeIncomplete(outcome.State) ||
+			nonBlocking[outcome.CoverageKey] ||
+			(outcome.Method == "collect" && outcome.Error == "" &&
+				hasSpecificOutcome[outcome.Collector]) {
+			continue
+		}
+		key := strings.Join([]string{
+			outcome.Collector,
+			outcome.Method,
+			outcome.Target,
+			string(outcome.State),
+			outcome.Error,
+		}, "\x00")
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		assessment.blockingOutcomes = append(
+			assessment.blockingOutcomes,
+			outcome,
+		)
+	}
+	sort.Slice(assessment.blockingOutcomes, func(i, j int) bool {
+		left := assessment.blockingOutcomes[i]
+		right := assessment.blockingOutcomes[j]
+		return strings.Join([]string{
+			left.Collector, left.Method, left.Target,
+			string(left.State), left.Error,
+		}, "\x00") < strings.Join([]string{
+			right.Collector, right.Method, right.Target,
+			string(right.State), right.Error,
+		}, "\x00")
+	})
+	if len(assessment.blockingOutcomes) > maxDisplayedScanOutcomes {
+		assessment.omittedOutcomeCount =
+			len(assessment.blockingOutcomes) - maxDisplayedScanOutcomes
+		assessment.blockingOutcomes =
+			assessment.blockingOutcomes[:maxDisplayedScanOutcomes]
+	}
+	return assessment
+}
+
+func scanOutcomeIncomplete(state ingest.OutcomeState) bool {
+	return state != ingest.OutcomeComplete &&
+		state != ingest.OutcomeNotApplicable
+}
+
+func writeScanCoverageWarnings(
+	w io.Writer,
+	report *ingest.CollectionReport,
+	assessment scanCoverageAssessment,
+) {
+	if !assessment.incomplete {
+		return
+	}
+	_, _ = fmt.Fprintf(
+		w,
+		"WARNING: Scan artifact is %s; collection coverage is not complete.\n",
+		assessment.state,
+	)
+	if assessment.blocking {
+		_, _ = fmt.Fprintln(w, "Blocking outcomes:")
+		if len(assessment.blockingOutcomes) == 0 {
+			_, _ = fmt.Fprintln(
+				w,
+				"- no detailed blocking outcome was supplied; inspect meta.collection.outcomes",
+			)
+		}
+		for _, outcome := range assessment.blockingOutcomes {
+			writeScanOutcomeWarning(w, outcome)
+		}
+		if assessment.omittedOutcomeCount > 0 {
+			_, _ = fmt.Fprintf(
+				w,
+				"- ... %d more blocking outcome(s); inspect meta.collection.outcomes\n",
+				assessment.omittedOutcomeCount,
+			)
+		}
+		_, _ = fmt.Fprintln(
+			w,
+			"Ingesting this artifact may withhold graph publication. Review meta.collection.outcomes and recollect blocking coverage before treating absence as evidence.",
+		)
+	}
+	writeInstructionCoverageWarnings(w, report)
+}
+
+func writeScanOutcomeWarning(w io.Writer, outcome ingest.CollectionOutcome) {
+	target, cause, causeOmitted := safeScanOutcomeDiagnostic(outcome)
+	label := strings.TrimSpace(outcome.Collector)
+	if method := strings.TrimSpace(outcome.Method); method != "" {
+		if label != "" {
+			label += "/"
+		}
+		label += method
+	}
+	if label == "" {
+		label = "collection"
+	}
+	if target != "" {
+		label += " " + target
+	}
+	state := outcome.State
+	if state == "" {
+		state = ingest.OutcomeUnknown
+	}
+	_, _ = fmt.Fprintf(w, "- %s — %s", label, state)
+	switch {
+	case cause != "":
+		_, _ = fmt.Fprintf(w, ": %s", cause)
+	case causeOmitted:
+		_, _ = fmt.Fprint(
+			w,
+			": cause omitted from terminal output; inspect meta.collection.outcomes",
+		)
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+func safeScanOutcomeDiagnostic(
+	outcome ingest.CollectionOutcome,
+) (target, cause string, causeOmitted bool) {
+	target = strings.TrimSpace(outcome.Target)
+	cause = strings.Join(strings.Fields(outcome.Error), " ")
+	rawTarget := target
+	lowerTarget := strings.ToLower(target)
+	httpTarget := strings.HasPrefix(lowerTarget, "http://") ||
+		strings.HasPrefix(lowerTarget, "https://")
+	sanitizeTarget := target
+	if outcome.Collector == "a2a" && !httpTarget && target != "" {
+		sanitizeTarget = "https://" + target
+		httpTarget = true
+	}
+	if !httpTarget {
+		return target, cause, false
+	}
+
+	safe := ingest.SanitizeHTTPEndpoint(sanitizeTarget)
+	target = safe.Display
+	if safe.Redacted() {
+		return target, "", cause != ""
+	}
+	if rawTarget != "" {
+		cause = strings.ReplaceAll(cause, rawTarget, target)
+	}
+	if sanitizeTarget != rawTarget {
+		cause = strings.ReplaceAll(cause, sanitizeTarget, target)
+	}
+	return target, cause, false
+}
+
+func writeScanNextStep(
+	w io.Writer,
+	output string,
+	assessment scanCoverageAssessment,
+	totalFailure bool,
+) {
+	if output == "" || output == "-" {
+		return
+	}
+	if totalFailure {
+		_, _ = fmt.Fprintf(
+			w,
+			"Artifact saved for diagnostics: %s\n",
+			output,
+		)
+		return
+	}
+	switch {
+	case !assessment.incomplete:
+		_, _ = fmt.Fprintf(
+			w,
+			"Next: agenthound-server ingest %s\n",
+			output,
+		)
+	case assessment.blocking:
+		_, _ = fmt.Fprintf(
+			w,
+			"Next (after reviewing incomplete coverage): agenthound-server ingest %s\n",
+			output,
+		)
+	default:
+		_, _ = fmt.Fprintf(
+			w,
+			"Next (coverage-limited artifact; review warnings): agenthound-server ingest %s\n",
+			output,
+		)
+	}
 }
 
 func writeInstructionCoverageWarnings(w io.Writer, report *ingest.CollectionReport) {
@@ -924,10 +1167,19 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 	if output == "" {
 		output = fmt.Sprintf("scan-%s.json", envelope.Meta.ScanID)
 	}
+	var writeErr error
 	if output == "-" {
-		return writeCollectorOutputStdout(envelope)
+		writeErr = writeCollectorOutputStdout(envelope)
+	} else {
+		writeErr = writeCollectorOutputFile(envelope, output)
 	}
-	return writeCollectorOutput(envelope, output)
+	if writeErr != nil {
+		return writeErr
+	}
+	assessment := assessScanCoverage(envelope.Meta.Collection)
+	writeScanCoverageWarnings(cmd.ErrOrStderr(), envelope.Meta.Collection, assessment)
+	writeScanNextStep(cmd.ErrOrStderr(), output, assessment, false)
+	return nil
 }
 
 // buildNetworkScanEnvelope constructs the ingest envelope populated by the

--- a/collector/cli/scan_fixes_test.go
+++ b/collector/cli/scan_fixes_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -569,32 +571,171 @@ func TestAllCollectorsFailed(t *testing.T) {
 	}
 }
 
-func TestInstructionCoverageWarningPreservesUsableScanSuccess(t *testing.T) {
-	root := ingest.CanonicalCoverageKey("config", "instruction-deep", "/home/example")
-	contract := ingest.CurrentInstructionRegistryContract()
+func TestScanCoverageWarningsIdentifyBlockingLeafOutcome(t *testing.T) {
+	root := ingest.CollectorRootCoverageKey("config")
+	path := ingest.CanonicalCoverageKey("config", "path", "/tmp/broken.json")
 	report := &ingest.CollectionReport{
-		State:        ingest.OutcomeTruncated,
-		CoverageKeys: []string{root},
-		AuthoritativeRoots: []ingest.CoverageRoot{{
-			CoverageKey:      root,
-			RegistryContract: &contract,
-		}},
+		State:        ingest.OutcomePartial,
+		CoverageKeys: []string{root, path},
+		Outcomes: []ingest.CollectionOutcome{
+			{
+				Collector: "config", CoverageKey: path,
+				ParentCoverageKey: root, Target: "/tmp/broken.json",
+				Method: "config_discovery", State: ingest.OutcomeFailed,
+				Error: "11 parser(s) failed",
+			},
+			{
+				Collector: "config", CoverageKey: root, Target: "config",
+				Method: "collect", State: ingest.OutcomePartial,
+			},
+		},
+	}
+
+	assessment := assessScanCoverage(report)
+	if !assessment.incomplete || !assessment.blocking {
+		t.Fatalf("assessment = %+v, want blocking incomplete", assessment)
+	}
+	if len(assessment.blockingOutcomes) != 1 ||
+		assessment.blockingOutcomes[0].Method != "config_discovery" {
+		t.Fatalf("blocking outcomes = %+v, want only leaf failure", assessment.blockingOutcomes)
+	}
+
+	var stderr bytes.Buffer
+	writeScanCoverageWarnings(&stderr, report, assessment)
+	writeScanNextStep(&stderr, "/tmp/scan.json", assessment, false)
+	for _, want := range []string{
+		"WARNING: Scan artifact is partial",
+		"config/config_discovery /tmp/broken.json — failed: 11 parser(s) failed",
+		"may withhold graph publication",
+		"Next (after reviewing incomplete coverage): agenthound-server ingest /tmp/scan.json",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("warning missing %q:\n%s", want, stderr.String())
+		}
+	}
+	if strings.Contains(stderr.String(), "config/collect") {
+		t.Fatalf("aggregate collector root duplicated the leaf failure:\n%s", stderr.String())
+	}
+}
+
+func TestNetworkScanCoverageWarningIdentifiesIncompleteFingerprint(t *testing.T) {
+	port := ingest.CanonicalCoverageKey("network", "port", "127.0.0.1:18080")
+	fingerprint := ingest.CanonicalCoverageKey(
+		"network",
+		"fingerprint",
+		"127.0.0.1:18080/http",
+	)
+	report := &ingest.CollectionReport{
+		State:        ingest.OutcomePartial,
+		CoverageKeys: []string{port, fingerprint},
+		Outcomes: []ingest.CollectionOutcome{
+			{
+				Collector: "network", CoverageKey: port,
+				Target: "127.0.0.1:18080", Method: "port_scan",
+				State: ingest.OutcomeComplete,
+			},
+			{
+				Collector: "network", CoverageKey: fingerprint,
+				ParentCoverageKey: port, Target: "127.0.0.1:18080",
+				Method: "http_fingerprint", State: ingest.OutcomePartial,
+				Error: "request timed out",
+			},
+		},
+	}
+
+	assessment := assessScanCoverage(report)
+	var stderr bytes.Buffer
+	writeScanCoverageWarnings(&stderr, report, assessment)
+	writeScanNextStep(&stderr, "/tmp/network.json", assessment, false)
+	for _, want := range []string{
+		"WARNING: Scan artifact is partial",
+		"network/http_fingerprint 127.0.0.1:18080 — partial: request timed out",
+		"Next (after reviewing incomplete coverage): agenthound-server ingest /tmp/network.json",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("network warning missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestScanCoverageWarningsRedactSecretBearingA2AOutcome(t *testing.T) {
+	const safeTarget = "https://agents.example.test/card"
+	rawTarget := "https://" +
+		strings.Join([]string{"url-user", "url-pass"}, ":") +
+		"@agents.example.test/card?api_key=query-secret#fragment-secret"
+	scope := ingest.CanonicalCoverageKey("a2a", "target", rawTarget)
+	report := &ingest.CollectionReport{
+		State:        ingest.OutcomeFailed,
+		CoverageKeys: []string{scope},
 		Outcomes: []ingest.CollectionOutcome{{
-			Collector:   "config",
-			CoverageKey: root,
-			Method:      ingest.InstructionMethodDeep,
-			State:       ingest.OutcomeTruncated,
-			Error:       "deep instruction discovery exceeded 60s budget",
+			Collector: "a2a", CoverageKey: scope, Target: rawTarget,
+			Method: "agent_card", State: ingest.OutcomeFailed,
+			Error: "fetch " + rawTarget + "/.well-known/agent-card.json: connection refused",
 		}},
 	}
 
 	var stderr bytes.Buffer
-	writeInstructionCoverageWarnings(&stderr, report)
+	writeScanCoverageWarnings(&stderr, report, assessScanCoverage(report))
+	if !strings.Contains(stderr.String(), safeTarget) {
+		t.Fatalf("warning missing sanitized target %q:\n%s", safeTarget, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cause omitted from terminal output") {
+		t.Fatalf("warning did not explain omitted sensitive cause:\n%s", stderr.String())
+	}
+	for _, secret := range []string{
+		rawTarget,
+		"url-user",
+		"url-pass",
+		"query-secret",
+		"fragment-secret",
+		"api_key",
+	} {
+		if strings.Contains(stderr.String(), secret) {
+			t.Fatalf("warning leaked %q:\n%s", secret, stderr.String())
+		}
+	}
+}
+
+func TestInstructionCoverageWarningPreservesUsableScanSuccess(t *testing.T) {
+	root := ingest.CanonicalCoverageKey("config", "instruction-deep", "/home/example")
+	configRoot := ingest.CollectorRootCoverageKey("config")
+	contract := ingest.CurrentInstructionRegistryContract()
+	report := &ingest.CollectionReport{
+		State:        ingest.OutcomeTruncated,
+		CoverageKeys: []string{configRoot, root},
+		AuthoritativeRoots: []ingest.CoverageRoot{{
+			CoverageKey:      root,
+			RegistryContract: &contract,
+		}},
+		Outcomes: []ingest.CollectionOutcome{
+			{
+				Collector: "config", CoverageKey: configRoot,
+				Method: "collect", State: ingest.OutcomeComplete,
+			},
+			{
+				Collector:   "config",
+				CoverageKey: root,
+				Method:      ingest.InstructionMethodDeep,
+				State:       ingest.OutcomeTruncated,
+				Error:       "deep instruction discovery exceeded 60s budget",
+			},
+		},
+	}
+
+	var stderr bytes.Buffer
+	assessment := assessScanCoverage(report)
+	if assessment.blocking {
+		t.Fatalf("instruction-only limitation became blocking: %+v", assessment)
+	}
+	writeScanCoverageWarnings(&stderr, report, assessment)
+	writeScanNextStep(&stderr, "/tmp/instructions.json", assessment, false)
 	for _, want := range []string{
+		"WARNING: Scan artifact is truncated",
 		"deep instruction coverage is limited",
 		"deep instruction discovery exceeded 60s budget",
 		"observed instruction positives were retained",
 		"missing instruction evidence is not a clean absence",
+		"Next (coverage-limited artifact; review warnings):",
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("warning missing %q: %s", want, stderr.String())
@@ -611,9 +752,10 @@ func TestInstructionCoverageWarningPreservesUsableScanSuccess(t *testing.T) {
 	}
 
 	stderr.Reset()
-	report.Outcomes[0].State = ingest.OutcomeComplete
+	report.Outcomes[1].State = ingest.OutcomeComplete
 	report.State = ingest.OutcomeComplete
-	writeInstructionCoverageWarnings(&stderr, report)
+	assessment = assessScanCoverage(report)
+	writeScanCoverageWarnings(&stderr, report, assessment)
 	if stderr.Len() != 0 {
 		t.Fatalf("complete deep coverage emitted warning: %s", stderr.String())
 	}
@@ -683,6 +825,8 @@ func TestRunScan_EmptySuccessExitsZero(t *testing.T) {
 	out := filepath.Join(dir, "empty-ok.json")
 
 	cmd := newScanCmdForTest()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
 	mustSetFlag(t, cmd, "config", "true")
 	mustSetFlag(t, cmd, "path", writeEmptyConfig(t))
 	mustSetFlag(t, cmd, "scan-output", out)
@@ -692,6 +836,96 @@ func TestRunScan_EmptySuccessExitsZero(t *testing.T) {
 	}
 	if _, err := os.Stat(out); err != nil {
 		t.Fatalf("expected artifact at %s: %v", out, err)
+	}
+	if strings.Contains(stderr.String(), "WARNING:") {
+		t.Fatalf("complete scan emitted a coverage warning:\n%s", stderr.String())
+	}
+	if !strings.Contains(
+		stderr.String(),
+		"Next: agenthound-server ingest "+out,
+	) {
+		t.Fatalf("complete scan lost the standard next step:\n%s", stderr.String())
+	}
+}
+
+func TestRunScan_MalformedConfigWarnsButExitsZero(t *testing.T) {
+	t.Setenv("AGENTHOUND_QUIET", "1")
+	dir := t.TempDir()
+	malformed := filepath.Join(dir, "malformed.json")
+	if err := os.WriteFile(malformed, []byte(`{"mcpServers":`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "partial.json")
+
+	cmd := newScanCmdForTest()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	mustSetFlag(t, cmd, "config", "true")
+	mustSetFlag(t, cmd, "path", malformed)
+	mustSetFlag(t, cmd, "project-dir", dir)
+	mustSetFlag(t, cmd, "scan-output", out)
+
+	if err := runScan(cmd, nil); err != nil {
+		t.Fatalf("malformed target-level outcome must retain exit zero: %v", err)
+	}
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var artifact ingest.IngestData
+	if err := json.Unmarshal(raw, &artifact); err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Meta.Collection == nil ||
+		artifact.Meta.Collection.State != ingest.OutcomePartial {
+		t.Fatalf("malformed config state = %+v, want partial", artifact.Meta.Collection)
+	}
+	for _, want := range []string{
+		"WARNING: Scan artifact is partial",
+		"config/config_discovery " + malformed,
+		"Next (after reviewing incomplete coverage): agenthound-server ingest " + out,
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("quiet partial scan warning missing %q:\n%s", want, stderr.String())
+		}
+	}
+	if strings.Contains(stderr.String(), "Collected ") {
+		t.Fatalf("--quiet retained routine progress:\n%s", stderr.String())
+	}
+}
+
+func TestRunScan_FailedA2AOutcomesRemainExitZeroWithQualifiedHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	out := filepath.Join(t.TempDir(), "failed-a2a.json")
+	cmd := newScanCmdForTest()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	mustSetFlag(t, cmd, "a2a", "true")
+	mustSetFlag(t, cmd, "target", server.URL)
+	mustSetFlag(t, cmd, "scan-output", out)
+
+	if err := runScan(cmd, nil); err != nil {
+		t.Fatalf("collector-returned failed artifact must retain exit zero: %v", err)
+	}
+	raw, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var artifact ingest.IngestData
+	if err := json.Unmarshal(raw, &artifact); err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Meta.Collection == nil ||
+		artifact.Meta.Collection.State != ingest.OutcomeFailed {
+		t.Fatalf("A2A collection state = %+v, want failed", artifact.Meta.Collection)
+	}
+	if !strings.Contains(stderr.String(), "WARNING: Scan artifact is failed") ||
+		!strings.Contains(stderr.String(), "Next (after reviewing incomplete coverage):") {
+		t.Fatalf("failed artifact did not receive review-qualified guidance:\n%s", stderr.String())
 	}
 }
 
@@ -704,6 +938,8 @@ func TestRunScan_AllCollectorsFailExitsNonZero(t *testing.T) {
 	out := filepath.Join(dir, "all-fail.json")
 
 	cmd := newScanCmdForTest()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
 	mustSetFlag(t, cmd, "config", "true")
 	mustSetFlag(t, cmd, "project-dir", filepath.Join(dir, "no-such-project"))
 	mustSetFlag(t, cmd, "scan-output", out)
@@ -729,6 +965,13 @@ func TestRunScan_AllCollectorsFailExitsNonZero(t *testing.T) {
 	}
 	if len(ingest.CompleteAuthoritativeRoots(artifact.Meta.Collection)) != 0 {
 		t.Fatalf("invalid root became authoritative: %+v", artifact.Meta.Collection.AuthoritativeRoots)
+	}
+	if strings.Contains(stderr.String(), "Next:") ||
+		strings.Contains(stderr.String(), "Next (") {
+		t.Fatalf("total collector failure emitted an ingest hint:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Artifact saved for diagnostics: "+out) {
+		t.Fatalf("total failure omitted diagnostic artifact path:\n%s", stderr.String())
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -85,15 +85,19 @@ When none specified, defaults to config + MCP.
 
 Supported clients (12): Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, Continue, Zed, Cline, JetBrains, Kiro, Amazon Q, Augment.
 
-Auto-discovery reads each physical configuration file once and applies every
-client format registered for that path. A shared settings file is represented
-by one `ConfigFile` with sorted `clients` and one `AgentInstance` per applicable
-client. Recognized empty server maps are valid empty configurations; malformed,
-unreadable, or oversized files produce non-authoritative failure states while
-valid views from the same file are retained. For an explicitly supplied export
-whose generic shape is shared by several clients and whose path proves none of
-them, the servers are retained under client `unknown` instead of inventing a
-specific application.
+Auto-discovery reads each registered lexical absolute path once and applies
+every client format registered for that path. A shared settings path is
+represented by one `ConfigFile` with sorted `clients` and one `AgentInstance`
+per applicable client. Explicit `--path` and `--paths` values retain the
+identity of every supplied absolute path, including symlink aliases: two
+logical client locations may point to the same underlying file without
+becoming the same `ConfigFile`. Their server definitions still converge on the
+normal deterministic `MCPServer` identity. Recognized empty server maps are
+valid empty configurations; malformed, unreadable, or oversized files produce
+non-authoritative failure states while valid views from the same path are
+retained. For an explicitly supplied export whose generic shape is shared by
+several clients and whose path proves none of them, the servers are retained
+under client `unknown` instead of inventing a specific application.
 
 Credential-named env vars, headers, arguments, and URL components with empty or
 whitespace-only values are omitted rather than emitted as exposed credentials
@@ -252,7 +256,7 @@ separate `signature_key_source` and `signature_key_trust` properties.
 
 Link-local and multicast addresses are refused unconditionally.
 
-By default network-mode `scan` prints a one-line summary (`N host(s) with at least one open port`) plus a final fingerprint summary; pass `--verbose` to list every host, which can run to thousands of lines on a large sweep. On an interactive terminal a single rewriting progress line is shown during the port sweep and fingerprint phase. `--quiet` (or `AGENTHOUND_QUIET=1`) suppresses the progress line, the per-host summary, and the fingerprint output, leaving only errors. None of this affects the JSON written to `--output`.
+By default network-mode `scan` prints a one-line summary (`N host(s) with at least one open port`) plus a final fingerprint summary; pass `--verbose` to list every host, which can run to thousands of lines on a large sweep. On an interactive terminal a single rewriting progress line is shown during the port sweep and fingerprint phase. `--quiet` (or `AGENTHOUND_QUIET=1`) suppresses routine progress, per-host summaries, and fingerprint output, but never suppresses errors or collection-coverage warnings. None of this affects the JSON written to `--output`.
 
 Every registered fingerprinter runs once against every open endpoint. Port
 mappings prioritize likely candidates but are not eligibility gates, so a real
@@ -285,6 +289,32 @@ endpoint already protected by an operator-controlled VPN/SSH tunnel. Use HTTPS
 or a trusted tunnel for any non-loopback route; `--insecure` applies to
 collection targets, not ingest TLS. Artifacts produced with
 `--include-credential-values` can contain raw secrets.
+
+#### Collection Outcome and Exit Semantics
+
+Every saved scan artifact records its aggregate state and per-target details
+under `meta.collection`. Complete scans print the normal
+`Next: agenthound-server ingest ...` instruction without a coverage warning.
+Partial, failed, truncated, or unknown artifacts print a warning on stderr,
+including the actionable blocking outcomes and a review-qualified ingest
+instruction. Full details remain in `meta.collection.outcomes`; stdout JSON is
+unchanged.
+
+Usable incomplete evidence retains exit status zero. This includes a collector
+that returned a typed artifact whose target observations all failed. The scan
+exits non-zero for collection failure only when every enabled top-level
+collector returned an error; the saved artifact is then identified as
+diagnostic evidence and no ingest instruction is printed. Output, argument,
+and remote-ingest failures retain their existing non-zero behavior.
+
+Recognized incomplete instruction roots are the non-blocking exception
+described above: their proven per-file positives may publish, so their warning
+does not claim that ingestion will be withheld. Other blocking incomplete
+coverage may cause ingestion to withhold graph publication. Review
+`meta.collection.outcomes`, correct or recollect the failed coverage, and do
+not treat missing facts as evidence of absence. With `--ingest`, the warning is
+printed after the backup artifact is saved and before the explicitly requested
+upload begins.
 
 #### Example
 

--- a/modules/config/collector_test.go
+++ b/modules/config/collector_test.go
@@ -724,6 +724,84 @@ func TestConfigCollector_MultipleConfigPaths(t *testing.T) {
 	}
 }
 
+func TestConfigCollector_ExplicitSymlinkPreservesLogicalPathIdentity(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	original := filepath.Join(tmp, ".vscode", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(original), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, original, `{"servers":{"shared":{"command":"node","args":["server.js"]}}}`)
+	alias := filepath.Join(tmp, "duplicate-config.json")
+	if err := os.Symlink(original, alias); err != nil {
+		t.Skipf("create config symlink: %v", err)
+	}
+
+	result, err := NewConfigCollector().Collect(
+		context.Background(),
+		collector.CollectOptions{
+			ConfigPaths: []string{original, alias},
+			ProjectDir:  tmp,
+			ScanID:      "logical-path-aliases",
+		},
+	)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	configIDs := make(map[string]bool)
+	agentIDs := make(map[string]bool)
+	serverIDs := make(map[string]bool)
+	configPaths := make(map[string]bool)
+	for _, node := range result.Graph.Nodes {
+		switch {
+		case hasNodeKind(node, "ConfigFile"):
+			configIDs[node.ID] = true
+			if path, _ := node.Properties["path"].(string); path != "" {
+				configPaths[path] = true
+			}
+		case hasNodeKind(node, "AgentInstance"):
+			agentIDs[node.ID] = true
+		case hasNodeKind(node, "MCPServer"):
+			serverIDs[node.ID] = true
+		}
+	}
+	if len(configIDs) != 2 || len(agentIDs) != 2 {
+		t.Fatalf(
+			"logical path identities: ConfigFile=%d AgentInstance=%d, want 2 each",
+			len(configIDs),
+			len(agentIDs),
+		)
+	}
+	if !configPaths[canonicalConfigPath(original)] ||
+		!configPaths[canonicalConfigPath(alias)] {
+		t.Fatalf("config paths = %v, want original and explicit alias", configPaths)
+	}
+	if len(serverIDs) != 1 {
+		t.Fatalf("MCPServer identities = %v, want one shared server identity", serverIDs)
+	}
+
+	configuredTargets := make(map[string]bool)
+	for _, edge := range result.Graph.Edges {
+		if edge.Kind == "CONFIGURED_IN" {
+			configuredTargets[edge.Target] = true
+			if !serverIDs[edge.Source] {
+				t.Fatalf("CONFIGURED_IN source %q is not the shared MCPServer", edge.Source)
+			}
+		}
+	}
+	if len(configuredTargets) != 2 {
+		t.Fatalf(
+			"CONFIGURED_IN logical locations = %v, want both ConfigFile identities",
+			configuredTargets,
+		)
+	}
+}
+
 func TestConfigCollector_InstructionFiles(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	tmp := t.TempDir()

--- a/modules/config/discovery.go
+++ b/modules/config/discovery.go
@@ -148,9 +148,9 @@ func ResolveProjectRoot(projectDir string) (*ValidatedProjectRoot, error) {
 	return &ValidatedProjectRoot{path: abs, dir: dir, info: openedInfo}, nil
 }
 
-// DiscoveryPathsForRoot returns the de-duplicated physical path inventory for
-// exhaustive discovery, rebasing every project-relative parser path onto the
-// validated effective project root.
+// DiscoveryPathsForRoot returns the de-duplicated registered-path inventory
+// for exhaustive discovery, rebasing every project-relative parser path onto
+// the validated effective project root.
 func (c *ConfigCollector) DiscoveryPathsForRoot(homeDir, projectRoot string) []string {
 	registry := c.discoveryRegistry(homeDir, projectRoot)
 	paths := make([]string, 0, len(registry))
@@ -193,10 +193,10 @@ func (c *ConfigCollector) discoveryRegistry(homeDir, projectRoot string) map[str
 	return registry
 }
 
-// DiscoverConfigs reads every physical file at most once. Exhaustive mode
-// uses the parser path registry; explicitly supplied unknown paths are tested
-// against every parser compatible with the file syntax so no valid view is
-// silently discarded.
+// DiscoverConfigs reads every registered lexical absolute path at most once.
+// Exhaustive mode uses the parser path registry; explicitly supplied unknown
+// paths retain their own logical identity and are tested against every parser
+// compatible with the file syntax so no valid view is silently discarded.
 func (c *ConfigCollector) DiscoverConfigs(
 	ctx context.Context,
 	homeDir string,
@@ -292,11 +292,11 @@ func discoverPhysicalFile(path string, parsers []ConfigParser, preferredClients 
 		parsedViews = append(parsedViews, *cfg)
 	}
 	if preferredClients == nil {
-		// Exhaustive registry discovery has physical-path provenance for every
+		// Exhaustive registry discovery has registered-path provenance for every
 		// parser selected for this file, including genuinely shared settings.
 		file.Configs = append(file.Configs, parsedViews...)
 	} else if len(preferredClients) > 0 {
-		// Explicit files still run every parser, but a documented physical path
+		// Explicit files still run every parser, but a documented registered path
 		// is stronger client-identity evidence than a shared JSON shape.
 		for _, cfg := range parsedViews {
 			if preferredClients[cfg.Client] {

--- a/scripts/release-process-test.sh
+++ b/scripts/release-process-test.sh
@@ -85,6 +85,7 @@ expect_failure "release-notes version mismatch" sh "$notes/scripts/release-notes
 
 formula_fixture="$test_root/agenthound.rb"
 checksums_fixture="$test_root/checksums.txt"
+printf '  version "1.0.1"\n' > "$formula_fixture"
 for platform in darwin linux; do
   for arch in amd64 arm64; do
     asset="agenthound_1.0.1_${platform}_${arch}.tar.gz"
@@ -94,9 +95,6 @@ for platform in darwin linux; do
     printf '%s  %s\n' "$checksum" "$asset" >> "$checksums_fixture"
   done
 done
-sed -i.bak '1i\
-  version "1.0.1"' "$formula_fixture"
-rm "$formula_fixture.bak"
 bash "$repo_root/scripts/verify-homebrew-formula.sh" \
   agenthound 1.0.1 v1.0.1 "$formula_fixture" "$checksums_fixture"
 


### PR DESCRIPTION
## Summary

Fixes the two release-impacting validation findings while preserving the intentional logical-path identity model:

- **AH-RV-001:** construct the Homebrew formula fixture directly instead of relying on GNU/BSD-incompatible `sed` insertion syntax. The verifier and negative case remain unchanged.
- **AH-RV-003:** warn on every non-complete scan artifact, list bounded actionable blocking outcomes, explain possible publication withholding, and qualify the ingest next step. Useful partial/failed evidence retains the existing exit-zero behavior; only the existing `allCollectorsFailed` condition suppresses the ingest hint and returns non-zero.
- **AH-RV-004:** no symlink resolution or inode deduplication. Documentation and a regression test now make explicit that supplied lexical paths retain separate `ConfigFile`/`AgentInstance` provenance while converging on one deterministic `MCPServer` identity.

## Behavior constraints preserved

- Reuses `AuthoritativeCoverageComplete` and `IncompleteInstructionRoots` so recognized instruction-only limitations remain non-blocking.
- Keeps stdout artifact JSON and ingest payloads unchanged; warnings go to stderr and survive `--quiet`.
- Explicit `--ingest` still uploads useful incomplete evidence, but warns after saving the backup and before upload.
- Sanitizes secret-bearing A2A target URLs/errors before rendering terminal diagnostics.
- Leaves server publication policy, schemas, flags, and exit-code policy unchanged.

## Validation

- `bash scripts/release-process-test.sh`
- `go test ./collector/cli ./modules/config -count=1 -timeout=5m`
- `make docs-check` (with a disposable docs virtualenv)
- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./... -race -timeout=15m`
- `make prerelease` — all 13 gates pass

Base: `d332af84ead4e8dd1fc2a55db39bb2efff187983`