### PR TITLE
Fix mixed observation owner transitions

### DIFF
--- a/server/internal/graph/fingerprint_test.go
+++ b/server/internal/graph/fingerprint_test.go
@@ -43,6 +43,45 @@ func TestObservationFactFingerprintIgnoresWriterLifecycleFields(t *testing.T) {
 	}
 }
 
+func TestObservationOwnerFingerprintsPairDomainsWithFacts(t *testing.T) {
+	const (
+		domainA = "config:path:sha256:owner-a"
+		domainB = "config:path:sha256:owner-b"
+	)
+	fingerprints, err := observationFactFingerprints(
+		[]string{domainB, domainA},
+		map[string]any{"properties": map[string]any{"endpoint": "stdio://server"}},
+	)
+	if err != nil {
+		t.Fatalf("fingerprints: %v", err)
+	}
+	owners := observationOwnerFingerprints(
+		[]string{domainB, domainA, domainA},
+		fingerprints,
+	)
+	want := []map[string]any{
+		{
+			"token_prefix":     observationDomainPrefix(domainA),
+			"fact_fingerprint": fingerprints[0],
+		},
+		{
+			"token_prefix":     observationDomainPrefix(domainB),
+			"fact_fingerprint": fingerprints[1],
+		},
+	}
+	if !reflect.DeepEqual(owners, want) {
+		t.Fatalf("owner fingerprints = %#v, want %#v", owners, want)
+	}
+
+	missing := observationOwnerFingerprints(
+		[]string{domainA, domainB},
+		fingerprints[:1],
+	)
+	if len(missing) != 1 {
+		t.Fatalf("missing owner fingerprint was fabricated: %#v", missing)
+	}
+}
+
 func TestPrepareObservationNodesFingerprintsOwnersBeforeUnion(t *testing.T) {
 	const (
 		domainA = "config:path:sha256:owner-a"
@@ -366,8 +405,12 @@ func TestWriterCarriesStableFingerprintsForExactSharedOwnerRefresh(t *testing.T)
 	}
 	for _, fragment := range []string{
 		"compatible_existing_owner",
+		"compatible_mixed_owners",
+		"size(node.observation_owner_fingerprints) =",
+		"owner.fact_fingerprint IN old_fact_fingerprints",
 		"fingerprint IN old_fact_fingerprints",
 		"WHEN compatible_existing_owner THEN true",
+		"WHEN compatible_mixed_owners THEN true",
 		"WHEN incoming_complete THEN\n        [fingerprint IN old_fact_fingerprints",
 	} {
 		if !strings.Contains(call.Cypher, fragment) {
@@ -378,8 +421,12 @@ func TestWriterCarriesStableFingerprintsForExactSharedOwnerRefresh(t *testing.T)
 	edgeQuery := edgeCypherForKinds("RUNS_ON", "MCPServer", "Host")
 	for _, fragment := range []string{
 		"compatible_existing_owner",
+		"compatible_mixed_owners",
+		"size(edge.observation_owner_fingerprints) =",
+		"owner.fact_fingerprint IN old_fact_fingerprints",
 		"edge.observation_fact_fingerprints",
 		"WHEN compatible_existing_owner THEN true",
+		"WHEN compatible_mixed_owners THEN true",
 	} {
 		if !strings.Contains(edgeQuery, fragment) {
 			t.Fatalf("edge refresh query missing %q:\n%s", fragment, edgeQuery)
@@ -389,7 +436,7 @@ func TestWriterCarriesStableFingerprintsForExactSharedOwnerRefresh(t *testing.T)
 
 func TestNodeLabelMutationIsCompatibilityGated(t *testing.T) {
 	query := nodeCypherForKindTuple("OllamaInstance", []string{"AIService"})
-	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner THEN [1] ELSE [] END | SET n:AIService)"
+	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners THEN [1] ELSE [] END | SET n:AIService)"
 	if !strings.Contains(query, want) {
 		t.Fatalf("extra label mutation is not compatibility-gated:\n%s", query)
 	}

--- a/server/internal/graph/integration_test.go
+++ b/server/internal/graph/integration_test.go
@@ -1940,6 +1940,232 @@ func TestIntegrationCompatibleDistinctOwnersRemainCompleteUntilOneRetires(t *tes
 	}
 }
 
+func TestIntegrationMixedExistingAndNewOwnersRemainComplete(t *testing.T) {
+	ctx := testDriver(t)
+	driver, err := NewDriver(
+		os.Getenv("AGENTHOUND_NEO4J_URI"),
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+
+	writer := NewWriter(driver)
+	db := NewDB(NewReader(driver), writer)
+	const (
+		serverID    = "mixed-owner-server"
+		hostID      = "mixed-owner-host"
+		configScope = "config:path:sha256:mixed-owner-original"
+		aliasScope  = "config:path:sha256:mixed-owner-alias"
+		liveScope   = "mcp:target:sha256:mixed-owner-live"
+	)
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(
+			ctx,
+			"MATCH (n) WHERE n.objectid IN $ids DETACH DELETE n",
+			map[string]any{"ids": []string{serverID, hostID}},
+		)
+	}
+	cleanup()
+	defer cleanup()
+
+	configNodes := func(domain, configuredName string) []ingest.Node {
+		return []ingest.Node{
+			{
+				ID: serverID, Kinds: []string{"MCPServer"},
+				ObservationDomains: []string{domain},
+				Properties: map[string]any{
+					"endpoint":        "http://mcp.example/mcp",
+					"transport":       "http",
+					"configured_name": configuredName,
+				},
+			},
+			{
+				ID: hostID, Kinds: []string{"Host"},
+				ObservationDomains: []string{domain},
+				Properties:         map[string]any{"hostname": "mcp.example"},
+			},
+		}
+	}
+	configEdge := func(domain, evidence string) ingest.Edge {
+		return ingest.Edge{
+			Source: serverID, Target: hostID, Kind: "RUNS_ON",
+			SourceKind: "MCPServer", TargetKind: "Host",
+			ObservationDomains: []string{domain},
+			Properties: map[string]any{
+				"confidence": 1.0, "risk_weight": 0.0, "is_composite": false,
+				"configured_evidence": evidence,
+			},
+		}
+	}
+	liveNodes := []ingest.Node{
+		{
+			ID: serverID, Kinds: []string{"MCPServer"},
+			ObservationDomains: []string{liveScope},
+			Properties: map[string]any{
+				"endpoint":         "http://mcp.example/mcp",
+				"transport":        "http",
+				"protocol_version": "2025-06-18",
+			},
+		},
+		{
+			ID: hostID, Kinds: []string{"Host"},
+			ObservationDomains: []string{liveScope},
+			Properties: map[string]any{
+				"hostname": "mcp.example",
+				"scope":    "public",
+			},
+		},
+	}
+	liveEdge := ingest.Edge{
+		Source: serverID, Target: hostID, Kind: "RUNS_ON",
+		SourceKind: "MCPServer", TargetKind: "Host",
+		ObservationDomains: []string{liveScope},
+		Properties: map[string]any{
+			"confidence": 1.0, "risk_weight": 0.0, "is_composite": false,
+			"live_evidence": "initialize",
+		},
+	}
+	writeAndReconcile := func(
+		nodes []ingest.Node,
+		edges []ingest.Edge,
+		scanID string,
+		completeDomains []string,
+	) {
+		t.Helper()
+		if _, err := writer.WriteObservationNodes(
+			ctx, nodes, scanID, completeDomains,
+		); err != nil {
+			t.Fatalf("%s nodes: %v", scanID, err)
+		}
+		if _, err := writer.WriteObservationEdges(
+			ctx, edges, scanID, completeDomains,
+		); err != nil {
+			t.Fatalf("%s edges: %v", scanID, err)
+		}
+		if _, err := ReconcileObservations(
+			ctx, db, scanID, completeDomains,
+		); err != nil {
+			t.Fatalf("%s reconcile: %v", scanID, err)
+		}
+	}
+
+	writeAndReconcile(
+		configNodes(configScope, "configured"),
+		[]ingest.Edge{configEdge(configScope, "configured")},
+		"mixed-owner-config",
+		[]string{configScope},
+	)
+	writeAndReconcile(
+		liveNodes,
+		[]ingest.Edge{liveEdge},
+		"mixed-owner-live",
+		[]string{liveScope},
+	)
+
+	aliasNodes := append(
+		configNodes(configScope, "configured"),
+		configNodes(aliasScope, "configured")...,
+	)
+	aliasEdges := []ingest.Edge{
+		configEdge(configScope, "configured"),
+		configEdge(aliasScope, "configured"),
+	}
+	writeAndReconcile(
+		aliasNodes,
+		aliasEdges,
+		"mixed-owner-alias",
+		[]string{configScope, aliasScope},
+	)
+
+	rows, err := db.Query(ctx, `
+		MATCH (server:MCPServer {objectid: $server})-[r:RUNS_ON]->
+		      (host:Host {objectid: $host})
+		RETURN server.observation_properties_complete AS server_complete,
+		       host.observation_properties_complete AS host_complete,
+		       r.observation_properties_complete AS edge_complete,
+		       server.configured_name AS configured_name,
+		       server.protocol_version AS protocol_version,
+		       r.configured_evidence AS configured_evidence,
+		       r.live_evidence AS live_evidence,
+		       size(server.observation_tokens) AS server_tokens,
+		       size(host.observation_tokens) AS host_tokens,
+		       size(r.observation_tokens) AS edge_tokens,
+		       size(server.observation_fact_fingerprints) AS server_fingerprints,
+		       size(host.observation_fact_fingerprints) AS host_fingerprints,
+		       size(r.observation_fact_fingerprints) AS edge_fingerprints`,
+		map[string]any{"server": serverID, "host": hostID})
+	if err != nil {
+		t.Fatalf("query compatible mixed owners: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("mixed owner rows = %+v", rows)
+	}
+	row := rows[0]
+	for _, key := range []string{
+		"server_complete", "host_complete", "edge_complete",
+	} {
+		if row[key] != true {
+			t.Fatalf("mixed owner %s = %v; row=%+v", key, row[key], row)
+		}
+	}
+	if row["configured_name"] != "configured" ||
+		row["protocol_version"] != "2025-06-18" ||
+		row["configured_evidence"] != "configured" ||
+		row["live_evidence"] != "initialize" {
+		t.Fatalf("mixed owner properties were not preserved: %+v", row)
+	}
+	for _, key := range []string{
+		"server_tokens", "host_tokens", "edge_tokens",
+		"server_fingerprints", "host_fingerprints", "edge_fingerprints",
+	} {
+		if row[key] != int64(3) {
+			t.Fatalf("mixed owner %s = %v, want 3; row=%+v", key, row[key], row)
+		}
+	}
+
+	// A changed existing owner combined with a new owner must still fail closed.
+	changedNodes := append(
+		configNodes(configScope, "changed"),
+		configNodes("config:path:sha256:mixed-owner-second-alias", "changed")...,
+	)
+	changedEdges := []ingest.Edge{
+		configEdge(configScope, "changed"),
+		configEdge("config:path:sha256:mixed-owner-second-alias", "changed"),
+	}
+	writeAndReconcile(
+		changedNodes,
+		changedEdges,
+		"mixed-owner-incompatible",
+		[]string{
+			configScope,
+			"config:path:sha256:mixed-owner-second-alias",
+		},
+	)
+	rows, err = db.Query(ctx, `
+		MATCH (server:MCPServer {objectid: $server})-[r:RUNS_ON]->
+		      (host:Host {objectid: $host})
+		RETURN server.observation_properties_complete AS server_complete,
+		       host.observation_properties_complete AS host_complete,
+		       r.observation_properties_complete AS edge_complete,
+		       server.configured_name AS configured_name,
+		       r.configured_evidence AS configured_evidence`,
+		map[string]any{"server": serverID, "host": hostID})
+	if err != nil {
+		t.Fatalf("query incompatible mixed owners: %v", err)
+	}
+	if len(rows) != 1 ||
+		rows[0]["server_complete"] != false ||
+		rows[0]["host_complete"] != true ||
+		rows[0]["edge_complete"] != false ||
+		rows[0]["configured_name"] != "configured" ||
+		rows[0]["configured_evidence"] != "configured" {
+		t.Fatalf("incompatible mixed owners did not fail closed: %+v", rows)
+	}
+}
+
 func TestIntegrationAuthProvenanceOwnersMergeInEitherOrder(t *testing.T) {
 	ctx := testDriver(t)
 	driver, err := NewDriver(

--- a/server/internal/graph/writer.go
+++ b/server/internal/graph/writer.go
@@ -139,6 +139,10 @@ func (w *Writer) writeNodesBatched(
 					"observation_tokens":            observationTokens(n.ObservationDomains, scanID),
 					"observation_domain_prefixes":   observationDomainPrefixes(n.ObservationDomains),
 					"observation_fact_fingerprints": fingerprints,
+					"observation_owner_fingerprints": observationOwnerFingerprints(
+						n.ObservationDomains,
+						fingerprints,
+					),
 					"observation_fingerprint_domain_prefixes": observationFingerprintDomainPrefixes(n.ObservationDomains),
 					"complete_domain_prefixes":                completePrefixes,
 					"reference_only": n.PropertySemantics ==
@@ -224,7 +228,27 @@ WITH n, node, observation_created,
       AND all(prefix IN node.observation_domain_prefixes WHERE
           any(token IN old_authoritative_tokens WHERE token STARTS WITH prefix))
       AND all(fingerprint IN node.observation_fact_fingerprints WHERE
-          fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner
+          fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner,
+     (NOT observation_created
+      AND NOT node.reference_only
+      AND incoming_complete
+      AND old_properties_complete
+      AND size(old_authoritative_tokens) > 0
+      AND size(node.observation_owner_fingerprints) =
+          size(node.observation_domain_prefixes)
+      AND any(owner IN node.observation_owner_fingerprints WHERE
+          any(token IN old_authoritative_tokens WHERE
+              token STARTS WITH owner.token_prefix))
+      AND any(owner IN node.observation_owner_fingerprints WHERE
+          none(token IN old_authoritative_tokens WHERE
+              token STARTS WITH owner.token_prefix))
+      AND all(owner IN node.observation_owner_fingerprints WHERE
+          none(token IN old_authoritative_tokens WHERE
+              token STARTS WITH owner.token_prefix)
+          OR owner.fact_fingerprint IN old_fact_fingerprints)
+      AND all(key IN keys(node.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR n[key] IS NULL OR n[key] = node.properties[key])) AS compatible_mixed_owners
 FOREACH (_ IN CASE
   WHEN (observation_created AND NOT node.reference_only) OR replace_properties
   THEN [1] ELSE [] END |
@@ -233,7 +257,7 @@ FOREACH (_ IN CASE WHEN observation_created AND node.reference_only THEN [1] ELS
   SET n = {objectid: node.id})
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties AND NOT node.reference_only
-       AND (compatible_new_owner OR compatible_existing_owner)
+       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners)
   THEN [1] ELSE [] END |
   SET n += node.properties)
 SET n.objectid = node.id,
@@ -269,6 +293,11 @@ SET n.objectid = node.id,
           fingerprint IN node.observation_fact_fingerprints |
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
+      WHEN compatible_mixed_owners THEN
+        reduce(fingerprints = old_fact_fingerprints,
+          fingerprint IN node.observation_fact_fingerprints |
+          CASE WHEN fingerprint IN fingerprints
+            THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
       WHEN incoming_complete THEN
         [fingerprint IN old_fact_fingerprints
@@ -284,6 +313,7 @@ SET n.objectid = node.id,
       WHEN replace_properties THEN true
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
+      WHEN compatible_mixed_owners THEN true
       ELSE false
     END`)
 	incomingLabels := make(map[string]bool, len(extraLabels)+1)
@@ -305,7 +335,7 @@ SET n.objectid = node.id,
 	for _, lbl := range extraLabels {
 		fmt.Fprintf(
 			&sb,
-			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner THEN [1] ELSE [] END | SET n:%s)",
+			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners THEN [1] ELSE [] END | SET n:%s)",
 			lbl,
 		)
 	}
@@ -442,12 +472,31 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
       AND all(prefix IN edge.observation_domain_prefixes WHERE
           any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
       AND all(fingerprint IN edge.observation_fact_fingerprints WHERE
-          fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner
+          fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner,
+     (NOT observation_created
+      AND incoming_complete
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND size(edge.observation_owner_fingerprints) =
+          size(edge.observation_domain_prefixes)
+      AND any(owner IN edge.observation_owner_fingerprints WHERE
+          any(token IN old_ownership_tokens WHERE
+              token STARTS WITH owner.token_prefix))
+      AND any(owner IN edge.observation_owner_fingerprints WHERE
+          none(token IN old_ownership_tokens WHERE
+              token STARTS WITH owner.token_prefix))
+      AND all(owner IN edge.observation_owner_fingerprints WHERE
+          none(token IN old_ownership_tokens WHERE
+              token STARTS WITH owner.token_prefix)
+          OR owner.fact_fingerprint IN old_fact_fingerprints)
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS compatible_mixed_owners
 FOREACH (_ IN CASE WHEN NOT observation_created AND replace_properties THEN [1] ELSE [] END |
   SET rel = edge.properties)
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
-       AND (compatible_new_owner OR compatible_existing_owner)
+       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners)
   THEN [1] ELSE [] END |
   SET rel += edge.properties)
 SET rel.observation_properties_complete = CASE
@@ -455,6 +504,7 @@ SET rel.observation_properties_complete = CASE
       WHEN replace_properties THEN true
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
+      WHEN compatible_mixed_owners THEN true
       ELSE false
     END,
     rel.observation_tokens = reduce(tokens = old_tokens, token IN edge.observation_tokens |
@@ -476,6 +526,11 @@ SET rel.observation_properties_complete = CASE
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_new_owner THEN
+        reduce(fingerprints = old_fact_fingerprints,
+          fingerprint IN edge.observation_fact_fingerprints |
+          CASE WHEN fingerprint IN fingerprints
+            THEN fingerprints ELSE fingerprints + fingerprint END)
+      WHEN compatible_mixed_owners THEN
         reduce(fingerprints = old_fact_fingerprints,
           fingerprint IN edge.observation_fact_fingerprints |
           CASE WHEN fingerprint IN fingerprints
@@ -628,12 +683,31 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
       AND all(prefix IN edge.observation_domain_prefixes WHERE
           any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
       AND all(fingerprint IN edge.observation_fact_fingerprints WHERE
-          fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner
+          fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner,
+     (NOT observation_created
+      AND incoming_complete
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND size(edge.observation_owner_fingerprints) =
+          size(edge.observation_domain_prefixes)
+      AND any(owner IN edge.observation_owner_fingerprints WHERE
+          any(token IN old_ownership_tokens WHERE
+              token STARTS WITH owner.token_prefix))
+      AND any(owner IN edge.observation_owner_fingerprints WHERE
+          none(token IN old_ownership_tokens WHERE
+              token STARTS WITH owner.token_prefix))
+      AND all(owner IN edge.observation_owner_fingerprints WHERE
+          none(token IN old_ownership_tokens WHERE
+              token STARTS WITH owner.token_prefix)
+          OR owner.fact_fingerprint IN old_fact_fingerprints)
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS compatible_mixed_owners
 FOREACH (_ IN CASE WHEN observation_created OR replace_properties THEN [1] ELSE [] END |
   SET r = edge.properties)
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
-       AND (compatible_new_owner OR compatible_existing_owner)
+       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners)
   THEN [1] ELSE [] END |
   SET r += edge.properties)
 SET r.scan_id = $scan_id,
@@ -661,6 +735,11 @@ SET r.scan_id = $scan_id,
           fingerprint IN edge.observation_fact_fingerprints |
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
+      WHEN compatible_mixed_owners THEN
+        reduce(fingerprints = old_fact_fingerprints,
+          fingerprint IN edge.observation_fact_fingerprints |
+          CASE WHEN fingerprint IN fingerprints
+            THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
       WHEN incoming_complete THEN
         [fingerprint IN old_fact_fingerprints
@@ -673,6 +752,7 @@ SET r.scan_id = $scan_id,
       WHEN replace_properties THEN true
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
+      WHEN compatible_mixed_owners THEN true
       ELSE false
     END
 REMOVE r.__agenthound_observation_created
@@ -752,6 +832,28 @@ func observationFingerprintDomainPrefixes(domains []string) []string {
 		prefixes[i] = observationFingerprintDomainPrefix(domain)
 	}
 	return prefixes
+}
+
+func observationOwnerFingerprints(
+	domains []string,
+	fingerprints []string,
+) []map[string]any {
+	domains = normalizedDomains(domains)
+	owners := make([]map[string]any, 0, len(domains))
+	for _, domain := range domains {
+		fingerprintPrefix := observationFingerprintDomainPrefix(domain)
+		for _, fingerprint := range fingerprints {
+			if !strings.HasPrefix(fingerprint, fingerprintPrefix) {
+				continue
+			}
+			owners = append(owners, map[string]any{
+				"token_prefix":     observationDomainPrefix(domain),
+				"fact_fingerprint": fingerprint,
+			})
+			break
+		}
+	}
+	return owners
 }
 
 func observationFactFingerprints(domains []string, fact any) ([]string, error) {

--- a/server/internal/graph/writer_prepare.go
+++ b/server/internal/graph/writer_prepare.go
@@ -556,15 +556,19 @@ func observationEdgeRow(
 	properties := factProperties(edge.Properties)
 	tokens, dependencyTokens := edgeObservationTokens(edge, scanID)
 	row := map[string]any{
-		"source":                                  edge.Source,
-		"target":                                  edge.Target,
-		"properties":                              properties,
-		"observation_tokens":                      tokens,
-		"observation_dependency_tokens":           dependencyTokens,
-		"observation_semantics":                   string(edge.ObservationSemantics),
-		"ownership_tokens":                        ownershipTokens(tokens, dependencyTokens),
-		"observation_domain_prefixes":             observationDomainPrefixes(edge.ObservationDomains),
-		"observation_fact_fingerprints":           append([]string{}, fingerprints...),
+		"source":                        edge.Source,
+		"target":                        edge.Target,
+		"properties":                    properties,
+		"observation_tokens":            tokens,
+		"observation_dependency_tokens": dependencyTokens,
+		"observation_semantics":         string(edge.ObservationSemantics),
+		"ownership_tokens":              ownershipTokens(tokens, dependencyTokens),
+		"observation_domain_prefixes":   observationDomainPrefixes(edge.ObservationDomains),
+		"observation_fact_fingerprints": append([]string{}, fingerprints...),
+		"observation_owner_fingerprints": observationOwnerFingerprints(
+			edge.ObservationDomains,
+			fingerprints,
+		),
 		"observation_fingerprint_domain_prefixes": observationFingerprintDomainPrefixes(edge.ObservationDomains),
 		"complete_domain_prefixes":                completePrefixes,
 	}


### PR DESCRIPTION
## Summary

- accept complete writer batches that contain both unchanged existing owners and property-compatible new owners
- preserve the intentional model where config aliases remain distinct owners of one deterministic MCP server
- apply the same compatibility proof to nodes, APOC relationships, and fallback relationships
- add regression coverage for the Config → live MCP → Config-plus-alias transition and for incompatible mixed-owner evidence

## Root cause

Writer preparation correctly fingerprints each owner before collapsing compatible contributions into one graph row. The writer then recognized only all-new, all-existing, or full-replacement owner sets. A row containing one existing config owner and one new alias owner therefore matched no compatibility case when an independent live MCP owner was already present. The write invalidated the refreshed fingerprints and left the shared `MCPServer`, `Host`, and `RUNS_ON` facts incomplete.

## Safety boundary

The new mixed-owner path is accepted only when:

- the prior projection and incoming domains are complete
- the batch contains both an existing and a new owner
- every existing owner presents its exact stored semantic fingerprint
- every incoming property is absent from or equal to the current union, except lifecycle-only fields

Changed existing evidence, missing fingerprints, and genuine property conflicts continue to fail closed. Symlinks are not resolved or deduplicated, and deterministic node IDs are unchanged.

## Validation

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./... -race`
- `make prerelease` — all 13 gates passed
- focused live integration regression on Neo4j 4.4 without APOC
- focused live integration regression on Neo4j 5.26 without APOC
- focused live integration regression on Neo4j 5.26 with APOC

No documentation change is required because this restores the already documented alias/identity contract rather than changing it.