### PR TITLE
Serialize empty coverage children as arrays

### DIFF
--- a/sdk/ingest/metadata.go
+++ b/sdk/ingest/metadata.go
@@ -34,6 +34,14 @@ type CoverageRoot struct {
 	RegistryContract  *RegistryContract `json:"registry_contract,omitempty"`
 }
 
+func (r CoverageRoot) MarshalJSON() ([]byte, error) {
+	type coverageRoot CoverageRoot
+	if r.ChildCoverageKeys == nil {
+		r.ChildCoverageKeys = []string{}
+	}
+	return json.Marshal(coverageRoot(r))
+}
+
 type CollectionOutcome struct {
 	Collector         string       `json:"collector"`
 	CoverageKey       string       `json:"coverage_key,omitempty"`

--- a/sdk/ingest/metadata_test.go
+++ b/sdk/ingest/metadata_test.go
@@ -1,6 +1,24 @@
 package ingest
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCoverageRootMarshalsEmptyChildrenAsArray(t *testing.T) {
+	data, err := json.Marshal(CoverageRoot{CoverageKey: "config:root:sha256:test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(decoded["child_coverage_keys"]); got != "[]" {
+		t.Fatalf("child_coverage_keys = %s, want []", got)
+	}
+}
 
 func TestMergeCollectionReportsPreservesCompleteEmptyState(t *testing.T) {
 	scope := CanonicalCoverageKey("config", "path", "/tmp/missing.json")


### PR DESCRIPTION
## What changed

- Serialize a nil `CoverageRoot.ChildCoverageKeys` as `[]` instead of `null`.
- Add a regression test for the wire contract.

## Why

A successful ingest could return `child_coverage_keys: null`. The Scan Import UI and OpenAPI contract require an array, so the UI reported `Import failed` after the server had already completed and published the scan.

The fix is centralized in `CoverageRoot` JSON serialization, preserving the existing API contract for collector artifacts and server responses without loosening UI validation.

## Validation

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./... -race`