### PR TITLE
Preserve confirmed evidence from partial scans

### DIFF
--- a/collector/cli/remote_ingest.go
+++ b/collector/cli/remote_ingest.go
@@ -162,7 +162,7 @@ func writeRemoteIngestResult(
 	heading := "Ingest complete"
 	if !complete {
 		heading = "Ingest incomplete"
-	} else if ingest.InstructionCoverageLimited(&result.Collection) {
+	} else if remoteResultCoverageLimited(result) {
 		heading = "Ingest complete with coverage limitations"
 	}
 	findings := "unknown"
@@ -183,6 +183,21 @@ func writeRemoteIngestResult(
 		return fmt.Errorf("write ingest result: %w", err)
 	}
 	return nil
+}
+
+func remoteResultCoverageLimited(result *ingest.IngestResult) bool {
+	if result == nil {
+		return false
+	}
+	if ingest.CoverageLimited(&result.Collection) {
+		return true
+	}
+	for _, warning := range result.Warnings {
+		if warning == ingest.CoverageLimitationWarning {
+			return true
+		}
+	}
+	return false
 }
 
 func validateRemoteIngestScanID(result *ingest.IngestResult, expectedScanID string) error {

--- a/collector/cli/remote_ingest_test.go
+++ b/collector/cli/remote_ingest_test.go
@@ -47,6 +47,7 @@ func TestRunScan_RemoteIngestSavesExactArtifactAndPrintsSummary(t *testing.T) {
 				Edges: len(artifact.Graph.Edges),
 			},
 			Findings:          2,
+			Collection:        *artifact.Meta.Collection,
 			PublishedRevision: &revision,
 			Duration:          1500 * time.Millisecond,
 		})

--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -256,6 +256,14 @@ Implementation details:
   re-certified by retrying an older targeted artifact. A complete joint write,
   or an exact remaining-owner write after the other owners retire, replaces the
   fact and restores completeness.
+- A partial refresh from an established owner is a semantic no-op only when all
+  fingerprint-participating values already match and every incoming public
+  label already exists. That path preserves the owner's prior fingerprint and
+  may update only volatile lifecycle fields. A compatible partial addition is
+  retained in the working graph, but the writer removes the owner's prior
+  fingerprint, installs no partial fingerprint, and marks the shared fact
+  incomplete. Publication remains quarantined until a complete joint write
+  covers the full property and label union.
 - Reference-only node observations add ownership without merging managed
   properties or downgrading an existing complete authoritative observation.
   Their owner tokens are tracked as an explicit subset of node owners.
@@ -392,7 +400,8 @@ Dependency validation runs before the first processor executes. If a processor a
 - `NormalizationStatus`, `NormalizationWarnings` -- deterministic
   `complete`/`warning`/`degraded` classification, codes, context, and the
   explicit publication-safety bit
-- `Collection` -- required collection report echoed from the artifact
+- `Collection` -- required finalized, server-scoped collection report copied
+  independently from the mutable submitted artifact
 - `Stages` -- typed required/optional outcomes (`complete`, `partial`,
   `failed`, `truncated`, `unknown`, `not_applicable`)
 - `PostProcessingStats` -- per-processor name, edges created, nodes updated, duration, error

--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -131,11 +131,10 @@ content identity, not source trust.
 Dynamic exhaustive collectors also declare `authoritative_roots`, pairing the
 stable collector-root key with the observed current child-key set. After a
 completed root run, previously headed children absent from that set are
-reconciled as complete-empty and their heads are retired. Recognized
-registry-backed instruction roots also declare the root and complete per-file
-children when the root is partial, failed, or truncated. That limited root may
-advance as posture metadata, but it is excluded from absence reconciliation;
-targeted and other non-exhaustive roots cannot retire sibling scopes.
+reconciled as complete-empty and their heads are retired. Incomplete roots may
+still report confirmed child facts, but neither the root nor an incomplete
+child has absence authority. Targeted and other non-exhaustive roots cannot
+retire sibling scopes.
 
 Root membership is explicit: each child outcome carries
 `parent_coverage_key`, and PostgreSQL retains the mapping. Parentage is never
@@ -213,10 +212,12 @@ Transformations:
 ## Stage 3: Record Scan and Projection Start
 
 Creates or restarts a scan record with status `running` and atomically marks
-the singleton projection state `updating`. Dirty coverage is the sorted union
-of inherited dirty keys and every key attempted by this scan; beginning a
-narrow scan never erases unrelated dirty MCP, A2A, or config scope. In
-production this persistence is required before graph mutation.
+the singleton projection state `updating`. Before Neo4j changes, it marks every
+domain that can mutate a graph fact or perform absence reconciliation dirty.
+Coverage limitations are tracked separately and are not dirty merely because
+collection was incomplete. Beginning a narrow scan never erases unrelated
+dirty MCP, A2A, or config scope. In production this persistence is required
+before graph mutation.
 
 ## Stages 4–6: Freeze and Write (Neo4j Batch)
 
@@ -229,11 +230,13 @@ Implementation details:
 - 1000 operations per transaction (configurable batch size)
 - Multi-label support: nodes carry multiple `kinds` (e.g., `["OllamaInstance", "AIService"]`); the writer MERGEs on the primary label and SETs umbrella labels
 - Merge strategy: `MERGE` by `objectid`. A complete observation replaces
-  properties only when it replaces every active owner of that fact; partial,
-  shared-unreplaced, and unknown observations remain additive/non-destructive.
-  This removes omitted stale managed properties without erasing unrelated
-  owners. Additive updates are marked property-incomplete and block global
-  publication until a complete observation replaces every active owner.
+  properties only when it replaces every active owner of that fact; partial
+  observations are additive and never remove omitted properties, labels,
+  owners, or relationships. This preserves both confirmed positives and prior
+  evidence that the partial scan did not conclusively re-check. A compatible
+  partial observation can remain property-complete; an ownership or semantic
+  conflict is marked property-incomplete and blocks publication until a
+  coherent observation resolves it.
 - New facts carry length-delimited observation owner tokens. Shared facts keep
   one token per active coverage domain. Complete authoritative writes also
   retain an internal stable-domain semantic fingerprint. Collectors and the
@@ -301,17 +304,17 @@ path; they retain the full v5 lifecycle and analysis checks.
 
 `analysis.RunPostProcessors()` computes composite edges and risk scores from graph state.
 
-It runs all 15 processors in dependency-validated order. When any complete raw
-domain was promoted, the pipeline first retires the entire prior composite
-epoch, then rebuilds every derived edge from the retained current raw
-projection. This global replacement is required because a narrow MCP, config,
-or A2A change can invalidate cross-domain evidence whose `source_collector`
-names another detector domain. Blocking unknown, partial, and failed collection
-does not publish. A recognized incomplete instruction root is the narrow
-exception: its complete per-file child domains may drive a limited publication,
-but the root is excluded from absence retirement and comparison. An attempt
-with no promotably complete domain skips derived processing and leaves the epoch
-untouched. See `docs/architecture/post-processors.md`.
+It runs all 15 processors in dependency-validated order. When any raw fact was
+accepted or any complete domain was promoted, the pipeline first retires the
+entire prior composite epoch, then rebuilds every derived edge from the
+retained current raw projection. This global replacement is required because a
+narrow MCP, config, or A2A change can invalidate cross-domain evidence whose
+`source_collector` names another detector domain. A safe partial collection can
+publish its confirmed facts and rebuilt findings, but incomplete domains
+remain non-authoritative for absence and make comparison unavailable. An
+attempt with neither accepted facts nor promoted absence authority skips
+derived processing and leaves the epoch untouched. See
+`docs/architecture/post-processors.md`.
 
 After analysis, the pipeline checks property completeness for public managed
 raw facts. Internal nodes such as `SchemaVersion` and derived relationships are
@@ -322,19 +325,15 @@ finding rows for the scan (including a successful empty retry), advances
 complete coverage heads, finalizes scan state, and optionally inserts a
 persisted export/publication revision. Analysis, stats, or snapshot failure
 withholds publication and leaves the prior published revision available.
-Finalization re-locks cumulative dirty state and publishes only when no inherited
-or current dirty key remains. Epoch-retirement or processor failure can leave
-the mutable Neo4j projection incomplete, but it cannot advance or overwrite the
-previous immutable PostgreSQL publication.
-If PostgreSQL finalization fails after Neo4j reconciliation, every attempted
-reconciliation domain is recorded dirty, including normally non-blocking deep
-instruction domains. A later exact-only scan cannot publish that cross-store
-inconsistency; the corresponding deep scan must reconcile it successfully.
-Limited publication never erases an unseen dirty instruction child: only the
-limited root and complete children actually processed by a successful attempt
-can resolve their dirty keys. Analysis, snapshot, publication, or finalization
-failure resolves none of them. This preserves failure safety while allowing a
-later complete root to recover and restore authoritative comparison.
+Finalization re-locks cumulative dirty state and publishes only when no
+inherited or current dirty mutation domain remains. Epoch-retirement or
+processor failure can leave the mutable Neo4j projection incomplete, but it
+cannot advance or overwrite the previous immutable PostgreSQL publication.
+If PostgreSQL finalization fails after any Neo4j mutation, every mutated or
+reconciled domain remains dirty. A later unrelated scan cannot silently publish
+those changes; the affected domains must complete the graph, analysis,
+snapshot, and PostgreSQL finalization path successfully. Coverage limitation
+rows are updated only in that same successful publication transaction.
 
 Collector-side deep instruction discovery isolates its recursive result behind
 the wall-clock budget. Local filesystem calls are not portably cancelable, so a
@@ -411,17 +410,23 @@ Created --> Running / Projection updating --> Completed + Published
 Terminal statuses:
 - `completed` — complete attributable coverage, graph reconciliation,
   analysis, graph totals, finding snapshot, and publication succeeded.
-- `completed_with_errors` — graph writes completed but coverage or a required
-  later stage was degraded; the previous published posture remains selected.
+- `completed_with_errors` — confirmed facts may have published, but collection
+  coverage remains limited; or a required later stage failed and the previous
+  published posture remains selected. Check `publication_status` and
+  `published_revision` to distinguish those cases.
 - `failed` — a raw graph write failed; actual committed write rows and the
   failed stage are persisted.
 
 The scan row stores summary lifecycle/publication state and frozen totals;
 metadata JSONB stores detailed coverage, rules, identity, normalization
 warnings, observation completeness, stage, count, and reconciliation payloads.
-`coverage_heads` records active raw ownership.
+`coverage_heads` records active raw ownership. `coverage_limitations` records
+the latest published `unknown`, `partial`, `failed`, or `truncated` state for
+each scope. A later published `complete` or `not_applicable` outcome clears that
+scope; an authoritative root also retires stale child limitations.
 `posture_state` separates the current mutable attempt from the selected
 published revision.
 
 `DELETE /api/v1/scans/{id}` is history-only. It never mutates Neo4j and rejects
-pending/running, active coverage-head, and currently published scans.
+pending/running, active coverage-head, active coverage-limitation, and currently
+published scans.

--- a/docs/architecture/post-processors.md
+++ b/docs/architecture/post-processors.md
@@ -464,14 +464,15 @@ cross-service credential chains. Keeping the prior epoch available while
 recomputing would also let downstream processors consume stale `HAS_ACCESS_TO`
 or `CAN_REACH` inputs and incorrectly refresh them into the new epoch.
 
-When no domain is promotably complete (unknown, partial, failed, or
-publication-unsafe coverage), derived processing is skipped and the current
-composite epoch is left untouched. If epoch retirement or any processor fails
-after a complete promotion, analysis is incomplete and publication is
-withheld. The mutable projection may contain an incomplete new epoch, but the
-previously published PostgreSQL revision and its frozen evidence remain
-unchanged. A later complete attempt starts from another empty derived epoch and
-rebuilds it.
+When a partial scan adds or updates a confirmed raw fact, that mutation also
+starts a new derived epoch so analysis reflects the retained graph plus the new
+positive evidence. Omitted partial-scan facts are retained rather than treated
+as absent. When there are neither accepted raw mutations nor promoted complete
+domains, derived processing is skipped and the current composite epoch is left
+untouched. If epoch retirement or any processor fails, analysis is incomplete
+and publication is withheld. The mutable projection may contain an incomplete
+new epoch, but the previously published PostgreSQL revision and its frozen
+evidence remain unchanged.
 
 This invariant requires every composite edge to be produced by the registered
 processor set and every processor to rebuild solely from retained raw facts or
@@ -501,12 +502,15 @@ finalization stores the resulting node/edge snapshots as JSONB with the finding
 row. Finding detail serves that frozen witness graph; it does not re-run
 detector-like `LIMIT 1` queries against the mutable projection.
 
-When all required stages and complete coverage succeed, the same transaction
-inserts an immutable `posture_publications` revision, persists its export, and
-advances `posture_state`. Otherwise the snapshot can remain historical but the
-published pointer does not move. A degraded retry using the currently
-published scan ID preserves the prior published rows and export until a new
-complete revision commits.
+When all required graph, analysis, and snapshot stages succeed, the same
+transaction inserts an immutable `posture_publications` revision, persists its
+export, advances `posture_state`, and records any published collection
+limitations. Collection coverage may remain limited: confirmed findings are
+then current, while missing findings are not an all-clear and comparison is
+disabled. Otherwise the snapshot can remain historical but the published
+pointer does not move. A degraded retry using the currently published scan ID
+preserves the prior published rows and export until a new safe revision
+commits.
 
 ## Integration-test isolation
 

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -97,8 +97,8 @@ explicitly.
 
 Scan deletion is deliberately history-only. It never issues a Neo4j delete or
 interprets last-writer `scan_id` as ownership. The API rejects pending/running
-scans, scans referenced by active coverage heads, and the currently published
-posture revision with `409`.
+scans, scans referenced by active coverage heads or coverage limitations, and
+the currently published posture revision with `409`.
 
 ## Collection provenance and storage pairing
 
@@ -131,29 +131,22 @@ services and edges involving them reconcile under an independent network (or
 artifact-local) variant. Moving between VPNs cannot retire the previous VPN's
 configured-service observations.
 
-## Limited instruction publication
+## Limited-evidence publication
 
-Instruction coverage is measured over AgentHound's registered static sources,
-not every instruction an effective client may load. Each observed registered
-file has a stable owner derived from its exact/deep root and canonical path.
-Registry-contract changes refresh those same owners rather than minting new
-ones.
+AgentHound separates collected facts from coverage. A safe incomplete scan can
+publish confirmed positive facts and findings. Its incomplete scopes have no
+absence authority: they cannot delete unseen prior evidence, create a
+comparison key, or justify an empty-findings all-clear. CLI, API, and UI
+surfaces therefore keep graph/findings access available while warning that
+missing evidence is unknown, not clean. CI `--fail-on` gates fail closed when
+the published scope has an active coverage limitation.
 
-An incomplete recognized exact or deep root is a successful but
-coverage-limited publication when the rest of the pipeline is safe. Complete
-per-file positives remain current and are published additively, including
-poisoning findings. The incomplete root has no absence authority: it cannot
-retire unseen files, create a comparison key, or justify an empty-findings
-all-clear. CLI and UI surfaces therefore keep graph/findings access available
-while warning that missing instruction evidence is unknown, not clean.
-
-Dirty-state safety still fails closed. A limited successful attempt resolves
-only the root and complete children it actually processed; an unseen dirty
-child continues to block publication. Graph, analysis, snapshot, or
-finalization failure resolves no attempted dirty instruction coverage. A later
-complete scan of the same root reuses stable per-file owners, regains
-root-level absence authority, retires sources proven absent, and restores
-normal comparison behavior.
+Dirty-state safety remains separate and fails closed. Every domain that mutates
+Neo4j is marked dirty before the mutation and is cleared only after graph,
+analysis, snapshot, and PostgreSQL publication all succeed. A PostgreSQL
+failure cannot leave Neo4j changes available for an unrelated scan to publish.
+A later complete scan clears the corresponding limitation, regains absence
+authority, and restores comparison behavior.
 
 PostgreSQL and Neo4j carry the same server-generated internal storage-pair UUID,
 so crossed volumes fail closed. Verification remains the first ingest

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -95,12 +95,18 @@ excluded from stats, node lists, and search results.
   "edge_counts": { "TRUSTS_SERVER": 15, "PROVIDES_TOOL": 47, "CAN_REACH": 8 },
   "total_nodes": 85,
   "total_edges": 70,
-  "projection": { "scan_id": "scan-abc123", "revision": 12 }
+  "projection": {
+    "scan_id": "scan-abc123",
+    "revision": 12,
+    "coverage_limited": false,
+    "coverage_limitation_count": 0
+  }
 }
 ```
 
 `projection` is required and identifies the immutable publication represented
-by the counts.
+by the counts. `coverage_limited` qualifies absence-based conclusions, while
+`coverage_limitation_count` reports the number of active limited scopes.
 
 ### `GET /api/v1/graph/search`
 
@@ -132,7 +138,12 @@ Node, edge, and scan lists use typed JSON envelopes. For example:
     "has_more": false,
     "complete": true,
     "revision": "...",
-    "projection": { "scan_id": "scan-abc123", "revision": 12 }
+    "projection": {
+      "scan_id": "scan-abc123",
+      "revision": 12,
+      "coverage_limited": false,
+      "coverage_limitation_count": 0
+    }
   }
 }
 ```
@@ -446,7 +457,12 @@ Use the separate `/analysis/topology/...` operations for undirected topology.
     "algorithm": "bounded-min-weight",
     "complete": true
   },
-  "projection": { "scan_id": "scan-abc123", "revision": 12 }
+  "projection": {
+    "scan_id": "scan-abc123",
+    "revision": 12,
+    "coverage_limited": false,
+    "coverage_limitation_count": 0
+  }
 }
 ```
 
@@ -589,7 +605,12 @@ non-verified findings.
     "evidence_node_ids": ["sha256:agent", "sha256:entry-server", "sha256:entry-tool", "sha256:server", "sha256:credential", "sha256:identity", "sha256:resource-tool", "sha256:resource"],
     "evidence_node_kinds": ["AgentInstance", "MCPServer", "MCPTool", "MCPServer", "Credential", "Identity", "MCPTool", "MCPResource"]
   },
-  "projection": { "scan_id": "scan-...", "revision": 7 }
+  "projection": {
+    "scan_id": "scan-...",
+    "revision": 7,
+    "coverage_limited": false,
+    "coverage_limitation_count": 0
+  }
 }
 ```
 
@@ -639,7 +660,12 @@ Execute a pre-built query and return results.
     "atlas_map": ["AML.T0051", "AML.T0110"]
   },
   "rows": [...],
-  "projection": { "scan_id": "scan-abc123", "revision": 12 }
+  "projection": {
+    "scan_id": "scan-abc123",
+    "revision": 12,
+    "coverage_limited": false,
+    "coverage_limitation_count": 0
+  }
 }
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -397,15 +397,14 @@ authoritative facts. `display` contains optional bounded, non-authoritative
 hostname/OS/architecture labels.
 
 Only explicitly complete, attributable target/config coverage keys can retire
-prior raw observations. Incomplete blocking coverage never retires data or
-replaces the latest published posture. Recognized registry-backed exact and
-deep instruction roots are the narrow non-blocking exception: complete
-per-file children publish additively under stable owners while an incomplete
-root has no absence authority. It cannot retire unseen sources or produce a
-comparison/all-clear claim. Partial, failed, and truncated roots may therefore
-publish observed positives while preserving unseen prior instruction evidence.
-A later complete root reuses those owners and restores normal absence
-reconciliation.
+prior raw observations. Incomplete coverage never retires omitted data. A safe
+partial, failed, truncated, or unknown collection may still publish the facts
+it did confirm; those writes are additive and preserve omitted properties,
+labels, owners, edges, and child scopes. The server persists each incomplete
+scope as an active coverage limitation, disables comparison, and does not
+permit an empty-findings all-clear. A later published `complete` or
+`not_applicable` outcome clears the corresponding limitation and restores
+normal absence reconciliation.
 Lossless normalization coercions are persisted as `warning` and may publish;
 only warnings explicitly marked `publication_unsafe` produce `degraded` and
 withhold publication.
@@ -501,10 +500,13 @@ inline `triage` state.
 | `include_suppressed` | bool | Default `false`. When `true`, include findings triaged `accepted-risk` / `false-positive` (hidden otherwise). |
 The response is `{ "findings": [...], "scope": {...} }`. `scope` carries the
 published scan ID, revision, publication time, projection/snapshot status,
-availability, and staleness. A partial live Neo4j projection does not move the
-published pointer. Clients require explicit available/complete/non-stale
-metadata before interpreting an empty findings array as a current all-clear.
-A failed refresh may show cached rows only when labelled as cached.
+availability, staleness, and `active_coverage_limitations`. A partial live
+Neo4j projection does not move the published pointer. Clients require explicit
+available/complete/non-stale metadata and `coverage_limited: false` before
+interpreting an empty findings array as a current all-clear. The boolean also
+covers an outdated registered instruction-source contract; the limitations
+array carries generic incomplete-scope details. A failed refresh may show
+cached rows only when labelled as cached.
 
 Each finding carries `owasp_map` and `atlas_map` arrays. Detections without a
 confident ATLAS mapping return `atlas_map: []`. `variant`, typed `evidence`,
@@ -679,30 +681,33 @@ The Origin gate protects against browser drive-by Cypher injection from a hostil
 Returns the mutable projection state separately from the latest published
 revision. When an ingest is updating or incomplete, `scan_id` identifies that
 attempt while `published_scan_id` / `published_revision` continue to identify
-the last complete snapshot. `active_coverage_roots` reports each current exact
-or deep instruction root by hashed coverage key, mode, state, owning scan,
-observation time, and registry contract. An old, truncated, or otherwise
-incomplete exact or deep contract is a coverage limitation rather than a clean
-absence. Positive findings and graph facts remain usable; consumers must not
-interpret an empty finding set as an all-clear while any active published root
-is incomplete or uses an older registry contract.
+the last safe snapshot. `active_coverage_roots` reports each current exact or
+deep instruction root by hashed coverage key, mode, state, owning scan,
+observation time, and registry contract.
+`active_coverage_limitations` reports every latest published `unknown`,
+`partial`, `failed`, or `truncated` collection scope with its optional parent,
+owning scan, and observation time. Positive findings and graph facts remain
+usable; consumers must not interpret an empty finding set as an all-clear while
+that list is non-empty or an active instruction root uses an older registry
+contract.
 
 ### `GET /api/v1/posture/export`
 
 Returns one persisted publication revision. The export is assembled inside the
 same PostgreSQL transaction that replaces the scan's finding snapshot and
-advances publication. Export schema version 3 adds typed
-`scope.active_coverage_roots`, so external clients can distinguish usable
-limited publications from complete registered-source coverage. The endpoint
-serves only schema version 3; unsupported persisted schemas fail closed rather
-than returning a response outside the OpenAPI contract. It includes
+advances publication. Export schema version 4 adds typed
+`scope.active_coverage_limitations`, while schema version 3 introduced
+`scope.active_coverage_roots`. The endpoint serves persisted schema versions 3
+and 4; unsupported schemas fail closed rather than returning a response outside
+the OpenAPI contract. It includes
 exact scope, stage/coverage completeness,
 normalization warnings, managed-observation completeness, observation and
 publication timestamps, suppression policy, frozen public graph totals,
-comparison metadata, rules provenance, active coverage-root state, and all findings with the triage state
-observed at publication. `scope.dirty_coverage` is always an explicit empty
-array for a published revision; `scope.active_coverage_keys` lists all active
-coverage heads. `completeness.observation_details` reports property-incomplete
+comparison metadata, rules provenance, active coverage-root/limitation state,
+and all findings with the triage state observed at publication.
+`scope.dirty_coverage` is always an explicit empty array for a published
+revision; `scope.active_coverage_keys` lists all active coverage heads.
+`completeness.observation_details` reports property-incomplete
 public managed node/raw-relationship counts plus public tokenless-node and raw
 relationship-incident-to-tokenless-node counts. Any non-zero count withholds
 publication.
@@ -725,8 +730,8 @@ Scan records serialize `model.Scan` verbatim. The `status` field is one of:
 |--------|---------|
 | `pending` | Registered but not yet started. |
 | `running` | Ingest in progress. |
-| `completed` | Required collection, graph, analysis, stats, snapshot, and publication stages succeeded. |
-| `completed_with_errors` | Graph writes completed, but blocking coverage or a required later stage was incomplete/failed; the prior published posture remains available. Recognized limited instruction-root publication remains `completed`. |
+| `completed` | Complete collection plus required graph, analysis, stats, snapshot, and publication stages succeeded. |
+| `completed_with_errors` | Either a safe limited-coverage revision published, or a required later stage failed and the prior published posture remains available. Check `publication_status` / `published_revision`. |
 | `failed` | A graph write failed. `write_rows` preserves rows committed before failure. |
 
 Additive lifecycle fields expose `collection_status`, `graph_status`,
@@ -742,8 +747,9 @@ totals, not write counts. Deltas are
 comparable only when a non-empty `comparison_key` matches. The key includes
 canonical target/config coverage, rules and identity semantics, plus each
 active root's registry contract/state and the revisions of every other active
-coverage head. Outdated or incomplete roots make comparison unavailable. The server records
-`comparable_to_scan_id` only in that case.
+coverage head. Any active coverage limitation or outdated/incomplete
+instruction root makes comparison unavailable. The server records
+`comparable_to_scan_id` only for matching non-empty comparison keys.
 
 Collector artifacts and the server use ingest v5 in lockstep. Version mismatch
 returns `UNSUPPORTED_INGEST_VERSION`; instruction-registry mismatch returns
@@ -773,9 +779,9 @@ page.
 
 Delete PostgreSQL history only; this endpoint never mutates Neo4j or infers
 ownership from scalar `scan_id`. It returns `409 SCAN_DELETE_CONFLICT` for
-pending/running scans, active coverage heads, and the currently published
-scan. Historical finding rows cascade with the scan; cross-scan triage state
-remains.
+pending/running scans, active coverage heads, active coverage limitations, and
+the currently published scan. Historical finding rows cascade with the scan;
+cross-scan triage state remains.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -379,6 +379,12 @@ credential material.
 `meta.collection` is required on every ingest request, and `collection` is
 required on every successful ingest result. A missing collection report is a
 validation error, not an implicit complete scan.
+The response contains the finalized server-scoped coverage keys, outcomes, and
+authoritative roots after identity scoping—not the producer-local key space.
+The receipt owns an independent copy of that report. Coverage warnings qualify
+both a limited current artifact and any unrelated coverage limitation that
+remains active after publication; a clean artifact clears the warning only
+when no active limitation remains.
 Nodes may set `property_semantics: "reference_only"` only with an empty
 `properties` object. This records ID/kind ownership without authoring or
 replacing managed properties; omitted `property_semantics` is authoritative.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -307,10 +307,9 @@ collector returned an error; the saved artifact is then identified as
 diagnostic evidence and no ingest instruction is printed. Output, argument,
 and remote-ingest failures retain their existing non-zero behavior.
 
-Recognized incomplete instruction roots are the non-blocking exception
-described above: their proven per-file positives may publish, so their warning
-does not claim that ingestion will be withheld. Other blocking incomplete
-coverage may cause ingestion to withhold graph publication. Review
+When the server can safely process an incomplete artifact, it publishes the
+confirmed facts additively and persists the incomplete scopes as coverage
+limitations. Omitted data is retained rather than treated as absent. Review
 `meta.collection.outcomes`, correct or recollect the failed coverage, and do
 not treat missing facts as evidence of absence. With `--ingest`, the warning is
 printed after the backup artifact is saved and before the explicitly requested
@@ -835,13 +834,12 @@ All three ingest entry points (CLI, `POST /api/v1/ingest`, UI drag-drop) run the
 The CLI prints the display label (or a short `Point <digest>` alias), full IDs,
 new/recognized state, separate point/network qualities, network class, pipeline
 outcome, projection status, and publication revision. It exits successfully
-only when the ingest produced a complete,
-published projection. A published projection with an incomplete recognized
-instruction root is headed `Ingest complete with coverage limitations` and
-reports the generalized instruction-coverage warning. If a required stage is
-partial or failed, or publication is withheld for any blocking reason, the CLI
-exits non-zero and reports the first unhealthy required stage; write-row counts
-remain visible for diagnosis.
+when the graph, analysis, snapshot, and publication stages succeed, including a
+safe limited-coverage publication. That case is headed
+`Ingest complete with coverage limitations` and reports that missing evidence
+is not proof of absence. If a required processing stage is partial or failed,
+or publication is withheld, the CLI exits non-zero and reports the first
+unhealthy required stage; write-row counts remain visible for diagnosis.
 
 #### Example
 
@@ -890,18 +888,28 @@ agenthound-server query --shortest-path --path-mode topology --from MCPResource:
 | `--to` | | Target node (`Kind:name`). |
 | `--path-mode` | `security` | `security` uses the directed security relationship policy; `topology` explicitly selects the undirected graph view. |
 | `--format` | `table` | `table` or `json`. |
-| `--fail-on` | | Exit 1 if findings at or above severity (CI gate). Always ignores suppressed findings, even with `--all-findings`. |
+| `--fail-on` | | Exit 1 if findings are at or above severity or published coverage is limited (CI gate). Always ignores suppressed findings, even with `--all-findings`. |
 
 Positional raw Cypher is an explicit live/admin interface: it reads the mutable
 graph directly and is not guarded by published scan/revision identity. In
 contrast, `--prebuilt` fails closed when the published projection is absent,
-updating, incomplete, or changes during the read. JSON output includes a
-`projection` object with `scan_id` and `revision`; table output prints the same
-identity before the rows.
+updating, incomplete, or changes during the read. Prebuilt queries,
+shortest-path output, and published findings warn when the selected revision
+has active coverage limitations. An empty findings result is qualified as “No
+findings in observed data.” `--diff` rejects revisions without matching
+non-empty comparison keys, and `--fail-on` exits non-zero when published
+coverage is limited. Raw administrator Cypher remains an explicit unqualified
+live-graph interface. JSON output includes the corresponding scope/projection
+metadata; table output prints the published identity before the rows.
 
 #### Suppression semantics
 
-Triage decisions (`accepted-risk`, `false-positive`) suppress a finding from the default `--findings` view and from the `added` set of `--diff`. `--all-findings` reveals them. `--fail-on` *always* evaluates against the non-suppressed set, so an accepted risk can never break CI regardless of `--all-findings`.
+Triage decisions (`accepted-risk`, `false-positive`) suppress a finding from
+the default `--findings` view and from the `added` set of `--diff`.
+`--all-findings` reveals them. `--fail-on` always evaluates against the
+non-suppressed set, so an accepted risk cannot break CI regardless of
+`--all-findings`; an active coverage limitation still fails the gate because
+missing findings are inconclusive.
 
 #### Pre-Built Query IDs
 

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -388,6 +388,16 @@ incoming owner's prior fingerprint so an older retry also remains incomplete.
 Completeness and replacement resume only after all active owners are observed
 together, or after retirement leaves an exact remaining-owner refresh able to
 replace the fact.
+When an established owner reports partial evidence while another owner remains,
+a semantic no-op subset—identical fingerprint-participating values and no new
+public labels—preserves the prior fingerprint and property completeness.
+Volatile lifecycle fields may still advance. If that partial owner instead adds
+a compatible property or public label, the writer retains the addition in the
+working graph but removes that owner's prior fingerprint and marks the shared
+fact property-incomplete. It never installs the partial fingerprint. The dirty
+working graph therefore cannot become the published projection until a joint
+complete refresh covers the full union; a later complete retry of only the
+smaller partial shape cannot certify retained values it omitted.
 Relationships marked `all_dependencies` instead carry one indivisible owner
 group for each logical `(source, edge kind, target)` fact. A complete incoming
 group atomically supersedes the prior dependency tokens, fingerprints, and

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -335,8 +335,10 @@ The writer derives internal `observation_tokens` from the validated
 `observation_domains` field and current scan ID. Complete-scope reconciliation
 retires only old tokens for that exact target/config key. A shared node or raw
 relationship remains while any owner token survives. Unknown, partial, failed,
-and truncated coverage is non-destructive. Coverage root and child keys use the
-same applicable identity scope. Each child outcome serializes its
+and truncated coverage is non-destructive: supplied facts are retained, while
+omitted properties, labels, owners, edges, and child scopes are not removed.
+Coverage root and child keys use the same applicable identity scope. Each child
+outcome serializes its
 `parent_coverage_key`; PostgreSQL records that membership explicitly.
 Lifecycle code never reconstructs parentage by parsing an opaque key, so one
 vantage cannot retire another vantage's evidence.
@@ -357,13 +359,12 @@ the static config collector does not infer them.
 
 Registered instruction files use stable per-file owners derived from the
 stable exact/deep root key and canonical path; the registry contract is not
-part of the owner key. A recognized incomplete instruction root may publish
-complete child facts additively, but only a complete root has absence authority
-over its current child set. Limited roots perform no unseen-child retirement,
-produce no comparison key, and cannot support an all-clear. A later complete
-root refreshes the same owners and can retire children it authoritatively
-proves absent. This is registered-source coverage only; it does not claim which
-effective client loads a file.
+part of the owner key. This is one instance of the general rule: incomplete
+collection may publish confirmed child facts additively, but only a complete
+root has absence authority over its current child set. Limited roots perform no
+unseen-child retirement, produce no comparison key, and cannot support an
+all-clear. A later complete root refreshes the same owners and can retire
+children it authoritatively proves absent.
 
 A complete exact re-observation replaces stale managed properties. Observation
 completeness considers only public collector-produced nodes and managed raw
@@ -415,17 +416,16 @@ another active owner is not present, the writer remains additive and marks the
 fact property-incomplete; publication stays withheld until all active owners
 are re-observed together.
 
-Composite edges are epoch-recomputed separately. When at least one complete raw
-domain is promoted, the server retires the entire derived epoch and rebuilds
-all processors from retained current raw facts in dependency order. Global
-replacement prevents a narrow-domain change from preserving cross-domain
-evidence merely because its `source_collector` names another detector.
-Blocking unknown, partial, and failed collection cannot publish. When no
-domain is promotably complete, derived processing is skipped and the epoch is
-untouched. The narrow exception is a recognized incomplete instruction root
-with complete per-file children: those children are promotable and may drive a
-limited publication, while the root remains non-authoritative for absence and
-retirement.
+Composite edges are epoch-recomputed separately. When at least one raw fact is
+accepted or a complete domain is promoted, the server retires the entire
+derived epoch and rebuilds all processors from retained current raw facts in
+dependency order. Global replacement prevents a narrow-domain change from
+preserving cross-domain evidence merely because its `source_collector` names
+another detector. Safe unknown, partial, failed, or truncated collection may
+publish confirmed facts and a rebuilt composite epoch. Its incomplete scopes
+remain non-authoritative for absence and are persisted as coverage
+limitations. When there are neither accepted raw mutations nor promotable
+complete domains, derived processing is skipped and the epoch is untouched.
 
 ---
 
@@ -592,10 +592,9 @@ epoch. All `is_composite=true` relationships are retired before every
 registered processor recomputes from the retained raw projection. This covers
 transitive, cross-protocol, credential-chain, and other multi-domain evidence
 without relying on the single-valued `source_collector` provenance field.
-Attempts with no promotably complete domain perform no epoch retirement;
-partial and failed blocking collection never publishes. A recognized limited
-instruction root can publish only because its complete per-file domains are
-promotable; its incomplete root is never used for absence retirement or
+Attempts with neither an accepted raw mutation nor a promotably complete domain
+perform no epoch retirement. Safe partial attempts can publish confirmed
+facts, but their incomplete scopes are never used for absence retirement or
 comparison.
 
 ### Neo4j Version Compatibility

--- a/sdk/ingest/observation.go
+++ b/sdk/ingest/observation.go
@@ -242,7 +242,26 @@ func NonBlockingInstructionCoverageDomains(report *CollectionReport) []string {
 	return result
 }
 
-const InstructionCoverageLimitationWarning = "instruction coverage is limited; missing instruction evidence is not a clean absence"
+const CoverageLimitationWarning = "coverage is limited; missing evidence is not proof of absence"
+
+// InstructionCoverageLimitationWarning remains as a compatibility alias for
+// callers that used the original instruction-only limited-publication path.
+const InstructionCoverageLimitationWarning = CoverageLimitationWarning
+
+// CoverageLimited reports whether any declared scope lacks absence authority.
+// An all-not-applicable optional surface aggregates to complete because the
+// collector conclusively established that none of those operations applied.
+func CoverageLimited(report *CollectionReport) bool {
+	if report == nil || len(report.CoverageKeys) == 0 {
+		return true
+	}
+	for _, state := range CoverageStates(report) {
+		if state != OutcomeComplete {
+			return true
+		}
+	}
+	return false
+}
 
 // IncompleteInstructionRoots returns recognized registry-backed instruction
 // roots whose observed state is partial, failed, or truncated.

--- a/sdk/ingest/observation_test.go
+++ b/sdk/ingest/observation_test.go
@@ -117,6 +117,41 @@ func TestCoverageStatesUsesTargetScopedOutcomeKey(t *testing.T) {
 	}
 }
 
+func TestCoverageLimitedSeparatesUnknownFromNotApplicable(t *testing.T) {
+	scope := CanonicalCoverageKey("a2a", "target", "https://agent.example")
+	for _, test := range []struct {
+		name  string
+		state OutcomeState
+		want  bool
+	}{
+		{name: "complete", state: OutcomeComplete, want: false},
+		{name: "not applicable", state: OutcomeNotApplicable, want: false},
+		{name: "partial", state: OutcomePartial, want: true},
+		{name: "failed", state: OutcomeFailed, want: true},
+		{name: "truncated", state: OutcomeTruncated, want: true},
+		{name: "unknown", state: OutcomeUnknown, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			report := &CollectionReport{
+				State:        AggregateOutcomeState([]CollectionOutcome{{State: test.state}}),
+				CoverageKeys: []string{scope},
+				Outcomes: []CollectionOutcome{{
+					Collector: "a2a", CoverageKey: scope, State: test.state,
+				}},
+			}
+			if got := CoverageLimited(report); got != test.want {
+				t.Fatalf("CoverageLimited(%s) = %t, want %t", test.state, got, test.want)
+			}
+		})
+	}
+	if !CoverageLimited(nil) {
+		t.Fatal("missing collection report was treated as complete coverage")
+	}
+	if !CoverageLimited(&CollectionReport{}) {
+		t.Fatal("zero declared scopes were treated as complete coverage")
+	}
+}
+
 func TestCompleteAuthoritativeRootsRequiresCompleteRootAndChildren(t *testing.T) {
 	root := CanonicalCoverageKey("mcp", "root", "collect")
 	child := CanonicalCoverageKey("mcp", "target", "server-a")

--- a/server/cli/ingest.go
+++ b/server/cli/ingest.go
@@ -107,7 +107,7 @@ func writeIngestResult(w io.Writer, result *ingest.IngestResult) error {
 	complete := result.Outcome == ingest.OutcomeComplete &&
 		result.ProjectionStatus == model.ProjectionComplete &&
 		result.PublishedRevision != nil
-	limitedCoverage := complete && ingest.InstructionCoverageLimited(&result.Collection)
+	limitedCoverage := complete && resultCoverageLimited(result)
 	heading := "Ingest incomplete"
 	if result.Outcome == ingest.OutcomeFailed {
 		heading = "Ingest failed"
@@ -175,6 +175,21 @@ func writeIngestResult(w io.Writer, result *ingest.IngestResult) error {
 		result.ProjectionStatus,
 		detail,
 	)
+}
+
+func resultCoverageLimited(result *ingest.IngestResult) bool {
+	if result == nil {
+		return false
+	}
+	if ingest.CoverageLimited(&result.Collection) {
+		return true
+	}
+	for _, warning := range result.Warnings {
+		if warning == ingest.CoverageLimitationWarning {
+			return true
+		}
+	}
+	return false
 }
 
 func collectionPointDisplay(identity ingest.IngestIdentityResult) string {

--- a/server/cli/ingest_test.go
+++ b/server/cli/ingest_test.go
@@ -67,6 +67,16 @@ func TestWriteIngestResultComplete(t *testing.T) {
 		PublishedRevision: &revision,
 		WriteRows:         ingest.FactCounts{Nodes: 3, Edges: 2},
 		Duration:          1500 * time.Millisecond,
+		Collection: ingest.CollectionReport{
+			State:        ingest.OutcomeComplete,
+			CoverageKeys: []string{"config:path:sha256:" + strings.Repeat("c", 64)},
+			Outcomes: []ingest.CollectionOutcome{{
+				Collector:   "config",
+				CoverageKey: "config:path:sha256:" + strings.Repeat("c", 64),
+				Method:      "config_discovery",
+				State:       ingest.OutcomeComplete,
+			}},
+		},
 		Identity: ingest.IngestIdentityResult{
 			CollectionPointID: "sha256:" + strings.Repeat("a", 64),
 			NetworkContextID:  "sha256:" + strings.Repeat("b", 64),
@@ -180,11 +190,11 @@ func TestWriteIngestResultPublishedIncompleteExactCoverageRemainsSuccessful(t *t
 			t.Fatalf("output missing %q:\n%s", want, output.String())
 		}
 	}
-	if strings.Contains(ingest.InstructionCoverageLimitationWarning, "deep") ||
-		!strings.Contains(ingest.InstructionCoverageLimitationWarning, "not a clean absence") {
+	if strings.Contains(ingest.CoverageLimitationWarning, "instruction") ||
+		!strings.Contains(ingest.CoverageLimitationWarning, "not proof of absence") {
 		t.Fatalf(
-			"warning is not generalized to incomplete instruction coverage: %q",
-			ingest.InstructionCoverageLimitationWarning,
+			"warning is not generalized to incomplete collection coverage: %q",
+			ingest.CoverageLimitationWarning,
 		)
 	}
 }

--- a/server/cli/query.go
+++ b/server/cli/query.go
@@ -206,6 +206,7 @@ func printPrebuiltResult(result prebuiltExecution, format string) error {
 		result.Projection.ScanID,
 		result.Projection.Revision,
 	)
+	printProjectionCoverageWarning(result.Projection)
 	if result.Metadata != nil {
 		_, _ = fmt.Fprintf(
 			os.Stderr,
@@ -291,6 +292,13 @@ func runFindings(ctx context.Context, severity, format, failOn string, includeSu
 		)
 		return fmt.Errorf("%d finding(s) at severity %q or above", failureCount, failOn)
 	}
+	if failOn != "" && findingScopeCoverageLimited(scope) {
+		_, _ = fmt.Fprintln(
+			os.Stderr,
+			"Failed: published coverage is limited; missing findings cannot satisfy a security gate",
+		)
+		return fmt.Errorf("published coverage is limited")
+	}
 
 	return nil
 }
@@ -347,8 +355,18 @@ func printPublishedFindings(
 		scope.ScanID,
 		*scope.Revision,
 	)
+	if findingScopeCoverageLimited(scope) {
+		_, _ = fmt.Fprintln(
+			os.Stderr,
+			"Warning: published coverage is limited; missing evidence is not proof of absence.",
+		)
+	}
 	if len(findings) == 0 {
-		fmt.Println("No findings found.")
+		if findingScopeCoverageLimited(scope) {
+			fmt.Println("No findings in observed data; coverage is limited.")
+		} else {
+			fmt.Println("No findings found.")
+		}
 		return nil
 	}
 
@@ -396,27 +414,63 @@ func runShortestPath(ctx context.Context, from, to, scopeValue, format string) e
 	}
 	defer cleanup()
 
-	result, err := findShortestPath(
+	execution, identity, err := projection.GuardedRead(
 		ctx,
-		infra.GraphDB,
-		fromKind,
-		fromName,
-		toKind,
-		toName,
-		scope,
+		infra.FindingStore,
+		func() (analysis.TraversalResult, error) {
+			return findShortestPath(
+				ctx,
+				infra.GraphDB,
+				fromKind,
+				fromName,
+				toKind,
+				toName,
+				scope,
+			)
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("shortest path: %w", err)
 	}
 
-	if len(result.Paths) == 0 {
+	if format == "json" {
+		return printJSON(struct {
+			Paths      []analysis.TraversalPath   `json:"paths"`
+			Metadata   analysis.TraversalMetadata `json:"metadata"`
+			Projection projection.Identity        `json:"projection"`
+		}{
+			Paths:      execution.Paths,
+			Metadata:   execution.Metadata,
+			Projection: identity,
+		})
+	}
+	_, _ = fmt.Fprintf(
+		os.Stderr,
+		"Published projection: scan=%s revision=%d\n",
+		identity.ScanID,
+		identity.Revision,
+	)
+	printProjectionCoverageWarning(identity)
+	if len(execution.Paths) == 0 {
 		fmt.Printf("No path found from %s:%s to %s:%s\n", fromKind, fromName, toKind, toName)
 		return nil
 	}
-	if format == "json" {
-		return printJSON(result)
+	return printRows(traversalPathRows(execution), format)
+}
+
+func findingScopeCoverageLimited(scope appdb.FindingScope) bool {
+	return scope.CoverageLimited || len(scope.ActiveCoverageLimitations) > 0
+}
+
+func printProjectionCoverageWarning(identity projection.Identity) {
+	if !identity.CoverageLimited {
+		return
 	}
-	return printRows(traversalPathRows(result), format)
+	_, _ = fmt.Fprintf(
+		os.Stderr,
+		"Warning: coverage is limited in %d scope(s); missing evidence is not proof of absence.\n",
+		identity.CoverageLimitationCount,
+	)
 }
 
 func findShortestPath(

--- a/server/cli/query_helpers_test.go
+++ b/server/cli/query_helpers_test.go
@@ -328,6 +328,37 @@ func TestPrintPublishedFindingsCurrentEmptyIncludesProjectionIdentity(t *testing
 	}
 }
 
+func TestPrintPublishedFindingsQualifiesLimitedEmptyResult(t *testing.T) {
+	revision := int64(7)
+	scope := appdb.FindingScope{
+		Mode:             "published",
+		ScanID:           "scan-7",
+		Revision:         &revision,
+		ProjectionStatus: model.ProjectionComplete,
+		SnapshotStatus:   model.LifecycleComplete,
+		Available:        true,
+		ActiveCoverageLimitations: []model.PostureCoverageLimitation{{
+			CoverageKey: "mcp:target:sha256:limited",
+			State:       "partial",
+			ScanID:      "scan-7",
+		}},
+	}
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			if err := printPublishedFindings(nil, scope, "table"); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+	if !strings.Contains(stderr, "missing evidence is not proof of absence") {
+		t.Fatalf("stderr missing coverage warning: %q", stderr)
+	}
+	if !strings.Contains(stdout, "No findings in observed data; coverage is limited.") {
+		t.Fatalf("stdout contains unqualified empty result: %q", stdout)
+	}
+}
+
 func TestPrintPublishedFindingsJSONIncludesProjectionIdentity(t *testing.T) {
 	revision := int64(7)
 	scope := appdb.FindingScope{
@@ -529,6 +560,43 @@ func TestExecutePrebuiltQueryAndOutputIncludeProjectionIdentity(t *testing.T) {
 	})
 	if !strings.Contains(tableStderr, "scan=scan-7 revision=7") {
 		t.Fatalf("table output missing projection identity: %q", tableStderr)
+	}
+}
+
+func TestPrebuiltOutputWarnsForLimitedPublishedProjection(t *testing.T) {
+	query, ok := prebuilt.Get("no-auth-servers")
+	if !ok {
+		t.Fatal("no-auth-servers query missing")
+	}
+	state := completeCLIProjection("scan-limited", 8)
+	state.ActiveCoverageLimitations = []model.PostureCoverageLimitation{{
+		CoverageKey: "mcp:target:sha256:limited",
+		State:       "partial",
+		ScanID:      "scan-limited",
+	}}
+	result, err := executePrebuiltQuery(
+		context.Background(),
+		query.ID,
+		query,
+		&graph.MockGraphDB{},
+		&fakeCLIProjectionReader{states: []*model.ProjectionState{state}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Projection.CoverageLimited ||
+		result.Projection.CoverageLimitationCount != 1 {
+		t.Fatalf("projection limitation = %+v", result.Projection)
+	}
+	stderr := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := printPrebuiltResult(result, "table"); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+	if !strings.Contains(stderr, "missing evidence is not proof of absence") {
+		t.Fatalf("stderr missing coverage warning: %q", stderr)
 	}
 }
 

--- a/server/internal/api/handlers/docs_test.go
+++ b/server/internal/api/handlers/docs_test.go
@@ -37,7 +37,15 @@ func TestOpenAPIProjectionAwareResponseContracts(t *testing.T) {
 	}
 
 	schemas := nestedMap(t, spec, "components", "schemas")
-	requireSchemaFields(t, schemas, "ProjectionIdentity", "scan_id", "revision")
+	requireSchemaFields(
+		t,
+		schemas,
+		"ProjectionIdentity",
+		"scan_id",
+		"revision",
+		"coverage_limited",
+		"coverage_limitation_count",
+	)
 	requireSchemaFields(
 		t,
 		schemas,

--- a/server/internal/api/handlers/docs_test.go
+++ b/server/internal/api/handlers/docs_test.go
@@ -241,6 +241,13 @@ func TestServedOpenAPICampaignParity(t *testing.T) {
 	requireSchemaFields(
 		t,
 		schemas,
+		"FindingScope",
+		"coverage_limited",
+		"active_coverage_limitations",
+	)
+	requireSchemaFields(
+		t,
+		schemas,
 		"PostureCoverageRoot",
 		"coverage_key",
 		"mode",
@@ -257,6 +264,7 @@ func TestServedOpenAPICampaignParity(t *testing.T) {
 		"scan_id",
 		"revision",
 		"active_coverage_roots",
+		"active_coverage_limitations",
 		"projection_state",
 	)
 	postureExportProperties := nestedMap(
@@ -270,8 +278,8 @@ func TestServedOpenAPICampaignParity(t *testing.T) {
 	}
 	schemaVersion := nestedMap(t, postureExportProperties, "schema_version")
 	versionEnum, ok := schemaVersion["enum"].([]any)
-	if !ok || !containsInt(versionEnum, 3) {
-		t.Fatalf("PostureExport.schema_version enum = %v, want 3", schemaVersion["enum"])
+	if !ok || !containsInt(versionEnum, 3) || !containsInt(versionEnum, 4) {
+		t.Fatalf("PostureExport.schema_version enum = %v, want 3 and 4", schemaVersion["enum"])
 	}
 
 	evidenceProperties := nestedMap(t, schemas, "FindingEvidence", "properties")

--- a/server/internal/api/handlers/graph_test.go
+++ b/server/internal/api/handlers/graph_test.go
@@ -143,10 +143,16 @@ func TestGraphStatsReturnsStableProjectionIdentity(t *testing.T) {
 		EdgeCounts: map[string]int64{},
 		TotalNodes: 1,
 	}}
+	state := completeProjectionState("scan-7", 7)
+	state.ActiveCoverageLimitations = []model.PostureCoverageLimitation{{
+		CoverageKey: "mcp:target:sha256:limited",
+		State:       ingest.OutcomePartial,
+		ScanID:      "scan-7",
+	}}
 	h := &GraphHandler{
 		reader: reader,
 		projectionReader: &fakeProjectionStateReader{
-			states: []*model.ProjectionState{completeProjectionState("scan-7", 7)},
+			states: []*model.ProjectionState{state},
 		},
 	}
 	rec := httptest.NewRecorder()
@@ -163,7 +169,12 @@ func TestGraphStatsReturnsStableProjectionIdentity(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
 		t.Fatal(err)
 	}
-	if response.Projection != (projectionIdentity{ScanID: "scan-7", Revision: 7}) {
+	if response.Projection != (projectionIdentity{
+		ScanID:                  "scan-7",
+		Revision:                7,
+		CoverageLimited:         true,
+		CoverageLimitationCount: 1,
+	}) {
 		t.Fatalf("projection = %+v", response.Projection)
 	}
 }

--- a/server/internal/api/handlers/openapi.yaml
+++ b/server/internal/api/handlers/openapi.yaml
@@ -885,7 +885,7 @@ components:
       type: object
       additionalProperties: false
       required:
-        [mode, scan_id, revision, published_at, projection_status, snapshot_status, available, stale]
+        [mode, scan_id, revision, published_at, projection_status, snapshot_status, available, stale, coverage_limited, active_coverage_limitations]
       properties:
         mode:
           type: string
@@ -908,6 +908,12 @@ components:
           type: boolean
         stale:
           type: boolean
+        coverage_limited:
+          type: boolean
+        active_coverage_limitations:
+          type: array
+          items:
+            $ref: "#/components/schemas/PostureCoverageLimitation"
 
     FindingsResponse:
       type: object
@@ -1465,7 +1471,7 @@ components:
     ProjectionState:
       type: object
       additionalProperties: false
-      required: [status, dirty_coverage, active_coverage_roots, updated_at]
+      required: [status, dirty_coverage, active_coverage_roots, active_coverage_limitations, updated_at]
       properties:
         status:
           type: string
@@ -1482,6 +1488,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PostureCoverageRoot"
+        active_coverage_limitations:
+          type: array
+          items:
+            $ref: "#/components/schemas/PostureCoverageLimitation"
         updated_at:
           type: string
           format: date-time
@@ -1526,6 +1536,31 @@ components:
         contract_current:
           type: boolean
 
+    PostureCoverageLimitation:
+      type: object
+      additionalProperties: false
+      required:
+        - coverage_key
+        - state
+        - scan_id
+        - observed_at
+      properties:
+        coverage_key:
+          type: string
+          minLength: 1
+        parent_coverage_key:
+          type: string
+          minLength: 1
+        state:
+          type: string
+          enum: [unknown, partial, failed, truncated]
+        scan_id:
+          type: string
+          minLength: 1
+        observed_at:
+          type: string
+          format: date-time
+
     PostureScope:
       type: object
       additionalProperties: false
@@ -1535,6 +1570,7 @@ components:
         - coverage_keys
         - active_coverage_keys
         - active_coverage_roots
+        - active_coverage_limitations
         - dirty_coverage
         - projection_state
       properties:
@@ -1557,6 +1593,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PostureCoverageRoot"
+        active_coverage_limitations:
+          type: array
+          items:
+            $ref: "#/components/schemas/PostureCoverageLimitation"
         dirty_coverage:
           type: array
           items:
@@ -1585,7 +1625,7 @@ components:
       properties:
         schema_version:
           type: integer
-          enum: [3]
+          enum: [3, 4]
         scope:
           $ref: "#/components/schemas/PostureScope"
         completeness:

--- a/server/internal/api/handlers/openapi.yaml
+++ b/server/internal/api/handlers/openapi.yaml
@@ -129,7 +129,8 @@ components:
     ProjectionIdentity:
       type: object
       additionalProperties: false
-      required: [scan_id, revision]
+      required:
+        [scan_id, revision, coverage_limited, coverage_limitation_count]
       properties:
         scan_id:
           type: string
@@ -138,6 +139,11 @@ components:
           type: integer
           format: int64
           minimum: 1
+        coverage_limited:
+          type: boolean
+        coverage_limitation_count:
+          type: integer
+          minimum: 0
 
     Node:
       type: object

--- a/server/internal/api/handlers/posture.go
+++ b/server/internal/api/handlers/posture.go
@@ -53,17 +53,22 @@ func (h *PostureHandler) HandleExport(w http.ResponseWriter, r *http.Request) {
 		WriteNotFound(w, "no posture revision has been published")
 		return
 	}
-	if export.SchemaVersion != model.PostureExportSchemaVersion {
+	if export.SchemaVersion != model.PostureExportSchemaVersion &&
+		export.SchemaVersion != model.PostureExportPreviousSchemaVersion {
 		WriteInternalError(
 			w,
 			r,
 			fmt.Errorf(
-				"published posture export schema %d is unsupported; expected %d",
+				"published posture export schema %d is unsupported; expected %d or %d",
 				export.SchemaVersion,
 				model.PostureExportSchemaVersion,
+				model.PostureExportPreviousSchemaVersion,
 			),
 		)
 		return
+	}
+	if export.Scope.ActiveCoverageLimitations == nil {
+		export.Scope.ActiveCoverageLimitations = []model.PostureCoverageLimitation{}
 	}
 	w.Header().Set("Content-Disposition", `attachment; filename="agenthound-posture.json"`)
 	WriteJSON(w, http.StatusOK, export)

--- a/server/internal/api/handlers/posture_test.go
+++ b/server/internal/api/handlers/posture_test.go
@@ -54,8 +54,39 @@ func TestPostureExportServesPersistedRevision(t *testing.T) {
 	if export.Scope.ActiveCoverageRoots == nil {
 		t.Fatal("current export emitted null active_coverage_roots")
 	}
+	if export.Scope.ActiveCoverageLimitations == nil {
+		t.Fatal("current export emitted null active_coverage_limitations")
+	}
 	if got := w.Header().Get("Content-Disposition"); got == "" {
 		t.Fatal("missing download content disposition")
+	}
+}
+
+func TestPostureExportServesPreviousPersistedSchema(t *testing.T) {
+	handler := &PostureHandler{store: &fakePostureReader{
+		export: &model.PostureExport{
+			SchemaVersion: model.PostureExportPreviousSchemaVersion,
+			Scope: model.PostureScope{
+				ScanID:   "scan-v3",
+				Revision: 3,
+			},
+		},
+	}}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/posture/export", nil)
+
+	handler.HandleExport(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var export model.PostureExport
+	if err := json.NewDecoder(w.Body).Decode(&export); err != nil {
+		t.Fatal(err)
+	}
+	if export.SchemaVersion != model.PostureExportPreviousSchemaVersion ||
+		export.Scope.ActiveCoverageLimitations == nil {
+		t.Fatalf("normalized previous export = %+v", export)
 	}
 }
 

--- a/server/internal/appdb/coverage_limitations.go
+++ b/server/internal/appdb/coverage_limitations.go
@@ -1,0 +1,136 @@
+package appdb
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	sdkingest "github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/adithyan-ak/agenthound/server/model"
+	"github.com/jackc/pgx/v5"
+)
+
+func updateCoverageLimitationsTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	scan model.Scan,
+	report *sdkingest.CollectionReport,
+	authoritativeRoots []sdkingest.CoverageRoot,
+) error {
+	if report == nil {
+		return nil
+	}
+
+	observedAt := time.Now().UTC()
+	if scan.ArtifactObservedAt != nil {
+		observedAt = scan.ArtifactObservedAt.UTC()
+	}
+	states := sdkingest.CoverageStates(report)
+	parents := sdkingest.CoverageParents(report)
+	keys := make([]string, 0, len(states))
+	for key := range states {
+		if key = strings.TrimSpace(key); key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		state := states[key]
+		switch state {
+		case sdkingest.OutcomeComplete, sdkingest.OutcomeNotApplicable:
+			if _, err := tx.Exec(ctx,
+				`DELETE FROM coverage_limitations WHERE coverage_key = $1`,
+				key,
+			); err != nil {
+				return fmt.Errorf("clear coverage limitation %s: %w", key, err)
+			}
+		case sdkingest.OutcomeUnknown, sdkingest.OutcomePartial,
+			sdkingest.OutcomeFailed, sdkingest.OutcomeTruncated:
+			if _, err := tx.Exec(ctx, `INSERT INTO coverage_limitations
+				    (coverage_key, parent_coverage_key, state, scan_id, observed_at)
+				VALUES ($1, NULLIF($2, ''), $3, $4, $5)
+				ON CONFLICT (coverage_key) DO UPDATE SET
+				    parent_coverage_key = EXCLUDED.parent_coverage_key,
+				    state = EXCLUDED.state,
+				    scan_id = EXCLUDED.scan_id,
+				    observed_at = EXCLUDED.observed_at`,
+				key,
+				parents[key],
+				state,
+				scan.ID,
+				observedAt,
+			); err != nil {
+				return fmt.Errorf("record coverage limitation %s: %w", key, err)
+			}
+		}
+	}
+
+	for _, root := range authoritativeRoots {
+		rootKey := strings.TrimSpace(root.CoverageKey)
+		if rootKey == "" {
+			continue
+		}
+		activeChildren := normalizeCoverageKeys(root.ChildCoverageKeys)
+		if len(activeChildren) == 0 {
+			if _, err := tx.Exec(ctx,
+				`DELETE FROM coverage_limitations WHERE parent_coverage_key = $1`,
+				rootKey,
+			); err != nil {
+				return fmt.Errorf("retire coverage limitations under %s: %w", rootKey, err)
+			}
+			continue
+		}
+		if _, err := tx.Exec(ctx, `DELETE FROM coverage_limitations
+			WHERE parent_coverage_key = $1
+			  AND NOT (coverage_key = ANY($2::text[]))`,
+			rootKey,
+			activeChildren,
+		); err != nil {
+			return fmt.Errorf("retire coverage limitations under %s: %w", rootKey, err)
+		}
+	}
+	return nil
+}
+
+type coverageLimitationQuerier interface {
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+}
+
+func listActiveCoverageLimitations(
+	ctx context.Context,
+	querier coverageLimitationQuerier,
+) ([]model.PostureCoverageLimitation, error) {
+	rows, err := querier.Query(ctx, `SELECT
+	    coverage_key,
+	    coalesce(parent_coverage_key, ''),
+	    state,
+	    scan_id,
+	    observed_at
+	FROM coverage_limitations
+	ORDER BY coverage_key`)
+	if err != nil {
+		return nil, fmt.Errorf("read active coverage limitations: %w", err)
+	}
+	defer rows.Close()
+
+	limitations := make([]model.PostureCoverageLimitation, 0)
+	for rows.Next() {
+		var limitation model.PostureCoverageLimitation
+		if err := rows.Scan(
+			&limitation.CoverageKey,
+			&limitation.ParentCoverageKey,
+			&limitation.State,
+			&limitation.ScanID,
+			&limitation.ObservedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan active coverage limitation: %w", err)
+		}
+		limitations = append(limitations, limitation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read active coverage limitations: %w", err)
+	}
+	return limitations, nil
+}

--- a/server/internal/appdb/coverage_state.go
+++ b/server/internal/appdb/coverage_state.go
@@ -184,3 +184,12 @@ func activePostureCoverageRoots(heads []coverageHead) []model.PostureCoverageRoo
 	})
 	return roots
 }
+
+func postureCoverageRootsLimited(roots []model.PostureCoverageRoot) bool {
+	for _, root := range roots {
+		if root.State != sdkingest.OutcomeComplete || !root.ContractCurrent {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/appdb/coverage_state_test.go
+++ b/server/internal/appdb/coverage_state_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	sdkingest "github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/adithyan-ak/agenthound/server/model"
 )
 
 func finalizeCoverageAttempt(
@@ -368,5 +369,20 @@ func TestActivePostureCoverageRootsExposeCurrentRootState(t *testing.T) {
 		!roots[0].RegistryContract.Equal(contract) ||
 		!roots[0].ContractCurrent {
 		t.Fatalf("active root status = %+v", roots[0])
+	}
+}
+
+func TestPostureCoverageRootsLimitedIncludesOutdatedContract(t *testing.T) {
+	if !postureCoverageRootsLimited([]model.PostureCoverageRoot{{
+		State:           sdkingest.OutcomeComplete,
+		ContractCurrent: false,
+	}}) {
+		t.Fatal("outdated registered-source contract was treated as complete coverage")
+	}
+	if postureCoverageRootsLimited([]model.PostureCoverageRoot{{
+		State:           sdkingest.OutcomeComplete,
+		ContractCurrent: true,
+	}}) {
+		t.Fatal("current complete registered-source contract was treated as limited")
 	}
 }

--- a/server/internal/appdb/findings_store.go
+++ b/server/internal/appdb/findings_store.go
@@ -40,14 +40,16 @@ type FindingsDiff struct {
 }
 
 type FindingScope struct {
-	Mode             string     `json:"mode"`
-	ScanID           string     `json:"scan_id"`
-	Revision         *int64     `json:"revision"`
-	PublishedAt      *time.Time `json:"published_at"`
-	ProjectionStatus string     `json:"projection_status"`
-	SnapshotStatus   string     `json:"snapshot_status"`
-	Available        bool       `json:"available"`
-	Stale            bool       `json:"stale"`
+	Mode                      string                            `json:"mode"`
+	ScanID                    string                            `json:"scan_id"`
+	Revision                  *int64                            `json:"revision"`
+	PublishedAt               *time.Time                        `json:"published_at"`
+	ProjectionStatus          string                            `json:"projection_status"`
+	SnapshotStatus            string                            `json:"snapshot_status"`
+	Available                 bool                              `json:"available"`
+	Stale                     bool                              `json:"stale"`
+	CoverageLimited           bool                              `json:"coverage_limited"`
+	ActiveCoverageLimitations []model.PostureCoverageLimitation `json:"active_coverage_limitations"`
 }
 
 func replaceFindingsTx(ctx context.Context, tx pgx.Tx, scanID string, findings []model.Finding) error {
@@ -121,17 +123,26 @@ const findingSelectColumns = `f.scan_id, f.captured_at, f.fingerprint, f.severit
 // callers can keep the prior rows while clearly marking them stale.
 func (s *FindingStore) PublishedFindingScope(ctx context.Context) (FindingScope, error) {
 	scope := FindingScope{
-		Mode:             "published",
-		ProjectionStatus: model.ProjectionUnknown,
-		SnapshotStatus:   model.LifecycleUnknown,
+		Mode:                      "published",
+		ProjectionStatus:          model.ProjectionUnknown,
+		SnapshotStatus:            model.LifecycleUnknown,
+		ActiveCoverageLimitations: []model.PostureCoverageLimitation{},
 	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		return FindingScope{}, fmt.Errorf("begin published finding scope read: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
 	var (
 		scanID           *string
 		revision         *int64
 		publishedAt      *time.Time
 		projectionScanID *string
 	)
-	err := s.pool.QueryRow(ctx, `SELECT
+	err = tx.QueryRow(ctx, `SELECT
 	    ps.published_scan_id,
 	    ps.published_revision,
 	    ps.published_at,
@@ -152,6 +163,9 @@ func (s *FindingStore) PublishedFindingScope(ctx context.Context) (FindingScope,
 		return FindingScope{}, fmt.Errorf("published finding scope: %w", err)
 	}
 	if scanID == nil || revision == nil {
+		if err := tx.Commit(ctx); err != nil {
+			return FindingScope{}, fmt.Errorf("commit published finding scope read: %w", err)
+		}
 		return scope, nil
 	}
 	scope.ScanID = *scanID
@@ -161,6 +175,19 @@ func (s *FindingStore) PublishedFindingScope(ctx context.Context) (FindingScope,
 	scope.Stale = scope.ProjectionStatus != model.ProjectionComplete ||
 		projectionScanID == nil ||
 		*projectionScanID != scope.ScanID
+	scope.ActiveCoverageLimitations, err = listActiveCoverageLimitations(ctx, tx)
+	if err != nil {
+		return FindingScope{}, err
+	}
+	heads, err := activeCoverageHeads(ctx, tx)
+	if err != nil {
+		return FindingScope{}, err
+	}
+	scope.CoverageLimited = len(scope.ActiveCoverageLimitations) > 0 ||
+		postureCoverageRootsLimited(activePostureCoverageRoots(heads))
+	if err := tx.Commit(ctx); err != nil {
+		return FindingScope{}, fmt.Errorf("commit published finding scope read: %w", err)
+	}
 	return scope, nil
 }
 
@@ -252,6 +279,35 @@ func (s *FindingStore) findingsForScan(ctx context.Context, scanID string) ([]mo
 // both. When includeSuppressed is false, suppressed findings are dropped
 // from the added set so CI-style diffs don't re-alert on accepted risks.
 func (s *FindingStore) Diff(ctx context.Context, scanA, scanB string, includeSuppressed bool) (*FindingsDiff, error) {
+	var comparisonKeyA, comparisonKeyB *string
+	if err := s.pool.QueryRow(ctx,
+		`SELECT comparison_key FROM scans WHERE id = $1`,
+		scanA,
+	).Scan(&comparisonKeyA); err != nil {
+		return nil, fmt.Errorf("read comparison scope for scan %s: %w", scanA, err)
+	}
+	if err := s.pool.QueryRow(ctx,
+		`SELECT comparison_key FROM scans WHERE id = $1`,
+		scanB,
+	).Scan(&comparisonKeyB); err != nil {
+		return nil, fmt.Errorf("read comparison scope for scan %s: %w", scanB, err)
+	}
+	if comparisonKeyA == nil || comparisonKeyB == nil ||
+		*comparisonKeyA == "" || *comparisonKeyB == "" {
+		return nil, fmt.Errorf(
+			"scans %s and %s are not comparable because at least one has no authoritative comparison key",
+			scanA,
+			scanB,
+		)
+	}
+	if *comparisonKeyA != *comparisonKeyB {
+		return nil, fmt.Errorf(
+			"scans %s and %s are not comparable because their comparison scopes differ",
+			scanA,
+			scanB,
+		)
+	}
+
 	a, err := s.findingsForScan(ctx, scanA)
 	if err != nil {
 		return nil, err

--- a/server/internal/appdb/findings_store_test.go
+++ b/server/internal/appdb/findings_store_test.go
@@ -3,6 +3,7 @@ package appdb
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,6 +74,7 @@ func TestIntegrationFindingStore(t *testing.T) {
 	// fingerprints up front. finding_triage has no FK, so it survives scan
 	// deletion and must be cleared explicitly.
 	cleanup := func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM coverage_limitations WHERE scan_id LIKE 'fs-test-%'")
 		_, _ = pool.Exec(ctx, "DELETE FROM scans WHERE id LIKE 'fs-test-%'")
 		_, _ = pool.Exec(ctx, "DELETE FROM finding_triage WHERE fingerprint = ANY($1)", []string{fpA, fpB, fpD})
 	}
@@ -93,6 +95,13 @@ func TestIntegrationFindingStore(t *testing.T) {
 	}
 	mustScan(scanID)
 	mustScan(scanID2)
+	if _, err := pool.Exec(ctx,
+		`UPDATE scans SET comparison_key = $1 WHERE id = ANY($2::text[])`,
+		"sha256:fs-test-scope",
+		[]string{scanID, scanID2},
+	); err != nil {
+		t.Fatalf("set comparable finding scopes: %v", err)
+	}
 	replaceFindings := func(id string, snapshot []model.Finding) {
 		t.Helper()
 		tx, err := pool.Begin(ctx)
@@ -256,6 +265,23 @@ func TestIntegrationFindingStore(t *testing.T) {
 			SourceKind: "MCPTool", TargetKind: "MCPTool", Confidence: 0.7},
 	}
 	replaceFindings(scanID2, findings2)
+	if _, err := pool.Exec(ctx,
+		`UPDATE scans SET comparison_key = NULL WHERE id = $1`,
+		scanID2,
+	); err != nil {
+		t.Fatalf("clear comparison scope: %v", err)
+	}
+	if _, err := fs.Diff(ctx, scanID, scanID2, false); err == nil ||
+		!strings.Contains(err.Error(), "no authoritative comparison key") {
+		t.Fatalf("limited-scope diff error = %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE scans SET comparison_key = $1 WHERE id = $2`,
+		"sha256:fs-test-scope",
+		scanID2,
+	); err != nil {
+		t.Fatalf("restore comparison scope: %v", err)
+	}
 	diff, err := fs.Diff(ctx, scanID, scanID2, false)
 	if err != nil {
 		t.Fatalf("Diff: %v", err)

--- a/server/internal/appdb/integration_test.go
+++ b/server/internal/appdb/integration_test.go
@@ -87,6 +87,7 @@ func TestIntegrationMigrations(t *testing.T) {
 	}
 	wantTables := []string{
 		"coverage_heads",
+		"coverage_limitations",
 		"coverage_memberships",
 		"finding_triage",
 		"findings",
@@ -117,7 +118,7 @@ func TestIntegrationMigrations(t *testing.T) {
 	if err := versionRows.Err(); err != nil {
 		t.Fatalf("list migration versions: %v", err)
 	}
-	if want := []int{1, 2, 3, 4}; !reflect.DeepEqual(versions, want) {
+	if want := []int{1, 2, 3, 4, 5}; !reflect.DeepEqual(versions, want) {
 		t.Fatalf("migration versions = %v, want %v", versions, want)
 	}
 
@@ -129,6 +130,47 @@ func TestIntegrationMigrations(t *testing.T) {
 	}
 	if postureRows != 1 {
 		t.Fatalf("posture singleton rows = %d, want 1", postureRows)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		DROP TABLE coverage_limitations;
+		DELETE FROM schema_migrations WHERE version = 5;
+		INSERT INTO scans (id, collector) VALUES ('limited-v4-publication', 'config');
+		INSERT INTO coverage_heads
+		    (
+		        coverage_key, scan_id, state, discovery_mode,
+		        contract_generation, contract_digest
+		    )
+		VALUES
+		    (
+		        'config:instruction-root:sha256:legacy',
+		        'limited-v4-publication',
+		        'partial',
+		        'deep',
+		        1,
+		        'sha256:legacy'
+		    )`); err != nil {
+		t.Fatalf("prepare coverage-limitation upgrade: %v", err)
+	}
+	if err := RunMigrations(ctx, pool); err != nil {
+		t.Fatalf("reapply coverage-limitation migration: %v", err)
+	}
+	var (
+		backfilledState  string
+		backfilledScanID string
+	)
+	if err := pool.QueryRow(ctx, `SELECT state, scan_id
+		FROM coverage_limitations
+		WHERE coverage_key = 'config:instruction-root:sha256:legacy'`).
+		Scan(&backfilledState, &backfilledScanID); err != nil {
+		t.Fatalf("read backfilled coverage limitation: %v", err)
+	}
+	if backfilledState != "partial" || backfilledScanID != "limited-v4-publication" {
+		t.Fatalf(
+			"backfilled limitation = state %q scan %q",
+			backfilledState,
+			backfilledScanID,
+		)
 	}
 }
 

--- a/server/internal/appdb/migrate_test.go
+++ b/server/internal/appdb/migrate_test.go
@@ -22,6 +22,7 @@ func TestMigrationsContainCurrentSchemaAndBindingUpgrade(t *testing.T) {
 		"002_storage_binding.sql",
 		"003_zero_config_storage_binding.sql",
 		"004_coverage_root_state.sql",
+		"005_coverage_limitations.sql",
 	}; !reflect.DeepEqual(names, want) {
 		t.Fatalf("migration files = %v, want %v", names, want)
 	}
@@ -110,6 +111,24 @@ func TestMigrationsContainCurrentSchemaAndBindingUpgrade(t *testing.T) {
 	} {
 		if !strings.Contains(rootStateSQL, expected) {
 			t.Errorf("coverage-root migration missing %q", expected)
+		}
+	}
+
+	data, err = migrationFS.ReadFile("migrations/005_coverage_limitations.sql")
+	if err != nil {
+		t.Fatalf("read coverage-limitations migration: %v", err)
+	}
+	limitationsSQL := string(data)
+	for _, expected := range []string{
+		"CREATE TABLE IF NOT EXISTS coverage_limitations",
+		"parent_coverage_key",
+		"'unknown', 'partial', 'failed', 'truncated'",
+		"REFERENCES scans(id) ON DELETE RESTRICT",
+		"INSERT INTO coverage_limitations",
+		"FROM coverage_heads",
+	} {
+		if !strings.Contains(limitationsSQL, expected) {
+			t.Errorf("coverage-limitations migration missing %q", expected)
 		}
 	}
 }

--- a/server/internal/appdb/migrations/005_coverage_limitations.sql
+++ b/server/internal/appdb/migrations/005_coverage_limitations.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS coverage_limitations (
+    coverage_key        TEXT PRIMARY KEY,
+    parent_coverage_key TEXT,
+    state               TEXT NOT NULL
+                        CHECK (state IN ('unknown', 'partial', 'failed', 'truncated')),
+    scan_id             TEXT NOT NULL REFERENCES scans(id) ON DELETE RESTRICT,
+    observed_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_coverage_limitations_scan_id
+    ON coverage_limitations(scan_id);
+
+CREATE INDEX IF NOT EXISTS idx_coverage_limitations_parent
+    ON coverage_limitations(parent_coverage_key);
+
+-- Before generic limited-evidence publication, only registered instruction
+-- roots could publish with incomplete coverage. Preserve those active warnings
+-- across upgrade so an existing limited posture cannot become a false all-clear.
+INSERT INTO coverage_limitations
+    (coverage_key, parent_coverage_key, state, scan_id, observed_at)
+SELECT coverage_key, NULL, state, scan_id, updated_at
+FROM coverage_heads
+WHERE root_key IS NULL
+  AND state IN ('partial', 'failed', 'truncated')
+ON CONFLICT (coverage_key) DO NOTHING;

--- a/server/internal/appdb/publication_store.go
+++ b/server/internal/appdb/publication_store.go
@@ -37,12 +37,13 @@ type FinalizeScanParams struct {
 }
 
 type PublicationResult struct {
-	Revision           *int64
-	PublishedAt        *time.Time
-	ComparableToScanID string
-	Export             *model.PostureExport
-	Published          bool
-	DirtyCoverage      []string
+	Revision                  *int64
+	PublishedAt               *time.Time
+	ComparableToScanID        string
+	Export                    *model.PostureExport
+	Published                 bool
+	DirtyCoverage             []string
+	ActiveCoverageLimitations []model.PostureCoverageLimitation
 }
 
 // FinalizeScan atomically replaces the per-scan finding snapshot, advances
@@ -194,9 +195,31 @@ func (s *FindingStore) FinalizeScan(
 	comparison := model.PostureComparison{}
 	activeCoverageKeys := normalizeCoverageKeys(params.CoverageKeys)
 	activeCoverageRoots := []model.PostureCoverageRoot{}
+	activeCoverageLimitations := []model.PostureCoverageLimitation{}
 	activeHeads, err := activeCoverageHeadsTx(ctx, tx)
 	if err != nil {
 		return nil, err
+	}
+	if params.Publish {
+		if err := updateCoverageLimitationsTx(
+			ctx,
+			tx,
+			params.Scan,
+			params.Collection,
+			params.AuthoritativeRoots,
+		); err != nil {
+			return nil, err
+		}
+		activeCoverageLimitations, err = listActiveCoverageLimitations(
+			ctx,
+			tx,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(activeCoverageLimitations) > 0 {
+			params.Scan.ComparisonKey = ""
+		}
 	}
 	params.Scan.ComparisonKey = comparisonKeyWithCoverageHeads(
 		params.Scan.ComparisonKey,
@@ -260,6 +283,7 @@ func (s *FindingStore) FinalizeScan(
 			comparison,
 			activeCoverageKeys,
 			activeCoverageRoots,
+			activeCoverageLimitations,
 		)
 		exportJSON, err := json.Marshal(export)
 		if err != nil {
@@ -274,6 +298,10 @@ func (s *FindingStore) FinalizeScan(
 		result.Revision = &revision
 		result.PublishedAt = &publishedAt
 		result.Export = &export
+		result.ActiveCoverageLimitations = append(
+			[]model.PostureCoverageLimitation(nil),
+			activeCoverageLimitations...,
+		)
 	}
 
 	if err := finalizeScanRow(ctx, tx, params, result, preservePublishedSnapshot); err != nil {
@@ -714,6 +742,7 @@ func buildPostureExport(
 	comparison model.PostureComparison,
 	activeCoverageKeys []string,
 	activeCoverageRoots []model.PostureCoverageRoot,
+	activeCoverageLimitations []model.PostureCoverageLimitation,
 ) model.PostureExport {
 	completedAt := publishedAt
 	if params.Scan.CompletedAt != nil {
@@ -766,6 +795,10 @@ func buildPostureExport(
 			ActiveCoverageRoots: append(
 				[]model.PostureCoverageRoot{},
 				activeCoverageRoots...,
+			),
+			ActiveCoverageLimitations: append(
+				[]model.PostureCoverageLimitation{},
+				activeCoverageLimitations...,
 			),
 			DirtyCoverage:   []string{},
 			ComparisonKey:   params.Scan.ComparisonKey,
@@ -838,6 +871,14 @@ func (s *FindingStore) GetPublishedExport(ctx context.Context) (*model.PostureEx
 }
 
 func (s *FindingStore) GetProjectionState(ctx context.Context) (*model.ProjectionState, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("begin projection state read: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
 	var (
 		state         model.ProjectionState
 		dirtyJSON     []byte
@@ -845,7 +886,7 @@ func (s *FindingStore) GetProjectionState(ctx context.Context) (*model.Projectio
 		projectionErr *string
 		publishedID   *string
 	)
-	err := s.pool.QueryRow(ctx, `SELECT
+	err = tx.QueryRow(ctx, `SELECT
 	    projection_status, projection_scan_id, projection_error,
 	    dirty_coverage, projection_updated_at,
 	    published_scan_id, published_revision, published_at
@@ -877,10 +918,17 @@ func (s *FindingStore) GetProjectionState(ctx context.Context) (*model.Projectio
 	if state.DirtyCoverage == nil {
 		state.DirtyCoverage = []string{}
 	}
-	heads, err := activeCoverageHeads(ctx, s.pool)
+	heads, err := activeCoverageHeads(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 	state.ActiveCoverageRoots = activePostureCoverageRoots(heads)
+	state.ActiveCoverageLimitations, err = listActiveCoverageLimitations(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit projection state read: %w", err)
+	}
 	return &state, nil
 }

--- a/server/internal/appdb/publication_store_test.go
+++ b/server/internal/appdb/publication_store_test.go
@@ -2,6 +2,7 @@ package appdb
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -34,11 +35,13 @@ func TestIntegrationPublicationLifecycle(t *testing.T) {
 	comparableID := prefix + "-comparable"
 	headID := prefix + "-head"
 	pendingID := prefix + "-pending"
+	limitationID := prefix + "-limitation"
 	cleanup := func() {
 		_, _ = pool.Exec(ctx, `UPDATE posture_state SET
 		    published_revision = NULL, published_scan_id = NULL, published_at = NULL,
 		    dirty_coverage = '[]'::jsonb, projection_error = NULL
 		    WHERE singleton = TRUE`)
+		_, _ = pool.Exec(ctx, `DELETE FROM coverage_limitations WHERE scan_id LIKE $1`, prefix+"%")
 		_, _ = pool.Exec(ctx, `DELETE FROM coverage_heads WHERE scan_id LIKE $1`, prefix+"%")
 		_, _ = pool.Exec(ctx, `DELETE FROM scans WHERE id LIKE $1`, prefix+"%")
 	}
@@ -261,6 +264,64 @@ func TestIntegrationPublicationLifecycle(t *testing.T) {
 		t.Fatalf("prior publication status = %q, want superseded", priorScan.PublicationStatus)
 	}
 
+	mustCreateScan(limitationID, model.ScanStatusRunning)
+	limitedScope := sdkingest.CanonicalCoverageKey(
+		"mcp",
+		"target",
+		"https://limited.example",
+	)
+	limitedReport := &sdkingest.CollectionReport{
+		State:        sdkingest.OutcomePartial,
+		CoverageKeys: []string{limitedScope},
+		Outcomes: []sdkingest.CollectionOutcome{{
+			Collector:   "mcp",
+			CoverageKey: limitedScope,
+			Method:      "enumerate",
+			State:       sdkingest.OutcomePartial,
+		}},
+	}
+	limitedScan := model.Scan{
+		ID:                 limitationID,
+		Collector:          "mcp",
+		Status:             model.ScanStatusCompletedWithErrors,
+		StartedAt:          started,
+		CompletedAt:        &completed,
+		ArtifactObservedAt: &observed,
+		CollectionStatus:   model.LifecyclePartial,
+		GraphStatus:        model.LifecycleComplete,
+		AnalysisStatus:     model.LifecycleComplete,
+		SnapshotStatus:     model.LifecycleComplete,
+		ProjectionStatus:   model.ProjectionComplete,
+		ComparisonKey:      "sha256:limited",
+	}
+	limitedResult, err := findings.FinalizeScan(ctx, FinalizeScanParams{
+		Scan:         limitedScan,
+		Collection:   limitedReport,
+		CoverageKeys: limitedReport.CoverageKeys,
+		GraphAfter:   graphAfter,
+		Publish:      true,
+	})
+	if err != nil {
+		t.Fatalf("finalize limited publication: %v", err)
+	}
+	if len(limitedResult.ActiveCoverageLimitations) != 1 {
+		t.Fatalf("limited publication = %+v", limitedResult)
+	}
+	limitedFindingScope, err := findings.PublishedFindingScope(ctx)
+	if err != nil {
+		t.Fatalf("read limited finding scope: %v", err)
+	}
+	if !limitedFindingScope.CoverageLimited ||
+		len(limitedFindingScope.ActiveCoverageLimitations) != 1 ||
+		limitedFindingScope.ActiveCoverageLimitations[0].CoverageKey != limitedScope {
+		t.Fatalf("limited finding scope = %+v", limitedFindingScope)
+	}
+	var deleteConflict *ScanDeleteConflictError
+	if err := scans.DeleteScan(ctx, limitationID); !errors.As(err, &deleteConflict) ||
+		!strings.Contains(deleteConflict.Reason, "coverage limitation") {
+		t.Fatalf("delete active limitation owner error = %v", err)
+	}
+
 	mustCreateScan(headID, model.ScanStatusCompleted)
 	if _, err := pool.Exec(ctx, `INSERT INTO coverage_heads (coverage_key, scan_id)
 		VALUES ('config', $1) ON CONFLICT (coverage_key) DO UPDATE SET scan_id = EXCLUDED.scan_id`,
@@ -333,6 +394,7 @@ func TestIntegrationAuthoritativeRootRetiresRemovedChildHeadAndDirtyKey(t *testi
 			`DELETE FROM coverage_heads WHERE coverage_key = ANY($1::text[])`,
 			[]string{root, childA, childB, childC, childD},
 		)
+		_, _ = pool.Exec(ctx, `DELETE FROM coverage_limitations WHERE scan_id LIKE $1`, prefix+"%")
 		_, _ = pool.Exec(ctx, `DELETE FROM scans WHERE id LIKE $1`, prefix+"%")
 	}
 	cleanup()
@@ -730,7 +792,15 @@ func TestIntegrationIncompleteInstructionRootPreservesChildrenUntilComplete(t *t
 	firstID := "instruction-root-first"
 	finalize(firstID, sdkingest.OutcomeComplete, true, currentChild, priorSibling)
 	partialID := "instruction-root-partial"
-	finalize(partialID, sdkingest.OutcomePartial, false, currentChild)
+	partialResult := finalize(partialID, sdkingest.OutcomePartial, false, currentChild)
+	if partialResult.Revision == nil ||
+		len(partialResult.ActiveCoverageLimitations) != 1 ||
+		partialResult.ActiveCoverageLimitations[0].CoverageKey != root ||
+		partialResult.ActiveCoverageLimitations[0].State != sdkingest.OutcomePartial ||
+		partialResult.Export == nil ||
+		len(partialResult.Export.Scope.ActiveCoverageLimitations) != 1 {
+		t.Fatalf("partial coverage publication = %+v", partialResult)
+	}
 
 	var (
 		rootState     sdkingest.OutcomeState
@@ -782,6 +852,46 @@ func TestIntegrationIncompleteInstructionRootPreservesChildrenUntilComplete(t *t
 		)
 	}
 
+	unrelatedID := "instruction-root-unrelated"
+	unrelatedScope := sdkingest.CanonicalCoverageKey(
+		"mcp",
+		"target",
+		"https://unrelated.example",
+	)
+	createRunning(unrelatedID)
+	unrelatedReport := &sdkingest.CollectionReport{
+		State:        sdkingest.OutcomeComplete,
+		CoverageKeys: []string{unrelatedScope},
+		Outcomes: []sdkingest.CollectionOutcome{{
+			Collector:   "mcp",
+			CoverageKey: unrelatedScope,
+			Method:      "enumerate",
+			State:       sdkingest.OutcomeComplete,
+		}},
+	}
+	unrelatedScan := finalScan(unrelatedID)
+	unrelatedScan.Collector = "mcp"
+	unrelatedResult, err := findings.FinalizeScan(ctx, FinalizeScanParams{
+		Scan:            unrelatedScan,
+		Collection:      unrelatedReport,
+		CoverageKeys:    unrelatedReport.CoverageKeys,
+		CompleteDomains: unrelatedReport.CoverageKeys,
+		GraphAfter:      graphAfter,
+		Publish:         true,
+	})
+	if err != nil {
+		t.Fatalf("finalize unrelated scan: %v", err)
+	}
+	if len(unrelatedResult.ActiveCoverageLimitations) != 1 ||
+		unrelatedResult.ActiveCoverageLimitations[0].CoverageKey != root ||
+		unrelatedResult.Export == nil ||
+		unrelatedResult.Export.Scope.ComparisonKey != "" {
+		t.Fatalf(
+			"unrelated publication lost or compared limited coverage: %+v",
+			unrelatedResult,
+		)
+	}
+
 	failedID := "instruction-root-failed"
 	finalize(failedID, sdkingest.OutcomeFailed, false, currentChild)
 	if err := pool.QueryRow(
@@ -797,6 +907,35 @@ func TestIntegrationIncompleteInstructionRootPreservesChildrenUntilComplete(t *t
 
 	completeID := "instruction-root-complete"
 	finalize(completeID, sdkingest.OutcomeComplete, true, currentChild)
+	projectionState, err := findings.GetProjectionState(ctx)
+	if err != nil {
+		t.Fatalf("read projection after complete coverage: %v", err)
+	}
+	if len(projectionState.ActiveCoverageLimitations) != 0 {
+		t.Fatalf(
+			"complete coverage retained limitations: %+v",
+			projectionState.ActiveCoverageLimitations,
+		)
+	}
+	var partialExportJSON []byte
+	if err := pool.QueryRow(
+		ctx,
+		`SELECT export FROM posture_publications WHERE revision = $1`,
+		*partialResult.Revision,
+	).Scan(&partialExportJSON); err != nil {
+		t.Fatalf("read historical partial export: %v", err)
+	}
+	var partialExport model.PostureExport
+	if err := json.Unmarshal(partialExportJSON, &partialExport); err != nil {
+		t.Fatalf("decode historical partial export: %v", err)
+	}
+	if len(partialExport.Scope.ActiveCoverageLimitations) != 1 ||
+		partialExport.Scope.ActiveCoverageLimitations[0].CoverageKey != root {
+		t.Fatalf(
+			"historical revision lost coverage limitation: %+v",
+			partialExport.Scope.ActiveCoverageLimitations,
+		)
+	}
 	var siblingCount int
 	if err := pool.QueryRow(
 		ctx,
@@ -893,6 +1032,7 @@ func TestBuildPostureExportDeclaresHealthAndCompleteState(t *testing.T) {
 			"config:path:sha256:current",
 			"mcp:target:sha256:prior",
 		},
+		nil,
 		nil,
 	)
 

--- a/server/internal/appdb/scans.go
+++ b/server/internal/appdb/scans.go
@@ -632,6 +632,16 @@ func (s *ScanStore) DeleteScan(ctx context.Context, id string) error {
 		return &ScanDeleteConflictError{Reason: "scan owns an active coverage head"}
 	}
 
+	var activeLimitation bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM coverage_limitations WHERE scan_id = $1)`, id,
+	).Scan(&activeLimitation); err != nil {
+		return fmt.Errorf("check scan coverage limitations: %w", err)
+	}
+	if activeLimitation {
+		return &ScanDeleteConflictError{Reason: "scan owns an active coverage limitation"}
+	}
+
 	var currentlyPublished bool
 	if err := tx.QueryRow(ctx,
 		`SELECT EXISTS (

--- a/server/internal/graph/fingerprint_test.go
+++ b/server/internal/graph/fingerprint_test.go
@@ -327,7 +327,7 @@ func TestWriterEdgePreparationMatchesAPOCAndFallback(t *testing.T) {
 		}
 		if !strings.Contains(
 			calls[0].Cypher,
-			"WHEN incoming_complete THEN\n        [fingerprint IN old_fact_fingerprints",
+			"WHEN incoming_authoritative THEN\n        [fingerprint IN old_fact_fingerprints",
 		) {
 			t.Fatalf("incompatible-refresh invalidation missing (APOC=%t):\n%s", hasAPOC, calls[0].Cypher)
 		}
@@ -411,7 +411,7 @@ func TestWriterCarriesStableFingerprintsForExactSharedOwnerRefresh(t *testing.T)
 		"fingerprint IN old_fact_fingerprints",
 		"WHEN compatible_existing_owner THEN true",
 		"WHEN compatible_mixed_owners THEN true",
-		"WHEN incoming_complete THEN\n        [fingerprint IN old_fact_fingerprints",
+		"WHEN incoming_authoritative THEN\n        [fingerprint IN old_fact_fingerprints",
 	} {
 		if !strings.Contains(call.Cypher, fragment) {
 			t.Fatalf("node refresh query missing %q:\n%s", fragment, call.Cypher)
@@ -436,7 +436,7 @@ func TestWriterCarriesStableFingerprintsForExactSharedOwnerRefresh(t *testing.T)
 
 func TestNodeLabelMutationIsCompatibilityGated(t *testing.T) {
 	query := nodeCypherForKindTuple("OllamaInstance", []string{"AIService"})
-	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners THEN [1] ELSE [] END | SET n:AIService)"
+	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:AIService)"
 	if !strings.Contains(query, want) {
 		t.Fatalf("extra label mutation is not compatibility-gated:\n%s", query)
 	}

--- a/server/internal/graph/fingerprint_test.go
+++ b/server/internal/graph/fingerprint_test.go
@@ -436,7 +436,7 @@ func TestWriterCarriesStableFingerprintsForExactSharedOwnerRefresh(t *testing.T)
 
 func TestNodeLabelMutationIsCompatibilityGated(t *testing.T) {
 	query := nodeCypherForKindTuple("OllamaInstance", []string{"AIService"})
-	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR compatible_owner_recovery OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:AIService)"
+	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR partial_existing_owner OR partial_new_owner OR partial_coowner_noop OR partial_coowner_addition OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:AIService)"
 	if !strings.Contains(query, want) {
 		t.Fatalf("extra label mutation is not compatibility-gated:\n%s", query)
 	}

--- a/server/internal/graph/fingerprint_test.go
+++ b/server/internal/graph/fingerprint_test.go
@@ -436,7 +436,7 @@ func TestWriterCarriesStableFingerprintsForExactSharedOwnerRefresh(t *testing.T)
 
 func TestNodeLabelMutationIsCompatibilityGated(t *testing.T) {
 	query := nodeCypherForKindTuple("OllamaInstance", []string{"AIService"})
-	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:AIService)"
+	want := "FOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR compatible_owner_recovery OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:AIService)"
 	if !strings.Contains(query, want) {
 		t.Fatalf("extra label mutation is not compatibility-gated:\n%s", query)
 	}

--- a/server/internal/graph/integration_test.go
+++ b/server/internal/graph/integration_test.go
@@ -1777,6 +1777,154 @@ RETURN server.observation_properties_complete AS server_complete,
 		rows[0]["edge_b_fingerprints"] != int64(1) {
 		t.Fatalf("complete shared owner did not recover after partial subset: %+v", rows)
 	}
+
+	partialAdditionA := serverA
+	partialAdditionA.Properties = map[string]any{
+		"endpoint":     "http://mcp.example/mcp",
+		"new_property": "confirmed-partial",
+	}
+	partialEdgeAdditionA := edgeA
+	partialEdgeAdditionA.Properties = map[string]any{
+		"confidence":   1.0,
+		"new_property": "confirmed-partial",
+	}
+	if _, err := writer.WriteObservationNodes(
+		ctx, []ingest.Node{partialAdditionA}, "partial-addition-a", nil,
+	); err != nil {
+		t.Fatalf("write partial owner A addition: %v", err)
+	}
+	if _, err := writer.WriteObservationEdges(
+		ctx, []ingest.Edge{partialEdgeAdditionA}, "partial-addition-a", nil,
+	); err != nil {
+		t.Fatalf("write partial owner A edge addition: %v", err)
+	}
+
+	assertAdditionQuarantined := func(stage string) {
+		t.Helper()
+		additionRows, queryErr := db.Query(ctx, `
+MATCH (server:MCPServer {objectid: $server})-[r:RUNS_ON]->
+      (:Host {objectid: $host})
+RETURN server.observation_properties_complete AS server_complete,
+       r.observation_properties_complete AS edge_complete,
+       server.configured_name AS configured_name,
+       server.new_property AS server_new_property,
+       r.configured_evidence AS configured_evidence,
+       r.new_property AS edge_new_property,
+       size([fingerprint IN server.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_a]) AS server_a_fingerprints,
+       size([fingerprint IN server.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_b]) AS server_b_fingerprints,
+       size([fingerprint IN r.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_a]) AS edge_a_fingerprints,
+       size([fingerprint IN r.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_b]) AS edge_b_fingerprints`,
+			map[string]any{
+				"server":  serverID,
+				"host":    hostID,
+				"scope_a": observationFingerprintDomainPrefix(scopeA),
+				"scope_b": observationFingerprintDomainPrefix(scopeB),
+			})
+		if queryErr != nil {
+			t.Fatalf("%s query partial addition: %v", stage, queryErr)
+		}
+		if len(additionRows) != 1 ||
+			additionRows[0]["server_complete"] != false ||
+			additionRows[0]["edge_complete"] != false ||
+			additionRows[0]["configured_name"] != "configured" ||
+			additionRows[0]["server_new_property"] != "confirmed-partial" ||
+			additionRows[0]["configured_evidence"] != "configured" ||
+			additionRows[0]["edge_new_property"] != "confirmed-partial" ||
+			additionRows[0]["server_a_fingerprints"] != int64(0) ||
+			additionRows[0]["server_b_fingerprints"] != int64(1) ||
+			additionRows[0]["edge_a_fingerprints"] != int64(0) ||
+			additionRows[0]["edge_b_fingerprints"] != int64(1) {
+			t.Fatalf("%s partial addition escaped quarantine: %+v", stage, additionRows)
+		}
+	}
+	assertAdditionQuarantined("partial")
+
+	// A later complete refresh with the partial shape must not certify the
+	// retained configured_name/configured_evidence values that it omitted.
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{partialAdditionA},
+		"complete-partial-shape-a",
+		[]string{scopeA},
+	); err != nil {
+		t.Fatalf("write complete partial-shape owner A node: %v", err)
+	}
+	if _, err := writer.WriteObservationEdges(
+		ctx,
+		[]ingest.Edge{partialEdgeAdditionA},
+		"complete-partial-shape-a",
+		[]string{scopeA},
+	); err != nil {
+		t.Fatalf("write complete partial-shape owner A edge: %v", err)
+	}
+	if _, err := ReconcileObservations(
+		ctx, db, "complete-partial-shape-a", []string{scopeA},
+	); err != nil {
+		t.Fatalf("reconcile complete partial-shape owner A: %v", err)
+	}
+	assertAdditionQuarantined("complete partial-shape retry")
+
+	restoredA := serverA
+	restoredA.Properties = cloneProperties(serverA.Properties)
+	restoredA.Properties["new_property"] = "confirmed-partial"
+	restoredEdgeA := edgeA
+	restoredEdgeA.Properties = cloneProperties(edgeA.Properties)
+	restoredEdgeA.Properties["new_property"] = "confirmed-partial"
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{restoredA, serverB, host},
+		"complete-joint-restore",
+		[]string{scopeA, scopeB},
+	); err != nil {
+		t.Fatalf("write complete joint restore nodes: %v", err)
+	}
+	if _, err := writer.WriteObservationEdges(
+		ctx,
+		[]ingest.Edge{restoredEdgeA, edgeB},
+		"complete-joint-restore",
+		[]string{scopeA, scopeB},
+	); err != nil {
+		t.Fatalf("write complete joint restore edge: %v", err)
+	}
+	if _, err := ReconcileObservations(
+		ctx, db, "complete-joint-restore", []string{scopeA, scopeB},
+	); err != nil {
+		t.Fatalf("reconcile complete joint restore: %v", err)
+	}
+	rows, err = db.Query(ctx, `
+MATCH (server:MCPServer {objectid: $server})-[r:RUNS_ON]->
+      (:Host {objectid: $host})
+RETURN server.observation_properties_complete AS server_complete,
+       r.observation_properties_complete AS edge_complete,
+       server.configured_name AS configured_name,
+       server.protocol_version AS protocol_version,
+       server.new_property AS server_new_property,
+       r.configured_evidence AS configured_evidence,
+       r.live_evidence AS live_evidence,
+       r.new_property AS edge_new_property,
+       size(server.observation_fact_fingerprints) AS server_fingerprints,
+       size(r.observation_fact_fingerprints) AS edge_fingerprints`,
+		map[string]any{"server": serverID, "host": hostID})
+	if err != nil {
+		t.Fatalf("query complete joint restore: %v", err)
+	}
+	if len(rows) != 1 ||
+		rows[0]["server_complete"] != true ||
+		rows[0]["edge_complete"] != true ||
+		rows[0]["configured_name"] != "configured" ||
+		rows[0]["protocol_version"] != "2025-06-18" ||
+		rows[0]["server_new_property"] != "confirmed-partial" ||
+		rows[0]["configured_evidence"] != "configured" ||
+		rows[0]["live_evidence"] != "observed" ||
+		rows[0]["edge_new_property"] != "confirmed-partial" ||
+		rows[0]["server_fingerprints"] != int64(2) ||
+		rows[0]["edge_fingerprints"] != int64(2) {
+		t.Fatalf("joint complete refresh did not recover exact union: %+v", rows)
+	}
 }
 
 func TestIntegrationCompatibleDistinctOwnersRemainCompleteUntilOneRetires(t *testing.T) {

--- a/server/internal/graph/integration_test.go
+++ b/server/internal/graph/integration_test.go
@@ -1631,6 +1631,154 @@ func TestIntegrationExactOwnerTransferPreservesOnlyRedundantFacts(t *testing.T) 
 	}
 }
 
+func TestIntegrationCompleteSharedOwnerRecoversAfterPartialSubset(t *testing.T) {
+	ctx := testDriver(t)
+	driver, err := NewDriver(
+		os.Getenv("AGENTHOUND_NEO4J_URI"),
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+
+	writer := NewWriter(driver)
+	db := NewDB(NewReader(driver), writer)
+	const (
+		serverID = "partial-recovery-shared-server"
+		hostID   = "partial-recovery-shared-host"
+		scopeA   = "config:path:sha256:partial-recovery-a"
+		scopeB   = "mcp:target:sha256:partial-recovery-b"
+	)
+	cleanup := func() {
+		_, _ = db.ExecuteWrite(
+			ctx,
+			"MATCH (n) WHERE n.objectid IN $ids DETACH DELETE n",
+			map[string]any{"ids": []string{serverID, hostID}},
+		)
+	}
+	cleanup()
+	defer cleanup()
+
+	serverA := ingest.Node{
+		ID: serverID, Kinds: []string{"MCPServer"},
+		ObservationDomains: []string{scopeA},
+		Properties: map[string]any{
+			"endpoint": "http://mcp.example/mcp", "transport": "http",
+			"configured_name": "configured",
+		},
+	}
+	serverB := ingest.Node{
+		ID: serverID, Kinds: []string{"MCPServer"},
+		ObservationDomains: []string{scopeB},
+		Properties: map[string]any{
+			"endpoint": "http://mcp.example/mcp", "transport": "http",
+			"protocol_version": "2025-06-18",
+		},
+	}
+	host := ingest.Node{
+		ID: hostID, Kinds: []string{"Host"},
+		ObservationDomains: []string{scopeA, scopeB},
+		Properties:         map[string]any{"hostname": "mcp.example"},
+	}
+	edgeA := ingest.Edge{
+		Source: serverID, Target: hostID, Kind: "RUNS_ON",
+		SourceKind: "MCPServer", TargetKind: "Host",
+		ObservationDomains: []string{scopeA},
+		Properties: map[string]any{
+			"confidence": 1.0, "configured_evidence": "configured",
+		},
+	}
+	edgeB := edgeA
+	edgeB.ObservationDomains = []string{scopeB}
+	edgeB.Properties = map[string]any{
+		"confidence": 1.0, "live_evidence": "observed",
+	}
+
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{serverA, serverB, host},
+		"complete-both",
+		[]string{scopeA, scopeB},
+	); err != nil {
+		t.Fatalf("write complete shared nodes: %v", err)
+	}
+	if _, err := writer.WriteObservationEdges(
+		ctx,
+		[]ingest.Edge{edgeA, edgeB},
+		"complete-both",
+		[]string{scopeA, scopeB},
+	); err != nil {
+		t.Fatalf("write complete shared edge: %v", err)
+	}
+
+	partialServerA := serverA
+	partialServerA.Properties = map[string]any{
+		"endpoint": "http://mcp.example/mcp",
+	}
+	partialEdgeA := edgeA
+	partialEdgeA.Properties = map[string]any{"confidence": 1.0}
+	if _, err := writer.WriteObservationNodes(
+		ctx, []ingest.Node{partialServerA}, "partial-a", nil,
+	); err != nil {
+		t.Fatalf("write partial owner A node: %v", err)
+	}
+	if _, err := writer.WriteObservationEdges(
+		ctx, []ingest.Edge{partialEdgeA}, "partial-a", nil,
+	); err != nil {
+		t.Fatalf("write partial owner A edge: %v", err)
+	}
+
+	if _, err := writer.WriteObservationNodes(
+		ctx, []ingest.Node{serverA}, "complete-a", []string{scopeA},
+	); err != nil {
+		t.Fatalf("restore complete owner A node: %v", err)
+	}
+	if _, err := writer.WriteObservationEdges(
+		ctx, []ingest.Edge{edgeA}, "complete-a", []string{scopeA},
+	); err != nil {
+		t.Fatalf("restore complete owner A edge: %v", err)
+	}
+	if _, err := ReconcileObservations(
+		ctx, db, "complete-a", []string{scopeA},
+	); err != nil {
+		t.Fatalf("reconcile complete owner A: %v", err)
+	}
+
+	rows, err := db.Query(ctx, `
+MATCH (server:MCPServer {objectid: $server})-[r:RUNS_ON]->
+      (:Host {objectid: $host})
+RETURN server.observation_properties_complete AS server_complete,
+       r.observation_properties_complete AS edge_complete,
+       size([fingerprint IN server.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_a]) AS server_a_fingerprints,
+       size([fingerprint IN server.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_b]) AS server_b_fingerprints,
+       size([fingerprint IN r.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_a]) AS edge_a_fingerprints,
+       size([fingerprint IN r.observation_fact_fingerprints
+             WHERE fingerprint STARTS WITH $scope_b]) AS edge_b_fingerprints`,
+		map[string]any{
+			"server":  serverID,
+			"host":    hostID,
+			"scope_a": observationFingerprintDomainPrefix(scopeA),
+			"scope_b": observationFingerprintDomainPrefix(scopeB),
+		})
+	if err != nil {
+		t.Fatalf("query recovered shared observation: %v", err)
+	}
+	if len(rows) != 1 ||
+		rows[0]["server_complete"] != true ||
+		rows[0]["edge_complete"] != true ||
+		rows[0]["server_a_fingerprints"] != int64(1) ||
+		rows[0]["server_b_fingerprints"] != int64(1) ||
+		rows[0]["edge_a_fingerprints"] != int64(1) ||
+		rows[0]["edge_b_fingerprints"] != int64(1) {
+		t.Fatalf("complete shared owner did not recover after partial subset: %+v", rows)
+	}
+}
+
 func TestIntegrationCompatibleDistinctOwnersRemainCompleteUntilOneRetires(t *testing.T) {
 	ctx := testDriver(t)
 	driver, err := NewDriver(

--- a/server/internal/graph/integration_test.go
+++ b/server/internal/graph/integration_test.go
@@ -1161,6 +1161,118 @@ func TestIntegrationCompleteObservationReplacesStaleManagedProperties(t *testing
 	}
 }
 
+func TestIntegrationPartialObservationRetainsOmittedProperties(t *testing.T) {
+	ctx := testDriver(t)
+	driver, err := NewDriver(
+		os.Getenv("AGENTHOUND_NEO4J_URI"),
+		os.Getenv("AGENTHOUND_NEO4J_USER"),
+		os.Getenv("AGENTHOUND_NEO4J_PASSWORD"),
+	)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer driver.Close(ctx)
+
+	reader := NewReader(driver)
+	writer := NewWriter(driver)
+	scope := "mcp:target:sha256:partial-property-retention"
+	ids := []string{
+		"partial-property-existing",
+		"partial-property-new",
+	}
+	_, _ = integrationWrite(
+		ctx,
+		driver,
+		`MATCH (n) WHERE n.objectid IN $ids DETACH DELETE n`,
+		map[string]any{"ids": ids},
+	)
+	defer func() {
+		_, _ = integrationWrite(
+			ctx,
+			driver,
+			`MATCH (n) WHERE n.objectid IN $ids DETACH DELETE n`,
+			map[string]any{"ids": ids},
+		)
+	}()
+
+	first := ingest.Node{
+		ID:                 ids[0],
+		Kinds:              []string{"MCPServer"},
+		ObservationDomains: []string{scope},
+		Properties: map[string]any{
+			"name":           "before",
+			"stale_property": "retain-until-complete",
+		},
+	}
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{first},
+		"partial-property-first",
+		[]string{scope},
+	); err != nil {
+		t.Fatalf("write complete baseline: %v", err)
+	}
+	partialExisting := first
+	partialExisting.Properties = map[string]any{"name": "observed-partial"}
+	partialNew := ingest.Node{
+		ID:                 ids[1],
+		Kinds:              []string{"MCPServer"},
+		ObservationDomains: []string{scope},
+		Properties:         map[string]any{"name": "new-partial"},
+	}
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{partialExisting, partialNew},
+		"partial-property-second",
+		nil,
+	); err != nil {
+		t.Fatalf("write partial observations: %v", err)
+	}
+
+	rows, err := reader.Query(
+		ctx,
+		`MATCH (n) WHERE n.objectid IN $ids
+		RETURN n.objectid AS id,
+		       n.name AS name,
+		       n.stale_property AS stale_property,
+		       n.observation_properties_complete AS properties_complete
+		ORDER BY id`,
+		map[string]any{"ids": ids},
+	)
+	if err != nil {
+		t.Fatalf("read partial observations: %v", err)
+	}
+	if len(rows) != 2 ||
+		rows[0]["name"] != "observed-partial" ||
+		rows[0]["stale_property"] != "retain-until-complete" ||
+		rows[0]["properties_complete"] != true ||
+		rows[1]["name"] != "new-partial" ||
+		rows[1]["properties_complete"] != true {
+		t.Fatalf("partial property state = %+v", rows)
+	}
+
+	if _, err := writer.WriteObservationNodes(
+		ctx,
+		[]ingest.Node{partialExisting},
+		"partial-property-third",
+		[]string{scope},
+	); err != nil {
+		t.Fatalf("write complete replacement: %v", err)
+	}
+	rows, err = reader.Query(
+		ctx,
+		`MATCH (n:MCPServer {objectid: $id})
+		RETURN n.stale_property AS stale_property`,
+		map[string]any{"id": ids[0]},
+	)
+	if err != nil {
+		t.Fatalf("read complete replacement: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["stale_property"] != nil {
+		t.Fatalf("complete replacement retained stale property: %+v", rows)
+	}
+}
+
 func TestIntegrationReferenceOwnerPreservesThenRetiresAuthoritativeProperties(t *testing.T) {
 	ctx := testDriver(t)
 	driver, err := NewDriver(

--- a/server/internal/graph/writer.go
+++ b/server/internal/graph/writer.go
@@ -136,6 +136,7 @@ func (w *Writer) writeNodesBatched(
 				params[j] = map[string]any{
 					"id":                            n.ID,
 					"properties":                    properties,
+					"public_labels":                 n.Kinds,
 					"observation_tokens":            observationTokens(n.ObservationDomains, scanID),
 					"observation_domain_prefixes":   observationDomainPrefixes(n.ObservationDomains),
 					"observation_fact_fingerprints": fingerprints,
@@ -234,22 +235,6 @@ WITH n, node, observation_created,
       AND incoming_authoritative
       AND old_properties_complete
       AND size(old_authoritative_tokens) > 0
-      AND size(node.observation_fact_fingerprints) > 0
-      AND all(prefix IN node.observation_domain_prefixes WHERE
-          any(token IN old_authoritative_tokens WHERE token STARTS WITH prefix))
-      AND all(prefix IN node.observation_fingerprint_domain_prefixes WHERE
-          any(fingerprint IN old_fact_fingerprints WHERE
-              fingerprint STARTS WITH prefix))
-      AND any(fingerprint IN node.observation_fact_fingerprints WHERE
-          NOT fingerprint IN old_fact_fingerprints)
-      AND all(key IN keys(node.properties) WHERE
-          key IN $semantic_volatile_properties
-          OR n[key] IS NULL OR n[key] = node.properties[key])) AS compatible_owner_recovery,
-     (NOT observation_created
-      AND NOT node.reference_only
-      AND incoming_authoritative
-      AND old_properties_complete
-      AND size(old_authoritative_tokens) > 0
       AND size(node.observation_owner_fingerprints) =
           size(node.observation_domain_prefixes)
       AND any(owner IN node.observation_owner_fingerprints WHERE
@@ -279,9 +264,39 @@ WITH n, node, observation_created,
       AND NOT incoming_authoritative
       AND old_properties_complete
       AND size(old_authoritative_tokens) > 0
+      AND none(prefix IN node.observation_domain_prefixes WHERE
+          any(token IN old_authoritative_tokens WHERE token STARTS WITH prefix))
       AND all(key IN keys(node.properties) WHERE
           key IN $semantic_volatile_properties
-          OR n[key] IS NULL OR n[key] = node.properties[key])) AS partial_compatible_owner,
+          OR n[key] IS NULL OR n[key] = node.properties[key])) AS partial_new_owner,
+     (NOT observation_created
+      AND NOT node.reference_only
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_authoritative_tokens) > 0
+      AND all(prefix IN node.observation_domain_prefixes WHERE
+          any(token IN old_authoritative_tokens WHERE token STARTS WITH prefix))
+      AND any(token IN old_authoritative_tokens WHERE
+          none(prefix IN node.observation_domain_prefixes WHERE token STARTS WITH prefix))
+      AND all(key IN keys(node.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR n[key] = node.properties[key])
+      AND all(label IN node.public_labels WHERE label IN labels(n))) AS partial_coowner_noop,
+     (NOT observation_created
+      AND NOT node.reference_only
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_authoritative_tokens) > 0
+      AND all(prefix IN node.observation_domain_prefixes WHERE
+          any(token IN old_authoritative_tokens WHERE token STARTS WITH prefix))
+      AND any(token IN old_authoritative_tokens WHERE
+          none(prefix IN node.observation_domain_prefixes WHERE token STARTS WITH prefix))
+      AND all(key IN keys(node.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR n[key] IS NULL OR n[key] = node.properties[key])
+      AND (any(key IN keys(node.properties) WHERE
+          NOT key IN $semantic_volatile_properties AND n[key] IS NULL)
+        OR any(label IN node.public_labels WHERE NOT label IN labels(n)))) AS partial_coowner_addition,
      (NOT observation_created
       AND NOT node.reference_only
       AND NOT incoming_authoritative
@@ -295,8 +310,8 @@ FOREACH (_ IN CASE WHEN observation_created AND node.reference_only THEN [1] ELS
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties AND NOT node.reference_only
        AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
-            OR compatible_owner_recovery
-            OR partial_existing_owner OR partial_compatible_owner
+            OR partial_existing_owner OR partial_new_owner
+            OR partial_coowner_noop OR partial_coowner_addition
             OR partial_reference_upgrade)
   THEN [1] ELSE [] END |
   SET n += node.properties)
@@ -320,9 +335,9 @@ SET n.objectid = node.id,
     END,
     n.observation_fact_fingerprints = CASE
       WHEN node.reference_only THEN old_fact_fingerprints
-      WHEN observation_created OR replace_properties OR compatible_owner_recovery
+      WHEN observation_created OR replace_properties
            OR partial_existing_owner
-           OR partial_compatible_owner OR partial_reference_upgrade THEN
+           OR partial_new_owner OR partial_reference_upgrade THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN node.observation_fingerprint_domain_prefixes WHERE
@@ -341,6 +356,11 @@ SET n.objectid = node.id,
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
+      WHEN partial_coowner_noop THEN old_fact_fingerprints
+      WHEN partial_coowner_addition THEN
+        [fingerprint IN old_fact_fingerprints
+         WHERE none(prefix IN node.observation_fingerprint_domain_prefixes WHERE
+           fingerprint STARTS WITH prefix)]
       WHEN incoming_authoritative THEN
         [fingerprint IN old_fact_fingerprints
          WHERE none(prefix IN node.observation_fingerprint_domain_prefixes WHERE
@@ -356,9 +376,10 @@ SET n.objectid = node.id,
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
-      WHEN compatible_owner_recovery THEN true
       WHEN partial_existing_owner THEN true
-      WHEN partial_compatible_owner THEN true
+      WHEN partial_new_owner THEN true
+      WHEN partial_coowner_noop THEN true
+      WHEN partial_coowner_addition THEN false
       WHEN partial_reference_upgrade THEN true
       ELSE false
     END`)
@@ -381,7 +402,7 @@ SET n.objectid = node.id,
 	for _, lbl := range extraLabels {
 		fmt.Fprintf(
 			&sb,
-			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR compatible_owner_recovery OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:%s)",
+			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR partial_existing_owner OR partial_new_owner OR partial_coowner_noop OR partial_coowner_addition OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:%s)",
 			lbl,
 		)
 	}
@@ -523,21 +544,6 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
       AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
-      AND size(edge.observation_fact_fingerprints) > 0
-      AND all(prefix IN edge.observation_domain_prefixes WHERE
-          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
-      AND all(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
-          any(fingerprint IN old_fact_fingerprints WHERE
-              fingerprint STARTS WITH prefix))
-      AND any(fingerprint IN edge.observation_fact_fingerprints WHERE
-          NOT fingerprint IN old_fact_fingerprints)
-      AND all(key IN keys(edge.properties) WHERE
-          key IN $semantic_volatile_properties
-          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS compatible_owner_recovery,
-     (NOT observation_created
-      AND incoming_authoritative
-      AND old_properties_complete
-      AND size(old_ownership_tokens) > 0
       AND size(edge.observation_owner_fingerprints) =
           size(edge.observation_domain_prefixes)
       AND any(owner IN edge.observation_owner_fingerprints WHERE
@@ -565,16 +571,42 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
       AND NOT incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
+      AND none(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
       AND all(key IN keys(edge.properties) WHERE
           key IN $semantic_volatile_properties
-          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS partial_compatible_owner
+          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS partial_new_owner,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND any(token IN old_ownership_tokens WHERE
+          none(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix))
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR rel[key] = edge.properties[key])) AS partial_coowner_noop,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND any(token IN old_ownership_tokens WHERE
+          none(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix))
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR rel[key] IS NULL OR rel[key] = edge.properties[key])
+      AND any(key IN keys(edge.properties) WHERE
+          NOT key IN $semantic_volatile_properties AND rel[key] IS NULL)) AS partial_coowner_addition
 FOREACH (_ IN CASE WHEN NOT observation_created AND replace_properties THEN [1] ELSE [] END |
   SET rel = edge.properties)
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
        AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
-            OR compatible_owner_recovery
-            OR partial_existing_owner OR partial_compatible_owner)
+            OR partial_existing_owner OR partial_new_owner
+            OR partial_coowner_noop OR partial_coowner_addition)
   THEN [1] ELSE [] END |
   SET rel += edge.properties)
 SET rel.observation_properties_complete = CASE
@@ -583,9 +615,10 @@ SET rel.observation_properties_complete = CASE
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
-      WHEN compatible_owner_recovery THEN true
       WHEN partial_existing_owner THEN true
-      WHEN partial_compatible_owner THEN true
+      WHEN partial_new_owner THEN true
+      WHEN partial_coowner_noop THEN true
+      WHEN partial_coowner_addition THEN false
       ELSE false
     END,
     rel.observation_tokens = reduce(tokens = old_tokens, token IN edge.observation_tokens |
@@ -598,8 +631,8 @@ SET rel.observation_properties_complete = CASE
     rel.observation_semantics = edge.observation_semantics,
     rel.observation_fact_fingerprints = CASE
       WHEN replace_dependency_set THEN edge.observation_fact_fingerprints
-      WHEN observation_created OR replace_properties OR compatible_owner_recovery
-           OR partial_existing_owner OR partial_compatible_owner THEN
+      WHEN observation_created OR replace_properties
+           OR partial_existing_owner OR partial_new_owner THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -618,6 +651,11 @@ SET rel.observation_properties_complete = CASE
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
+      WHEN partial_coowner_noop THEN old_fact_fingerprints
+      WHEN partial_coowner_addition THEN
+        [fingerprint IN old_fact_fingerprints
+         WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
+           fingerprint STARTS WITH prefix)]
       WHEN incoming_authoritative THEN
         [fingerprint IN old_fact_fingerprints
          WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -770,21 +808,6 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
       AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
-      AND size(edge.observation_fact_fingerprints) > 0
-      AND all(prefix IN edge.observation_domain_prefixes WHERE
-          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
-      AND all(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
-          any(fingerprint IN old_fact_fingerprints WHERE
-              fingerprint STARTS WITH prefix))
-      AND any(fingerprint IN edge.observation_fact_fingerprints WHERE
-          NOT fingerprint IN old_fact_fingerprints)
-      AND all(key IN keys(edge.properties) WHERE
-          key IN $semantic_volatile_properties
-          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS compatible_owner_recovery,
-     (NOT observation_created
-      AND incoming_authoritative
-      AND old_properties_complete
-      AND size(old_ownership_tokens) > 0
       AND size(edge.observation_owner_fingerprints) =
           size(edge.observation_domain_prefixes)
       AND any(owner IN edge.observation_owner_fingerprints WHERE
@@ -812,16 +835,42 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
       AND NOT incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
+      AND none(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
       AND all(key IN keys(edge.properties) WHERE
           key IN $semantic_volatile_properties
-          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS partial_compatible_owner
+          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS partial_new_owner,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND any(token IN old_ownership_tokens WHERE
+          none(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix))
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR r[key] = edge.properties[key])) AS partial_coowner_noop,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND any(token IN old_ownership_tokens WHERE
+          none(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix))
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR r[key] IS NULL OR r[key] = edge.properties[key])
+      AND any(key IN keys(edge.properties) WHERE
+          NOT key IN $semantic_volatile_properties AND r[key] IS NULL)) AS partial_coowner_addition
 FOREACH (_ IN CASE WHEN observation_created OR replace_properties THEN [1] ELSE [] END |
   SET r = edge.properties)
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
        AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
-            OR compatible_owner_recovery
-            OR partial_existing_owner OR partial_compatible_owner)
+            OR partial_existing_owner OR partial_new_owner
+            OR partial_coowner_noop OR partial_coowner_addition)
   THEN [1] ELSE [] END |
   SET r += edge.properties)
 SET r.scan_id = $scan_id,
@@ -836,8 +885,8 @@ SET r.scan_id = $scan_id,
     r.observation_semantics = edge.observation_semantics,
     r.observation_fact_fingerprints = CASE
       WHEN replace_dependency_set THEN edge.observation_fact_fingerprints
-      WHEN observation_created OR replace_properties OR compatible_owner_recovery
-           OR partial_existing_owner OR partial_compatible_owner THEN
+      WHEN observation_created OR replace_properties
+           OR partial_existing_owner OR partial_new_owner THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -856,6 +905,11 @@ SET r.scan_id = $scan_id,
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
+      WHEN partial_coowner_noop THEN old_fact_fingerprints
+      WHEN partial_coowner_addition THEN
+        [fingerprint IN old_fact_fingerprints
+         WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
+           fingerprint STARTS WITH prefix)]
       WHEN incoming_authoritative THEN
         [fingerprint IN old_fact_fingerprints
          WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -868,9 +922,10 @@ SET r.scan_id = $scan_id,
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
-      WHEN compatible_owner_recovery THEN true
       WHEN partial_existing_owner THEN true
-      WHEN partial_compatible_owner THEN true
+      WHEN partial_new_owner THEN true
+      WHEN partial_coowner_noop THEN true
+      WHEN partial_coowner_addition THEN false
       ELSE false
     END
 REMOVE r.__agenthound_observation_created

--- a/server/internal/graph/writer.go
+++ b/server/internal/graph/writer.go
@@ -234,6 +234,22 @@ WITH n, node, observation_created,
       AND incoming_authoritative
       AND old_properties_complete
       AND size(old_authoritative_tokens) > 0
+      AND size(node.observation_fact_fingerprints) > 0
+      AND all(prefix IN node.observation_domain_prefixes WHERE
+          any(token IN old_authoritative_tokens WHERE token STARTS WITH prefix))
+      AND all(prefix IN node.observation_fingerprint_domain_prefixes WHERE
+          any(fingerprint IN old_fact_fingerprints WHERE
+              fingerprint STARTS WITH prefix))
+      AND any(fingerprint IN node.observation_fact_fingerprints WHERE
+          NOT fingerprint IN old_fact_fingerprints)
+      AND all(key IN keys(node.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR n[key] IS NULL OR n[key] = node.properties[key])) AS compatible_owner_recovery,
+     (NOT observation_created
+      AND NOT node.reference_only
+      AND incoming_authoritative
+      AND old_properties_complete
+      AND size(old_authoritative_tokens) > 0
       AND size(node.observation_owner_fingerprints) =
           size(node.observation_domain_prefixes)
       AND any(owner IN node.observation_owner_fingerprints WHERE
@@ -279,6 +295,7 @@ FOREACH (_ IN CASE WHEN observation_created AND node.reference_only THEN [1] ELS
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties AND NOT node.reference_only
        AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
+            OR compatible_owner_recovery
             OR partial_existing_owner OR partial_compatible_owner
             OR partial_reference_upgrade)
   THEN [1] ELSE [] END |
@@ -303,7 +320,8 @@ SET n.objectid = node.id,
     END,
     n.observation_fact_fingerprints = CASE
       WHEN node.reference_only THEN old_fact_fingerprints
-      WHEN observation_created OR replace_properties OR partial_existing_owner
+      WHEN observation_created OR replace_properties OR compatible_owner_recovery
+           OR partial_existing_owner
            OR partial_compatible_owner OR partial_reference_upgrade THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
@@ -338,6 +356,7 @@ SET n.objectid = node.id,
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
+      WHEN compatible_owner_recovery THEN true
       WHEN partial_existing_owner THEN true
       WHEN partial_compatible_owner THEN true
       WHEN partial_reference_upgrade THEN true
@@ -362,7 +381,7 @@ SET n.objectid = node.id,
 	for _, lbl := range extraLabels {
 		fmt.Fprintf(
 			&sb,
-			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:%s)",
+			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR compatible_owner_recovery OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:%s)",
 			lbl,
 		)
 	}
@@ -504,6 +523,21 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
       AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
+      AND size(edge.observation_fact_fingerprints) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND all(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
+          any(fingerprint IN old_fact_fingerprints WHERE
+              fingerprint STARTS WITH prefix))
+      AND any(fingerprint IN edge.observation_fact_fingerprints WHERE
+          NOT fingerprint IN old_fact_fingerprints)
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS compatible_owner_recovery,
+     (NOT observation_created
+      AND incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
       AND size(edge.observation_owner_fingerprints) =
           size(edge.observation_domain_prefixes)
       AND any(owner IN edge.observation_owner_fingerprints WHERE
@@ -539,6 +573,7 @@ FOREACH (_ IN CASE WHEN NOT observation_created AND replace_properties THEN [1] 
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
        AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
+            OR compatible_owner_recovery
             OR partial_existing_owner OR partial_compatible_owner)
   THEN [1] ELSE [] END |
   SET rel += edge.properties)
@@ -548,6 +583,7 @@ SET rel.observation_properties_complete = CASE
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
+      WHEN compatible_owner_recovery THEN true
       WHEN partial_existing_owner THEN true
       WHEN partial_compatible_owner THEN true
       ELSE false
@@ -562,7 +598,8 @@ SET rel.observation_properties_complete = CASE
     rel.observation_semantics = edge.observation_semantics,
     rel.observation_fact_fingerprints = CASE
       WHEN replace_dependency_set THEN edge.observation_fact_fingerprints
-      WHEN observation_created OR replace_properties OR partial_existing_owner OR partial_compatible_owner THEN
+      WHEN observation_created OR replace_properties OR compatible_owner_recovery
+           OR partial_existing_owner OR partial_compatible_owner THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -733,6 +770,21 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
       AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
+      AND size(edge.observation_fact_fingerprints) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND all(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
+          any(fingerprint IN old_fact_fingerprints WHERE
+              fingerprint STARTS WITH prefix))
+      AND any(fingerprint IN edge.observation_fact_fingerprints WHERE
+          NOT fingerprint IN old_fact_fingerprints)
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS compatible_owner_recovery,
+     (NOT observation_created
+      AND incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
       AND size(edge.observation_owner_fingerprints) =
           size(edge.observation_domain_prefixes)
       AND any(owner IN edge.observation_owner_fingerprints WHERE
@@ -768,6 +820,7 @@ FOREACH (_ IN CASE WHEN observation_created OR replace_properties THEN [1] ELSE 
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
        AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
+            OR compatible_owner_recovery
             OR partial_existing_owner OR partial_compatible_owner)
   THEN [1] ELSE [] END |
   SET r += edge.properties)
@@ -783,7 +836,8 @@ SET r.scan_id = $scan_id,
     r.observation_semantics = edge.observation_semantics,
     r.observation_fact_fingerprints = CASE
       WHEN replace_dependency_set THEN edge.observation_fact_fingerprints
-      WHEN observation_created OR replace_properties OR partial_existing_owner OR partial_compatible_owner THEN
+      WHEN observation_created OR replace_properties OR compatible_owner_recovery
+           OR partial_existing_owner OR partial_compatible_owner THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -814,6 +868,7 @@ SET r.scan_id = $scan_id,
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
+      WHEN compatible_owner_recovery THEN true
       WHEN partial_existing_owner THEN true
       WHEN partial_compatible_owner THEN true
       ELSE false

--- a/server/internal/graph/writer.go
+++ b/server/internal/graph/writer.go
@@ -330,7 +330,7 @@ SET n.objectid = node.id,
       ELSE old_fact_fingerprints
     END,
     n.observation_properties_complete = CASE
-      WHEN observation_created THEN NOT node.reference_only
+      WHEN observation_created THEN true
       WHEN node.reference_only THEN
         old_properties_complete OR
         (incoming_authoritative AND size(old_authoritative_tokens) = 0)

--- a/server/internal/graph/writer.go
+++ b/server/internal/graph/writer.go
@@ -193,25 +193,25 @@ WITH n, node, observation_created,
      [token IN old_tokens WHERE NOT token IN old_reference_tokens] AS old_authoritative_tokens,
      (size(node.observation_tokens) > 0
       AND all(token IN node.observation_tokens WHERE
-          any(prefix IN node.complete_domain_prefixes WHERE token STARTS WITH prefix))) AS incoming_complete
+          any(prefix IN node.complete_domain_prefixes WHERE token STARTS WITH prefix))) AS incoming_authoritative
 WITH n, node, observation_created,
      old_description_hash, old_input_schema_hash, old_instructions_hash,
      old_first_seen, old_tokens, old_reference_tokens, old_fact_fingerprints,
      old_properties_complete,
-     old_authoritative_tokens, incoming_complete,
+     old_authoritative_tokens, incoming_authoritative,
      (NOT observation_created
       AND NOT node.reference_only
-      AND incoming_complete
+      AND incoming_authoritative
       AND all(token IN old_authoritative_tokens WHERE
           any(prefix IN node.observation_domain_prefixes WHERE token STARTS WITH prefix))) AS replace_properties
 WITH n, node, observation_created,
      old_description_hash, old_input_schema_hash, old_instructions_hash,
      old_first_seen, old_tokens, old_reference_tokens, old_fact_fingerprints,
      old_properties_complete,
-     old_authoritative_tokens, incoming_complete, replace_properties,
+     old_authoritative_tokens, incoming_authoritative, replace_properties,
      (NOT observation_created
       AND NOT node.reference_only
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_authoritative_tokens) > 0
       AND none(token IN old_authoritative_tokens WHERE
@@ -221,7 +221,7 @@ WITH n, node, observation_created,
           OR n[key] IS NULL OR n[key] = node.properties[key])) AS compatible_new_owner,
      (NOT observation_created
       AND NOT node.reference_only
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_authoritative_tokens) > 0
       AND size(node.observation_fact_fingerprints) > 0
@@ -231,7 +231,7 @@ WITH n, node, observation_created,
           fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner,
      (NOT observation_created
       AND NOT node.reference_only
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_authoritative_tokens) > 0
       AND size(node.observation_owner_fingerprints) =
@@ -248,7 +248,28 @@ WITH n, node, observation_created,
           OR owner.fact_fingerprint IN old_fact_fingerprints)
       AND all(key IN keys(node.properties) WHERE
           key IN $semantic_volatile_properties
-          OR n[key] IS NULL OR n[key] = node.properties[key])) AS compatible_mixed_owners
+          OR n[key] IS NULL OR n[key] = node.properties[key])) AS compatible_mixed_owners,
+     (NOT observation_created
+      AND NOT node.reference_only
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_authoritative_tokens) > 0
+      AND all(prefix IN node.observation_domain_prefixes WHERE
+          any(token IN old_authoritative_tokens WHERE token STARTS WITH prefix))
+      AND all(token IN old_authoritative_tokens WHERE
+          any(prefix IN node.observation_domain_prefixes WHERE token STARTS WITH prefix))) AS partial_existing_owner,
+     (NOT observation_created
+      AND NOT node.reference_only
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_authoritative_tokens) > 0
+      AND all(key IN keys(node.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR n[key] IS NULL OR n[key] = node.properties[key])) AS partial_compatible_owner,
+     (NOT observation_created
+      AND NOT node.reference_only
+      AND NOT incoming_authoritative
+      AND size(old_authoritative_tokens) = 0) AS partial_reference_upgrade
 FOREACH (_ IN CASE
   WHEN (observation_created AND NOT node.reference_only) OR replace_properties
   THEN [1] ELSE [] END |
@@ -257,7 +278,9 @@ FOREACH (_ IN CASE WHEN observation_created AND node.reference_only THEN [1] ELS
   SET n = {objectid: node.id})
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties AND NOT node.reference_only
-       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners)
+       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
+            OR partial_existing_owner OR partial_compatible_owner
+            OR partial_reference_upgrade)
   THEN [1] ELSE [] END |
   SET n += node.properties)
 SET n.objectid = node.id,
@@ -280,7 +303,8 @@ SET n.objectid = node.id,
     END,
     n.observation_fact_fingerprints = CASE
       WHEN node.reference_only THEN old_fact_fingerprints
-      WHEN (observation_created AND incoming_complete) OR replace_properties THEN
+      WHEN observation_created OR replace_properties OR partial_existing_owner
+           OR partial_compatible_owner OR partial_reference_upgrade THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN node.observation_fingerprint_domain_prefixes WHERE
@@ -299,21 +323,24 @@ SET n.objectid = node.id,
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
-      WHEN incoming_complete THEN
+      WHEN incoming_authoritative THEN
         [fingerprint IN old_fact_fingerprints
          WHERE none(prefix IN node.observation_fingerprint_domain_prefixes WHERE
            fingerprint STARTS WITH prefix)]
       ELSE old_fact_fingerprints
     END,
     n.observation_properties_complete = CASE
-      WHEN observation_created THEN incoming_complete
+      WHEN observation_created THEN NOT node.reference_only
       WHEN node.reference_only THEN
         old_properties_complete OR
-        (incoming_complete AND size(old_authoritative_tokens) = 0)
+        (incoming_authoritative AND size(old_authoritative_tokens) = 0)
       WHEN replace_properties THEN true
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
+      WHEN partial_existing_owner THEN true
+      WHEN partial_compatible_owner THEN true
+      WHEN partial_reference_upgrade THEN true
       ELSE false
     END`)
 	incomingLabels := make(map[string]bool, len(extraLabels)+1)
@@ -335,7 +362,7 @@ SET n.objectid = node.id,
 	for _, lbl := range extraLabels {
 		fmt.Fprintf(
 			&sb,
-			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners THEN [1] ELSE [] END | SET n:%s)",
+			"\nFOREACH (_ IN CASE WHEN observation_created OR replace_properties OR compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners OR partial_existing_owner OR partial_compatible_owner OR partial_reference_upgrade THEN [1] ELSE [] END | SET n:%s)",
 			lbl,
 		)
 	}
@@ -437,26 +464,26 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
      old_fact_fingerprints, old_properties_complete, old_ownership_tokens,
      (size(edge.ownership_tokens) > 0
       AND all(token IN edge.ownership_tokens WHERE
-          any(prefix IN edge.complete_domain_prefixes WHERE token STARTS WITH prefix))) AS incoming_complete
+          any(prefix IN edge.complete_domain_prefixes WHERE token STARTS WITH prefix))) AS incoming_authoritative
 WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
-     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_complete,
+     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_authoritative,
 	     (NOT observation_created
 	      AND edge.observation_semantics = 'all_dependencies'
-	      AND incoming_complete
+	      AND incoming_authoritative
 	      AND size(old_ownership_tokens) > 0) AS replace_dependency_set
 WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
-     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_complete,
+     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_authoritative,
      replace_dependency_set,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND (replace_dependency_set
            OR all(token IN old_ownership_tokens WHERE
              any(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix)))) AS replace_properties
 WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
      old_fact_fingerprints, old_properties_complete, old_ownership_tokens,
-     incoming_complete, replace_dependency_set, replace_properties,
+     incoming_authoritative, replace_dependency_set, replace_properties,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
       AND none(token IN old_ownership_tokens WHERE
@@ -465,7 +492,7 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
           key IN $semantic_volatile_properties
           OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS compatible_new_owner,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
       AND size(edge.observation_fact_fingerprints) > 0
@@ -474,7 +501,7 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
       AND all(fingerprint IN edge.observation_fact_fingerprints WHERE
           fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
       AND size(edge.observation_owner_fingerprints) =
@@ -491,20 +518,38 @@ WITH rel, edge, observation_created, old_tokens, old_dependency_tokens,
           OR owner.fact_fingerprint IN old_fact_fingerprints)
       AND all(key IN keys(edge.properties) WHERE
           key IN $semantic_volatile_properties
-          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS compatible_mixed_owners
+          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS compatible_mixed_owners,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND all(token IN old_ownership_tokens WHERE
+          any(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix))) AS partial_existing_owner,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR rel[key] IS NULL OR rel[key] = edge.properties[key])) AS partial_compatible_owner
 FOREACH (_ IN CASE WHEN NOT observation_created AND replace_properties THEN [1] ELSE [] END |
   SET rel = edge.properties)
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
-       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners)
+       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
+            OR partial_existing_owner OR partial_compatible_owner)
   THEN [1] ELSE [] END |
   SET rel += edge.properties)
 SET rel.observation_properties_complete = CASE
-      WHEN observation_created THEN incoming_complete
+      WHEN observation_created THEN true
       WHEN replace_properties THEN true
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
+      WHEN partial_existing_owner THEN true
+      WHEN partial_compatible_owner THEN true
       ELSE false
     END,
     rel.observation_tokens = reduce(tokens = old_tokens, token IN edge.observation_tokens |
@@ -517,7 +562,7 @@ SET rel.observation_properties_complete = CASE
     rel.observation_semantics = edge.observation_semantics,
     rel.observation_fact_fingerprints = CASE
       WHEN replace_dependency_set THEN edge.observation_fact_fingerprints
-      WHEN (observation_created AND incoming_complete) OR replace_properties THEN
+      WHEN observation_created OR replace_properties OR partial_existing_owner OR partial_compatible_owner THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -536,7 +581,7 @@ SET rel.observation_properties_complete = CASE
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
-      WHEN incoming_complete THEN
+      WHEN incoming_authoritative THEN
         [fingerprint IN old_fact_fingerprints
          WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
            fingerprint STARTS WITH prefix)]
@@ -648,26 +693,26 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
      old_fact_fingerprints, old_properties_complete, old_ownership_tokens,
      (size(edge.ownership_tokens) > 0
       AND all(token IN edge.ownership_tokens WHERE
-          any(prefix IN edge.complete_domain_prefixes WHERE token STARTS WITH prefix))) AS incoming_complete
+          any(prefix IN edge.complete_domain_prefixes WHERE token STARTS WITH prefix))) AS incoming_authoritative
 WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
-     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_complete,
+     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_authoritative,
 	     (NOT observation_created
 	      AND edge.observation_semantics = 'all_dependencies'
-	      AND incoming_complete
+	      AND incoming_authoritative
 	      AND size(old_ownership_tokens) > 0) AS replace_dependency_set
 WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
-     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_complete,
+     old_fact_fingerprints, old_properties_complete, old_ownership_tokens, incoming_authoritative,
      replace_dependency_set,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND (replace_dependency_set
            OR all(token IN old_ownership_tokens WHERE
              any(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix)))) AS replace_properties
 WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
      old_fact_fingerprints, old_properties_complete, old_ownership_tokens,
-     incoming_complete, replace_dependency_set, replace_properties,
+     incoming_authoritative, replace_dependency_set, replace_properties,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
       AND none(token IN old_ownership_tokens WHERE
@@ -676,7 +721,7 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
           key IN $semantic_volatile_properties
           OR r[key] IS NULL OR r[key] = edge.properties[key])) AS compatible_new_owner,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
       AND size(edge.observation_fact_fingerprints) > 0
@@ -685,7 +730,7 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
       AND all(fingerprint IN edge.observation_fact_fingerprints WHERE
           fingerprint IN old_fact_fingerprints)) AS compatible_existing_owner,
      (NOT observation_created
-      AND incoming_complete
+      AND incoming_authoritative
       AND old_properties_complete
       AND size(old_ownership_tokens) > 0
       AND size(edge.observation_owner_fingerprints) =
@@ -702,12 +747,28 @@ WITH r, edge, observation_created, old_tokens, old_dependency_tokens,
           OR owner.fact_fingerprint IN old_fact_fingerprints)
       AND all(key IN keys(edge.properties) WHERE
           key IN $semantic_volatile_properties
-          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS compatible_mixed_owners
+          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS compatible_mixed_owners,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(prefix IN edge.observation_domain_prefixes WHERE
+          any(token IN old_ownership_tokens WHERE token STARTS WITH prefix))
+      AND all(token IN old_ownership_tokens WHERE
+          any(prefix IN edge.observation_domain_prefixes WHERE token STARTS WITH prefix))) AS partial_existing_owner,
+     (NOT observation_created
+      AND NOT incoming_authoritative
+      AND old_properties_complete
+      AND size(old_ownership_tokens) > 0
+      AND all(key IN keys(edge.properties) WHERE
+          key IN $semantic_volatile_properties
+          OR r[key] IS NULL OR r[key] = edge.properties[key])) AS partial_compatible_owner
 FOREACH (_ IN CASE WHEN observation_created OR replace_properties THEN [1] ELSE [] END |
   SET r = edge.properties)
 FOREACH (_ IN CASE
   WHEN NOT observation_created AND NOT replace_properties
-       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners)
+       AND (compatible_new_owner OR compatible_existing_owner OR compatible_mixed_owners
+            OR partial_existing_owner OR partial_compatible_owner)
   THEN [1] ELSE [] END |
   SET r += edge.properties)
 SET r.scan_id = $scan_id,
@@ -722,7 +783,7 @@ SET r.scan_id = $scan_id,
     r.observation_semantics = edge.observation_semantics,
     r.observation_fact_fingerprints = CASE
       WHEN replace_dependency_set THEN edge.observation_fact_fingerprints
-      WHEN (observation_created AND incoming_complete) OR replace_properties THEN
+      WHEN observation_created OR replace_properties OR partial_existing_owner OR partial_compatible_owner THEN
         reduce(fingerprints = [
           fingerprint IN old_fact_fingerprints
           WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
@@ -741,18 +802,20 @@ SET r.scan_id = $scan_id,
           CASE WHEN fingerprint IN fingerprints
             THEN fingerprints ELSE fingerprints + fingerprint END)
       WHEN compatible_existing_owner THEN old_fact_fingerprints
-      WHEN incoming_complete THEN
+      WHEN incoming_authoritative THEN
         [fingerprint IN old_fact_fingerprints
          WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes WHERE
            fingerprint STARTS WITH prefix)]
       ELSE old_fact_fingerprints
     END,
     r.observation_properties_complete = CASE
-      WHEN observation_created THEN incoming_complete
+      WHEN observation_created THEN true
       WHEN replace_properties THEN true
       WHEN compatible_new_owner THEN true
       WHEN compatible_existing_owner THEN true
       WHEN compatible_mixed_owners THEN true
+      WHEN partial_existing_owner THEN true
+      WHEN partial_compatible_owner THEN true
       ELSE false
     END
 REMOVE r.__agenthound_observation_created

--- a/server/internal/graph/writer_test.go
+++ b/server/internal/graph/writer_test.go
@@ -985,14 +985,15 @@ func TestPartialObservationUsesAdditivePropertyUpdates(t *testing.T) {
 	}
 	for _, fragment := range []string{
 		"AS partial_existing_owner",
-		"AS partial_compatible_owner",
-		"AS compatible_owner_recovery",
-		"NOT fingerprint IN old_fact_fingerprints",
+		"AS partial_new_owner",
+		"AS partial_coowner_noop",
+		"AS partial_coowner_addition",
+		"WHERE none(prefix IN node.observation_fingerprint_domain_prefixes",
 		"SET n += node.properties",
 		"WHEN observation_created THEN true",
-		"WHEN compatible_owner_recovery THEN true",
 		"WHEN partial_existing_owner THEN true",
-		"WHEN partial_compatible_owner THEN true",
+		"WHEN partial_coowner_noop THEN true",
+		"WHEN partial_coowner_addition THEN false",
 	} {
 		if !strings.Contains(call.Cypher, fragment) {
 			t.Fatalf("partial merge query missing %q:\n%s", fragment, call.Cypher)
@@ -1025,11 +1026,12 @@ func TestPartialObservationUsesAdditivePropertyUpdates(t *testing.T) {
 	edgeCall := recorder.snapshot()[1]
 	for _, fragment := range []string{
 		"AS partial_existing_owner",
-		"AS partial_compatible_owner",
-		"AS compatible_owner_recovery",
+		"AS partial_new_owner",
+		"AS partial_coowner_noop",
+		"AS partial_coowner_addition",
 		"SET r += edge.properties",
 		"WHEN observation_created THEN true",
-		"WHEN compatible_owner_recovery THEN true",
+		"WHEN partial_coowner_addition THEN false",
 	} {
 		if !strings.Contains(edgeCall.Cypher, fragment) {
 			t.Fatalf("partial edge query missing %q:\n%s", fragment, edgeCall.Cypher)
@@ -1037,7 +1039,7 @@ func TestPartialObservationUsesAdditivePropertyUpdates(t *testing.T) {
 	}
 }
 
-func TestRelationshipWritersRestoreCertifiedOwnerFingerprintAfterPartialSubset(
+func TestRelationshipWritersRejectCompatibleOwnerRecoveryShortcut(
 	t *testing.T,
 ) {
 	edge := ingest.Edge{
@@ -1067,14 +1069,17 @@ func TestRelationshipWritersRestoreCertifiedOwnerFingerprintAfterPartialSubset(
 			}
 			query := recorder.snapshot()[0].Cypher
 			for _, fragment := range []string{
-				"AS compatible_owner_recovery",
-				"NOT fingerprint IN old_fact_fingerprints",
-				"OR compatible_owner_recovery",
-				"WHEN compatible_owner_recovery THEN true",
+				"WHERE none(prefix IN edge.observation_fingerprint_domain_prefixes",
+				"AS partial_coowner_noop",
+				"AS partial_coowner_addition",
+				"WHEN partial_coowner_addition THEN false",
 			} {
 				if !strings.Contains(query, fragment) {
-					t.Fatalf("owner recovery query missing %q:\n%s", fragment, query)
+					t.Fatalf("owner quarantine query missing %q:\n%s", fragment, query)
 				}
+			}
+			if strings.Contains(query, "compatible_owner_recovery") {
+				t.Fatalf("unsafe compatible owner recovery remains:\n%s", query)
 			}
 		})
 	}

--- a/server/internal/graph/writer_test.go
+++ b/server/internal/graph/writer_test.go
@@ -905,7 +905,7 @@ func TestWriterReplacesCompleteAllDependencyOwnerSetAtomically(t *testing.T) {
 			}
 			for _, fragment := range []string{
 				"AS replace_dependency_set",
-				"AND incoming_complete",
+				"AND incoming_authoritative",
 				"AND (replace_dependency_set",
 				"WHEN replace_dependency_set THEN edge.observation_dependency_tokens",
 				"WHEN replace_dependency_set THEN edge.observation_fact_fingerprints",
@@ -956,6 +956,79 @@ func TestCompleteObservationReplacesManagedProperties(t *testing.T) {
 	}
 	if strings.Contains(call.Cypher, "REMOVE n:SchemaVersion") {
 		t.Fatal("managed replacement removes internal labels")
+	}
+}
+
+func TestPartialObservationUsesAdditivePropertyUpdates(t *testing.T) {
+	scope := "mcp:target:sha256:server-partial"
+	recorder := &recordedExec{}
+	writer := newTestWriter(recorder.exec, false)
+	node := ingest.Node{
+		ID:                 "server-partial",
+		Kinds:              []string{"MCPServer"},
+		ObservationDomains: []string{scope},
+		Properties:         map[string]any{"name": "observed"},
+	}
+
+	if _, err := writer.WriteObservationNodes(
+		context.Background(),
+		[]ingest.Node{node},
+		"scan-partial",
+		nil,
+	); err != nil {
+		t.Fatalf("WriteObservationNodes: %v", err)
+	}
+	call := recorder.snapshot()[0]
+	row := rowsAt(t, call.Params, "nodes")[0]
+	if prefixes, _ := row["complete_domain_prefixes"].([]string); len(prefixes) != 0 {
+		t.Fatalf("partial observation has authoritative prefixes: %v", prefixes)
+	}
+	for _, fragment := range []string{
+		"AS partial_existing_owner",
+		"AS partial_compatible_owner",
+		"SET n += node.properties",
+		"WHEN observation_created THEN NOT node.reference_only",
+		"WHEN partial_existing_owner THEN true",
+		"WHEN partial_compatible_owner THEN true",
+	} {
+		if !strings.Contains(call.Cypher, fragment) {
+			t.Fatalf("partial merge query missing %q:\n%s", fragment, call.Cypher)
+		}
+	}
+	if strings.Contains(
+		call.Cypher,
+		"CASE WHEN partial_existing_owner THEN [1] ELSE [] END | REMOVE",
+	) {
+		t.Fatalf("partial observation can remove labels:\n%s", call.Cypher)
+	}
+
+	edge := ingest.Edge{
+		Source:             "server-partial",
+		Target:             "host-partial",
+		Kind:               "RUNS_ON",
+		SourceKind:         "MCPServer",
+		TargetKind:         "Host",
+		ObservationDomains: []string{scope},
+		Properties:         map[string]any{"confidence": 0.8},
+	}
+	if _, err := writer.WriteObservationEdges(
+		context.Background(),
+		[]ingest.Edge{edge},
+		"scan-partial",
+		nil,
+	); err != nil {
+		t.Fatalf("WriteObservationEdges: %v", err)
+	}
+	edgeCall := recorder.snapshot()[1]
+	for _, fragment := range []string{
+		"AS partial_existing_owner",
+		"AS partial_compatible_owner",
+		"SET r += edge.properties",
+		"WHEN observation_created THEN true",
+	} {
+		if !strings.Contains(edgeCall.Cypher, fragment) {
+			t.Fatalf("partial edge query missing %q:\n%s", fragment, edgeCall.Cypher)
+		}
 	}
 }
 

--- a/server/internal/graph/writer_test.go
+++ b/server/internal/graph/writer_test.go
@@ -986,8 +986,11 @@ func TestPartialObservationUsesAdditivePropertyUpdates(t *testing.T) {
 	for _, fragment := range []string{
 		"AS partial_existing_owner",
 		"AS partial_compatible_owner",
+		"AS compatible_owner_recovery",
+		"NOT fingerprint IN old_fact_fingerprints",
 		"SET n += node.properties",
 		"WHEN observation_created THEN true",
+		"WHEN compatible_owner_recovery THEN true",
 		"WHEN partial_existing_owner THEN true",
 		"WHEN partial_compatible_owner THEN true",
 	} {
@@ -1023,12 +1026,57 @@ func TestPartialObservationUsesAdditivePropertyUpdates(t *testing.T) {
 	for _, fragment := range []string{
 		"AS partial_existing_owner",
 		"AS partial_compatible_owner",
+		"AS compatible_owner_recovery",
 		"SET r += edge.properties",
 		"WHEN observation_created THEN true",
+		"WHEN compatible_owner_recovery THEN true",
 	} {
 		if !strings.Contains(edgeCall.Cypher, fragment) {
 			t.Fatalf("partial edge query missing %q:\n%s", fragment, edgeCall.Cypher)
 		}
+	}
+}
+
+func TestRelationshipWritersRestoreCertifiedOwnerFingerprintAfterPartialSubset(
+	t *testing.T,
+) {
+	edge := ingest.Edge{
+		Source:             "server-recovery",
+		Target:             "host-recovery",
+		Kind:               "RUNS_ON",
+		SourceKind:         "MCPServer",
+		TargetKind:         "Host",
+		ObservationDomains: []string{"mcp:target:sha256:recovery"},
+		Properties:         map[string]any{"confidence": 1.0},
+	}
+	for _, hasAPOC := range []bool{false, true} {
+		name := "fallback"
+		if hasAPOC {
+			name = "apoc"
+		}
+		t.Run(name, func(t *testing.T) {
+			recorder := &recordedExec{}
+			writer := newTestWriter(recorder.exec, hasAPOC)
+			if _, err := writer.WriteObservationEdges(
+				context.Background(),
+				[]ingest.Edge{edge},
+				"complete-recovery",
+				edge.ObservationDomains,
+			); err != nil {
+				t.Fatalf("WriteObservationEdges: %v", err)
+			}
+			query := recorder.snapshot()[0].Cypher
+			for _, fragment := range []string{
+				"AS compatible_owner_recovery",
+				"NOT fingerprint IN old_fact_fingerprints",
+				"OR compatible_owner_recovery",
+				"WHEN compatible_owner_recovery THEN true",
+			} {
+				if !strings.Contains(query, fragment) {
+					t.Fatalf("owner recovery query missing %q:\n%s", fragment, query)
+				}
+			}
+		})
 	}
 }
 

--- a/server/internal/graph/writer_test.go
+++ b/server/internal/graph/writer_test.go
@@ -987,7 +987,7 @@ func TestPartialObservationUsesAdditivePropertyUpdates(t *testing.T) {
 		"AS partial_existing_owner",
 		"AS partial_compatible_owner",
 		"SET n += node.properties",
-		"WHEN observation_created THEN NOT node.reference_only",
+		"WHEN observation_created THEN true",
 		"WHEN partial_existing_owner THEN true",
 		"WHEN partial_compatible_owner THEN true",
 	} {
@@ -1065,6 +1065,7 @@ func TestReferenceOnlyObservationPreservesAuthoritativeProperties(t *testing.T) 
 		"old_authoritative_tokens",
 		"AND NOT node.reference_only",
 		"old_properties_complete OR",
+		"WHEN observation_created THEN true",
 		"n.observation_reference_tokens",
 		"NOT replace_properties AND NOT node.reference_only",
 	} {

--- a/server/internal/ingest/lifecycle.go
+++ b/server/internal/ingest/lifecycle.go
@@ -39,6 +39,28 @@ func collectionState(report *sdkingest.CollectionReport) sdkingest.OutcomeState 
 	return report.State
 }
 
+func cloneCollectionReport(report *sdkingest.CollectionReport) sdkingest.CollectionReport {
+	if report == nil {
+		return sdkingest.CollectionReport{}
+	}
+	cloned := *report
+	cloned.CoverageKeys = append([]string(nil), report.CoverageKeys...)
+	cloned.Outcomes = append([]sdkingest.CollectionOutcome(nil), report.Outcomes...)
+	cloned.AuthoritativeRoots = make([]sdkingest.CoverageRoot, len(report.AuthoritativeRoots))
+	for i, root := range report.AuthoritativeRoots {
+		cloned.AuthoritativeRoots[i] = root
+		cloned.AuthoritativeRoots[i].ChildCoverageKeys = append(
+			[]string(nil),
+			root.ChildCoverageKeys...,
+		)
+		if root.RegistryContract != nil {
+			contract := *root.RegistryContract
+			cloned.AuthoritativeRoots[i].RegistryContract = &contract
+		}
+	}
+	return cloned
+}
+
 func mergeCoverage(groups ...[]string) []string {
 	seen := make(map[string]bool)
 	var merged []string

--- a/server/internal/ingest/lifecycle.go
+++ b/server/internal/ingest/lifecycle.go
@@ -39,22 +39,6 @@ func collectionState(report *sdkingest.CollectionReport) sdkingest.OutcomeState 
 	return report.State
 }
 
-func incompleteCoverageDomains(report *sdkingest.CollectionReport) []string {
-	nonBlocking := make(map[string]bool)
-	for _, key := range sdkingest.NonBlockingInstructionCoverageDomains(report) {
-		nonBlocking[key] = true
-	}
-	states := sdkingest.CoverageStates(report)
-	domains := make([]string, 0, len(states))
-	for domain, state := range states {
-		if state != sdkingest.OutcomeComplete && !nonBlocking[domain] {
-			domains = append(domains, domain)
-		}
-	}
-	sort.Strings(domains)
-	return domains
-}
-
 func mergeCoverage(groups ...[]string) []string {
 	seen := make(map[string]bool)
 	var merged []string
@@ -88,6 +72,26 @@ func subtractCoverage(keys []string, replaced ...[]string) []string {
 		}
 	}
 	return remaining
+}
+
+func graphObservationDomains(graph sdkingest.GraphData) []string {
+	var groups [][]string
+	for _, node := range graph.Nodes {
+		groups = append(groups, node.ObservationDomains)
+	}
+	for _, edge := range graph.Edges {
+		groups = append(groups, edge.ObservationDomains)
+	}
+	return mergeCoverage(groups...)
+}
+
+func appendWarningOnce(warnings []string, warning string) []string {
+	for _, existing := range warnings {
+		if existing == warning {
+			return warnings
+		}
+	}
+	return append(warnings, warning)
 }
 
 // prepareObservationDomains verifies the strict-v5 ownership contract after

--- a/server/internal/ingest/pipeline.go
+++ b/server/internal/ingest/pipeline.go
@@ -180,10 +180,10 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	}
 
 	result.Collection = *data.Meta.Collection
-	if sdkingest.InstructionCoverageLimited(data.Meta.Collection) {
+	if sdkingest.CoverageLimited(data.Meta.Collection) {
 		result.Warnings = append(
 			result.Warnings,
-			sdkingest.InstructionCoverageLimitationWarning,
+			sdkingest.CoverageLimitationWarning,
 		)
 	}
 	stageStart = time.Now()
@@ -231,11 +231,6 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 
 	attributionComplete := prepareObservationDomains(data)
 	keys := coverageKeys(data.Meta.Collection)
-	// Recognized incomplete instruction roots are non-blocking. Their complete
-	// children may advance without granting the root absence authority.
-	nonBlockingKeys := sdkingest.NonBlockingInstructionCoverageDomains(
-		data.Meta.Collection,
-	)
 	observedCompleteDomains := sdkingest.CompleteCoverageDomains(
 		data.Meta.Collection,
 	)
@@ -249,9 +244,6 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		coverageRoots = nil
 		authoritativeRoots = nil
 	}
-	coverageComplete := sdkingest.AuthoritativeCoverageComplete(data.Meta.Collection) &&
-		attributionComplete &&
-		normalizationDegradedErr == nil
 	// Preserve owner-scoped contributions through the pipeline. The graph
 	// writer fingerprints each original owner before deterministically
 	// coalescing compatible contributions into unique database rows.
@@ -308,6 +300,10 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		return nil, fmt.Errorf("resolve authoritative coverage: %w", err)
 	}
 	reconciliationDomains := mergeCoverage(completeDomains, retiredDomains)
+	mutationDomains := mergeCoverage(
+		graphObservationDomains(writeGraph),
+		reconciliationDomains,
+	)
 	var normalizationDirtyDomains []string
 	if normalizationDegradedErr != nil {
 		normalizationDirtyDomains = observedCompleteDomains
@@ -316,8 +312,7 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		ctx,
 		initialScan,
 		mergeCoverage(
-			subtractCoverage(keys, nonBlockingKeys),
-			reconciliationDomains,
+			mutationDomains,
 			normalizationDirtyDomains,
 		),
 		sdkingest.CoverageParents(data.Meta.Collection),
@@ -358,7 +353,7 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	if err != nil {
 		appendStage(result, "write_nodes", sdkingest.OutcomeFailed, true, stageStart, err)
 		appendStage(result, "write_edges", sdkingest.OutcomeNotApplicable, true, time.Now(), nil)
-		p.finishWriteFailure(ctx, data, result, graphBefore, reconciliationDomains, fmt.Errorf("write nodes: %w", err))
+		p.finishWriteFailure(ctx, data, result, graphBefore, mutationDomains, fmt.Errorf("write nodes: %w", err))
 		result.Duration = time.Since(start)
 		return result, fmt.Errorf("write nodes: %w", err)
 	}
@@ -376,15 +371,14 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	result.WriteRows.Edges = edgesWritten
 	if err != nil {
 		appendStage(result, "write_edges", sdkingest.OutcomeFailed, true, stageStart, err)
-		p.finishWriteFailure(ctx, data, result, graphBefore, reconciliationDomains, fmt.Errorf("write edges: %w", err))
+		p.finishWriteFailure(ctx, data, result, graphBefore, mutationDomains, fmt.Errorf("write edges: %w", err))
 		result.Duration = time.Since(start)
 		return result, fmt.Errorf("write edges: %w", err)
 	}
 	appendStage(result, "write_edges", sdkingest.OutcomeComplete, true, stageStart, nil)
 	slog.Info("edges written", "count", edgesWritten)
 
-	pristineEmptyProjection := coverageComplete &&
-		sdkingest.CollectionCoverageComplete(data.Meta.Collection) &&
+	pristineEmptyProjection := sdkingest.CollectionCoverageComplete(data.Meta.Collection) &&
 		graphBefore != nil &&
 		graphBefore.TotalNodes == 0 &&
 		graphBefore.TotalEdges == 0 &&
@@ -406,7 +400,7 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	if pristineEmptyProjection {
 		appendStage(result, "reconcile_observations", sdkingest.OutcomeComplete, true, stageStart, nil)
 	} else if len(reconciliationDomains) == 0 {
-		appendStage(result, "reconcile_observations", sdkingest.OutcomeUnknown, true, stageStart, nil)
+		appendStage(result, "reconcile_observations", sdkingest.OutcomeNotApplicable, false, stageStart, nil)
 	} else {
 		reconciliation, reconcileErr = graph.ReconcileObservations(
 			ctx,
@@ -425,8 +419,9 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		promotedDomains = nil
 	}
 
-	// Stage 8: Post-processing. Any promoted raw domain starts a fresh global
-	// composite epoch, rebuilt from the retained current raw projection.
+	// Stage 8: Post-processing. Any accepted raw mutation or promoted absence
+	// authority starts a fresh global composite epoch, rebuilt from the
+	// retained current raw projection.
 	var ppErr error
 	stageStart = time.Now()
 	if pristineEmptyProjection && p.graphDB != nil && p.runPP != nil {
@@ -437,7 +432,7 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 			ctx,
 			p.graphDB,
 			data.Meta.ScanID,
-			promotedDomains,
+			mutationDomains,
 		)
 		if ppErr != nil {
 			slog.Error("post-processing failed", "error", ppErr)
@@ -485,11 +480,6 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 			nil,
 		)
 	}
-	finalizedDomains := promotedDomains
-	if pruneErr != nil {
-		finalizedDomains = nil
-	}
-
 	// Stage 10: Verify property completeness for public managed raw facts.
 	var (
 		observationCompleteness  graph.ObservationCompleteness
@@ -629,8 +619,20 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	}
 	result.Findings = len(snapshot)
 
-	publicationDomains := finalizedDomains
-	if observationQueryErr != nil || observationIncompleteErr != nil {
+	publicationDomains := mutationDomains
+	if !attributionComplete ||
+		normalizationDegradedErr != nil ||
+		rulesetErr != nil ||
+		artifactObservedAt == nil ||
+		timestampErr != nil ||
+		reconcileErr != nil ||
+		pruneErr != nil ||
+		ppErr != nil ||
+		graphBeforeErr != nil ||
+		graphAfterErr != nil ||
+		snapshotErr != nil ||
+		observationQueryErr != nil ||
+		observationIncompleteErr != nil {
 		publicationDomains = nil
 	}
 	publicationCompleteDomains := completeDomains
@@ -656,29 +658,19 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		snapshotErr == nil &&
 		observationQueryErr == nil &&
 		observationIncompleteErr == nil
-	resolvedDirtyCoverage := append(
-		[]string(nil),
-		publicationRetiredDomains...,
+	resolvedDirtyCoverage := mergeCoverage(
+		publicationRetiredDomains,
+		publicationDomains,
 	)
 	dirtyCoverage := append([]string(nil), cumulativeDirtyCoverage...)
 	if projectionPrerequisitesComplete {
 		dirtyCoverage = subtractCoverage(
 			cumulativeDirtyCoverage,
-			publicationDomains,
-			nonBlockingKeys,
-		)
-		dirtyCoverage = mergeCoverage(
-			dirtyCoverage,
-			incompleteCoverageDomains(data.Meta.Collection),
-		)
-		resolvedDirtyCoverage = mergeCoverage(
 			resolvedDirtyCoverage,
-			nonBlockingKeys,
 		)
 	}
 
-	requiredComplete := coverageComplete &&
-		projectionPrerequisitesComplete &&
+	requiredComplete := projectionPrerequisitesComplete &&
 		p.graphDB != nil &&
 		p.runPP != nil
 	publish := requiredComplete && len(dirtyCoverage) == 0
@@ -686,7 +678,7 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	graphStatus := model.LifecyclePartial
 	if data.Meta.Collection == nil {
 		graphStatus = model.LifecycleUnknown
-	} else if coverageComplete &&
+	} else if p.graphDB != nil &&
 		reconcileErr == nil &&
 		pruneErr == nil &&
 		observationQueryErr == nil &&
@@ -707,12 +699,14 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	finalStatus := model.ScanStatusCompletedWithErrors
 	projectionStatus := model.ProjectionIncomplete
 	if publish {
-		finalStatus = model.ScanStatusCompleted
+		if !sdkingest.CoverageLimited(data.Meta.Collection) {
+			finalStatus = model.ScanStatusCompleted
+		}
 		projectionStatus = model.ProjectionComplete
 	}
 	var coverageErr error
-	if !coverageComplete {
-		coverageErr = fmt.Errorf("collection coverage is partial, unknown, or lacks per-fact attribution")
+	if sdkingest.CoverageLimited(data.Meta.Collection) {
+		coverageErr = fmt.Errorf("%s", sdkingest.CoverageLimitationWarning)
 	}
 	var dirtyCoverageErr error
 	if len(dirtyCoverage) > 0 {
@@ -806,7 +800,7 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		publicationErr := fmt.Errorf("publication: %w", err)
 		failureDirtyCoverage := mergeCoverage(
 			dirtyCoverage,
-			reconciliationDomains,
+			mutationDomains,
 		)
 		result.Stages[len(result.Stages)-1].State = sdkingest.OutcomeFailed
 		result.Stages[len(result.Stages)-1].Error = publicationErr.Error()
@@ -839,6 +833,12 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 	}
 	if publication != nil {
 		result.PublishedRevision = publication.Revision
+		if len(publication.ActiveCoverageLimitations) > 0 {
+			result.Warnings = appendWarningOnce(
+				result.Warnings,
+				sdkingest.CoverageLimitationWarning,
+			)
+		}
 		if publish && !publication.Published {
 			publish = false
 			result.Stages[len(result.Stages)-1].State = sdkingest.OutcomeNotApplicable

--- a/server/internal/ingest/pipeline.go
+++ b/server/internal/ingest/pipeline.go
@@ -179,13 +179,6 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 		return nil, err
 	}
 
-	result.Collection = *data.Meta.Collection
-	if sdkingest.CoverageLimited(data.Meta.Collection) {
-		result.Warnings = append(
-			result.Warnings,
-			sdkingest.CoverageLimitationWarning,
-		)
-	}
 	stageStart = time.Now()
 	rulesetState, rulesetErr := rulesetPublicationState(data.Meta.Ruleset)
 	appendStage(result, "ruleset", rulesetState, true, stageStart, rulesetErr)
@@ -226,6 +219,14 @@ func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdk
 			"normalization warnings",
 			"count", len(normalizationWarnings),
 			"status", result.NormalizationStatus,
+		)
+	}
+
+	result.Collection = cloneCollectionReport(data.Meta.Collection)
+	if sdkingest.CoverageLimited(data.Meta.Collection) {
+		result.Warnings = appendWarningOnce(
+			result.Warnings,
+			sdkingest.CoverageLimitationWarning,
 		)
 	}
 

--- a/server/internal/ingest/pipeline_test.go
+++ b/server/internal/ingest/pipeline_test.go
@@ -463,10 +463,11 @@ func (s *fakeScanStore) lastUpdate(id string) (scanUpdate, bool) {
 }
 
 type fakePublisher struct {
-	finalizations []appdb.FinalizeScanParams
-	err           error
-	lifecycle     *fakeLifecycleScanStore
-	scanStore     *fakeScanStore
+	finalizations             []appdb.FinalizeScanParams
+	activeCoverageLimitations []model.PostureCoverageLimitation
+	err                       error
+	lifecycle                 *fakeLifecycleScanStore
+	scanStore                 *fakeScanStore
 }
 
 func (p *fakePublisher) FinalizeScan(
@@ -514,6 +515,10 @@ func (p *fakePublisher) FinalizeScan(
 		Revision:    &revision,
 		PublishedAt: &publishedAt,
 		Published:   true,
+		ActiveCoverageLimitations: append(
+			[]model.PostureCoverageLimitation(nil),
+			p.activeCoverageLimitations...,
+		),
 	}, nil
 }
 
@@ -984,6 +989,74 @@ func TestPipelineReportsRecognizedCollectionPoint(t *testing.T) {
 	}
 	if result.Identity.Recognition != "recognized" {
 		t.Fatalf("recognition = %q, want recognized", result.Identity.Recognition)
+	}
+}
+
+func TestPipelineReceiptUsesFinalizedDeepClonedCollection(t *testing.T) {
+	data := validIngestDataFor("finalized-collection-receipt")
+	rawCoverageKey := data.Meta.Collection.CoverageKeys[0]
+	pipeline := newTestPipeline(
+		&fakeWriter{},
+		&graph.MockGraphDB{},
+		&fakeScanStore{},
+		noOpRunPP,
+	)
+	result, err := pipeline.Ingest(context.Background(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Collection.CoverageKeys) != 1 ||
+		result.Collection.CoverageKeys[0] == rawCoverageKey ||
+		result.Collection.CoverageKeys[0] != data.Meta.Collection.CoverageKeys[0] {
+		t.Fatalf(
+			"receipt coverage = %v, finalized coverage = %v, raw = %q",
+			result.Collection.CoverageKeys,
+			data.Meta.Collection.CoverageKeys,
+			rawCoverageKey,
+		)
+	}
+	wantCoverageKey := result.Collection.CoverageKeys[0]
+	wantOutcome := result.Collection.Outcomes[0]
+	data.Meta.Collection.CoverageKeys[0] = "mutated-after-ingest"
+	data.Meta.Collection.Outcomes[0].CoverageKey = "mutated-after-ingest"
+	data.Meta.Collection.Outcomes[0].Error = "mutated-after-ingest"
+	if result.Collection.CoverageKeys[0] != wantCoverageKey ||
+		result.Collection.Outcomes[0] != wantOutcome {
+		t.Fatalf("submitted report mutated receipt clone: %+v", result.Collection)
+	}
+}
+
+func TestCloneCollectionReportClonesNestedRoots(t *testing.T) {
+	contract := sdkingest.RegistryContract{Generation: 7, Digest: "sha256:contract"}
+	report := &sdkingest.CollectionReport{
+		State:        sdkingest.OutcomeComplete,
+		CoverageKeys: []string{"root", "child"},
+		AuthoritativeRoots: []sdkingest.CoverageRoot{{
+			CoverageKey:       "root",
+			ChildCoverageKeys: []string{"child"},
+			RegistryContract:  &contract,
+		}},
+		Outcomes: []sdkingest.CollectionOutcome{{
+			CoverageKey: "child",
+			State:       sdkingest.OutcomeComplete,
+		}},
+	}
+	cloned := cloneCollectionReport(report)
+	report.CoverageKeys[0] = "changed-root"
+	report.AuthoritativeRoots[0].CoverageKey = "changed-root"
+	report.AuthoritativeRoots[0].ChildCoverageKeys[0] = "changed-child"
+	report.AuthoritativeRoots[0].RegistryContract.Digest = "changed-digest"
+	report.Outcomes[0].CoverageKey = "changed-child"
+
+	if !slices.Equal(cloned.CoverageKeys, []string{"root", "child"}) ||
+		cloned.AuthoritativeRoots[0].CoverageKey != "root" ||
+		!slices.Equal(
+			cloned.AuthoritativeRoots[0].ChildCoverageKeys,
+			[]string{"child"},
+		) ||
+		cloned.AuthoritativeRoots[0].RegistryContract.Digest != "sha256:contract" ||
+		cloned.Outcomes[0].CoverageKey != "child" {
+		t.Fatalf("nested collection clone was mutated: %+v", cloned)
 	}
 }
 
@@ -2001,6 +2074,57 @@ func TestPipeline_FailedCollectionDoesNotQuarantineUnchangedGraph(t *testing.T) 
 	finalized := publisher.finalizations[1]
 	if !finalized.Publish || len(finalized.DirtyCoverage) != 0 {
 		t.Fatalf("config finalization = %+v, want no graph dirtiness", finalized)
+	}
+}
+
+func TestPipelineReceiptWarnsForPersistentActiveCoverageLimitations(t *testing.T) {
+	tests := []struct {
+		name        string
+		limitations []model.PostureCoverageLimitation
+		wantWarning bool
+	}{
+		{name: "none", wantWarning: false},
+		{
+			name: "unrelated persistent limitation",
+			limitations: []model.PostureCoverageLimitation{{
+				CoverageKey: "mcp:network:sha256:persistent",
+				State:       sdkingest.OutcomePartial,
+				ScanID:      "earlier-limited-scan",
+			}},
+			wantWarning: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			publisher := &fakePublisher{
+				activeCoverageLimitations: test.limitations,
+			}
+			pipeline := newTestPipeline(
+				&fakeWriter{},
+				&graph.MockGraphDB{},
+				&fakeScanStore{},
+				noOpRunPP,
+			)
+			pipeline.findingStore = publisher
+			result, err := pipeline.Ingest(
+				context.Background(),
+				validIngestDataFor("clean-receipt-"+strings.ReplaceAll(test.name, " ", "-")),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			hasWarning := slices.Contains(
+				result.Warnings,
+				sdkingest.CoverageLimitationWarning,
+			)
+			if hasWarning != test.wantWarning {
+				t.Fatalf(
+					"warnings = %v, want coverage warning %t",
+					result.Warnings,
+					test.wantWarning,
+				)
+			}
+		})
 	}
 }
 

--- a/server/internal/ingest/pipeline_test.go
+++ b/server/internal/ingest/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1161,12 +1162,12 @@ func TestPipeline_ExhaustiveRootReconcilesRemovedChildAsCompleteEmpty(t *testing
 		strings.Join(mergeCoverage([]string{scopedCurrentChild, scopedNetworkRoot, scopedPointRoot}), "\x00") {
 		t.Fatalf("promoted heads = %v, want current child and root", got)
 	}
-	if len(finalized.ResolvedDirtyCoverage) != 1 ||
-		finalized.ResolvedDirtyCoverage[0] != scopedRemovedChild {
+	if got := finalized.ResolvedDirtyCoverage; strings.Join(got, "\x00") !=
+		strings.Join(wantReconciled, "\x00") {
 		t.Fatalf(
-			"resolved removed coverage = %v, want [%s]",
-			finalized.ResolvedDirtyCoverage,
-			scopedRemovedChild,
+			"resolved mutation coverage = %v, want %v",
+			got,
+			wantReconciled,
 		)
 	}
 	if len(finalized.AuthoritativeRoots) != 2 {
@@ -1239,8 +1240,10 @@ func TestPipeline_CompleteEmptyRootClearsFailedUnheadedChild(t *testing.T) {
 	}
 	if len(publisher.finalizations) != 1 ||
 		!publisher.finalizations[0].Publish ||
-		len(publisher.finalizations[0].ResolvedDirtyCoverage) != 1 ||
-		publisher.finalizations[0].ResolvedDirtyCoverage[0] != scopedFailedChild {
+		strings.Join(
+			publisher.finalizations[0].ResolvedDirtyCoverage,
+			"\x00",
+		) != strings.Join(wantReconciled, "\x00") {
 		t.Fatalf("complete-empty finalization = %+v", publisher.finalizations)
 	}
 	if len(lifecycle.dirtyCoverage) != 0 {
@@ -1411,10 +1414,10 @@ func TestPipeline_LimitedExactRootPublishesChildWithoutRootAuthority(t *testing.
 		containsCoverage(finalized.CompleteDomains, scopedRoot) {
 		t.Fatalf("complete domains = %v, want child only for limited root", finalized.CompleteDomains)
 	}
-	if !containsCoverage(finalized.ResolvedDirtyCoverage, scopedRoot) ||
+	if containsCoverage(finalized.ResolvedDirtyCoverage, scopedRoot) ||
 		!containsCoverage(finalized.ResolvedDirtyCoverage, scopedChild) {
 		t.Fatalf(
-			"resolved dirty coverage = %v, want processed limited root and child",
+			"resolved dirty coverage = %v, want mutated child but not limitation-only root",
 			finalized.ResolvedDirtyCoverage,
 		)
 	}
@@ -1477,14 +1480,18 @@ func TestPipeline_LimitedExactDirtyResolutionIsSuccessfulAndSeenOnly(t *testing.
 		t.Fatalf("unseen dirty sibling unexpectedly published: %+v", result)
 	}
 	finalized := publisher.finalizations[0]
-	if !containsCoverage(finalized.ResolvedDirtyCoverage, scopedRoot) ||
+	if containsCoverage(finalized.ResolvedDirtyCoverage, scopedRoot) ||
 		!containsCoverage(finalized.ResolvedDirtyCoverage, scopedChild) ||
 		containsCoverage(finalized.ResolvedDirtyCoverage, unseenSibling) {
 		t.Fatalf("resolved dirty coverage = %v", finalized.ResolvedDirtyCoverage)
 	}
-	if len(finalized.DirtyCoverage) != 1 ||
-		finalized.DirtyCoverage[0] != unseenSibling {
-		t.Fatalf("final dirty coverage = %v, want unseen sibling", finalized.DirtyCoverage)
+	if !containsCoverage(finalized.DirtyCoverage, scopedRoot) ||
+		!containsCoverage(finalized.DirtyCoverage, unseenSibling) ||
+		containsCoverage(finalized.DirtyCoverage, scopedChild) {
+		t.Fatalf(
+			"final dirty coverage = %v, want unresolved root and unseen sibling",
+			finalized.DirtyCoverage,
+		)
 	}
 }
 
@@ -1610,7 +1617,7 @@ func TestPipeline_PartialOrFailedDeepDoesNotSeedDeepDirtiness(t *testing.T) {
 	}
 }
 
-func TestPipeline_PartialCurrentChildPreventsRootRetirement(t *testing.T) {
+func TestPipeline_PartialCurrentChildPublishesWithoutRootRetirement(t *testing.T) {
 	currentChild := sdkingest.CanonicalCoverageKey(
 		"mcp",
 		"target",
@@ -1663,8 +1670,13 @@ func TestPipeline_PartialCurrentChildPreventsRootRetirement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ingest: %v", err)
 	}
-	if result.Outcome != sdkingest.OutcomePartial {
-		t.Fatalf("partial result = %+v", result)
+	if result.Outcome != sdkingest.OutcomeComplete ||
+		result.ProjectionStatus != model.ProjectionComplete ||
+		result.PublishedRevision == nil {
+		t.Fatalf("limited result = %+v, want published projection", result)
+	}
+	if !slices.Contains(result.Warnings, sdkingest.CoverageLimitationWarning) {
+		t.Fatalf("limited result warnings = %v", result.Warnings)
 	}
 	if len(store.resolvedRoots) != 0 {
 		t.Fatalf("partial child resolved authoritative roots: %+v", store.resolvedRoots)
@@ -1783,39 +1795,57 @@ func TestPipeline_SnapshotFailureFinalizesExplicitEmptySnapshot(t *testing.T) {
 	}
 }
 
-func TestPipeline_PartialCoverageNeverPublishesOrReconciles(t *testing.T) {
+func TestPipeline_PartialCoveragePublishesWithoutAbsenceReconciliation(t *testing.T) {
 	w := &fakeWriter{}
-	ss := &fakeScanStore{}
+	lifecycle := &fakeLifecycleScanStore{fakeScanStore: &fakeScanStore{}}
 	db := &graph.MockGraphDB{}
-	publisher := &fakePublisher{scanStore: ss}
+	publisher := &fakePublisher{lifecycle: lifecycle}
 	var ppDomains []string
 	runPP := func(_ context.Context, _ graph.GraphDB, _ string, completeDomains []string) ([]graph.ProcessingStats, error) {
 		ppDomains = append([]string(nil), completeDomains...)
 		return nil, nil
 	}
-	p := newTestPipeline(w, db, ss, runPP)
+	p := newTestPipeline(w, db, lifecycle, runPP)
 	p.findingStore = publisher
 
 	data := validIngestDataFor("scan-partial")
 	data.Meta.Collection.State = sdkingest.OutcomePartial
 	data.Meta.Collection.Outcomes[0].State = sdkingest.OutcomePartial
-	data.Graph = sdkingest.GraphData{Nodes: []sdkingest.Node{}, Edges: []sdkingest.Edge{}}
 	result, err := p.Ingest(context.Background(), data)
 	if err != nil {
 		t.Fatalf("Ingest: %v", err)
 	}
-	if result.Outcome != sdkingest.OutcomePartial ||
-		result.ProjectionStatus != model.ProjectionIncomplete {
-		t.Fatalf("result = %+v, want partial incomplete projection", result)
+	scope := data.Meta.Collection.CoverageKeys[0]
+	if result.Outcome != sdkingest.OutcomeComplete ||
+		result.ProjectionStatus != model.ProjectionComplete ||
+		result.PublishedRevision == nil {
+		t.Fatalf("result = %+v, want published limited projection", result)
 	}
-	if len(publisher.finalizations) != 1 || publisher.finalizations[0].Publish {
-		t.Fatalf("partial scan publication = %+v, want withheld", publisher.finalizations)
+	if len(publisher.finalizations) != 1 || !publisher.finalizations[0].Publish {
+		t.Fatalf("partial scan publication = %+v, want published", publisher.finalizations)
 	}
 	if len(publisher.finalizations[0].CompleteDomains) != 0 {
 		t.Fatalf("partial domains promoted: %v", publisher.finalizations[0].CompleteDomains)
 	}
-	if len(ppDomains) != 0 {
-		t.Fatalf("partial coverage enabled composite replacement: %v", ppDomains)
+	if !slices.Equal(ppDomains, []string{scope}) {
+		t.Fatalf("partial positive analysis domains = %v, want [%s]", ppDomains, scope)
+	}
+	if len(lifecycle.beginDirtyCoverage) != 1 ||
+		!slices.Equal(lifecycle.beginDirtyCoverage[0], []string{scope}) {
+		t.Fatalf(
+			"partial positive dirty coverage = %v, want mutation scope",
+			lifecycle.beginDirtyCoverage,
+		)
+	}
+	if !slices.Equal(
+		publisher.finalizations[0].ResolvedDirtyCoverage,
+		[]string{scope},
+	) {
+		t.Fatalf(
+			"partial positive resolved coverage = %v, want [%s]",
+			publisher.finalizations[0].ResolvedDirtyCoverage,
+			scope,
+		)
 	}
 	if got := len(db.CallsTo("ExecuteWrite")); got != 0 {
 		t.Fatalf("partial coverage executed %d retirement writes", got)
@@ -1902,7 +1932,7 @@ func TestPipeline_IncompleteRulesetWithholdsPublication(t *testing.T) {
 	}
 }
 
-func TestPipeline_FailedMCPThenSuccessfulConfigKeepsMCPDirty(t *testing.T) {
+func TestPipeline_FailedCollectionDoesNotQuarantineUnchangedGraph(t *testing.T) {
 	lifecycle := &fakeLifecycleScanStore{fakeScanStore: &fakeScanStore{}}
 	publisher := &fakePublisher{lifecycle: lifecycle}
 	p := newTestPipeline(
@@ -1921,8 +1951,13 @@ func TestPipeline_FailedMCPThenSuccessfulConfigKeepsMCPDirty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed MCP ingest: %v", err)
 	}
-	if first.Outcome != sdkingest.OutcomePartial {
+	if first.Outcome != sdkingest.OutcomeComplete ||
+		first.ProjectionStatus != model.ProjectionComplete ||
+		first.PublishedRevision == nil {
 		t.Fatalf("failed MCP result = %+v", first)
+	}
+	if !slices.Contains(first.Warnings, sdkingest.CoverageLimitationWarning) {
+		t.Fatalf("failed MCP warnings = %v", first.Warnings)
 	}
 
 	successfulConfig := validIngestDataFor("scan-successful-config")
@@ -1955,18 +1990,17 @@ func TestPipeline_FailedMCPThenSuccessfulConfigKeepsMCPDirty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("successful config ingest: %v", err)
 	}
-	if second.Outcome != sdkingest.OutcomePartial ||
-		second.ProjectionStatus != model.ProjectionIncomplete {
-		t.Fatalf("config result laundered MCP dirtiness: %+v", second)
+	if second.Outcome != sdkingest.OutcomeComplete ||
+		second.ProjectionStatus != model.ProjectionComplete ||
+		second.PublishedRevision == nil {
+		t.Fatalf("config result = %+v, want published projection", second)
 	}
 	if len(publisher.finalizations) != 2 {
 		t.Fatalf("finalizations = %d, want two", len(publisher.finalizations))
 	}
 	finalized := publisher.finalizations[1]
-	if finalized.Publish ||
-		len(finalized.DirtyCoverage) != 1 ||
-		finalized.DirtyCoverage[0] != failedMCP.Meta.Collection.CoverageKeys[0] {
-		t.Fatalf("config finalization = %+v, want dirty MCP only", finalized)
+	if !finalized.Publish || len(finalized.DirtyCoverage) != 0 {
+		t.Fatalf("config finalization = %+v, want no graph dirtiness", finalized)
 	}
 }
 
@@ -1977,7 +2011,11 @@ func TestPipeline_PublicationFailureMarksProjectionIncomplete(t *testing.T) {
 	p := newTestPipeline(w, &graph.MockGraphDB{}, ss, noOpRunPP)
 	p.findingStore = publisher
 
-	result, err := p.Ingest(context.Background(), validIngestDataFor("scan-publication-fail"))
+	data := validIngestDataFor("scan-publication-fail")
+	data.Meta.Collection.State = sdkingest.OutcomePartial
+	data.Meta.Collection.Outcomes[0].State = sdkingest.OutcomePartial
+	result, err := p.Ingest(context.Background(), data)
+	scope := data.Meta.Collection.CoverageKeys[0]
 
 	if err != nil {
 		t.Fatalf("post-write publication failure should be represented in stages: %v", err)
@@ -1993,6 +2031,13 @@ func TestPipeline_PublicationFailureMarksProjectionIncomplete(t *testing.T) {
 	update, ok := ss.lastUpdate("scan-publication-fail")
 	if !ok || update.Status != model.ScanStatusCompletedWithErrors {
 		t.Fatalf("failure lifecycle update = %+v, found=%t", update, ok)
+	}
+	if len(ss.failures) != 1 ||
+		!containsCoverage(ss.failures[0].DirtyCoverage, scope) {
+		t.Fatalf(
+			"partial graph mutation escaped dirty quarantine: %+v",
+			ss.failures,
+		)
 	}
 }
 

--- a/server/internal/ingest/validator.go
+++ b/server/internal/ingest/validator.go
@@ -293,7 +293,6 @@ func (v *Validator) Validate(data *ingest.IngestData) error {
 	}
 	errs = append(errs, validateRuleset(data.Meta.Ruleset)...)
 	errs = append(errs, validateIdentitySchemes(data.Meta.IdentitySchemes)...)
-	coverageStates := ingest.CoverageStates(data.Meta.Collection)
 	if data.Graph.Nodes == nil {
 		errs = append(errs, FieldError{Path: "graph.nodes", Message: "must be a non-null array"})
 	}
@@ -331,11 +330,6 @@ func (v *Validator) Validate(data *ingest.IngestData) error {
 		errs = append(errs, validateObservationDomains(
 			node.ObservationDomains,
 			declaredCoverage,
-			fmt.Sprintf("graph.nodes[%d].observation_domains", i),
-		)...)
-		errs = append(errs, validateCompleteObservationDomains(
-			node.ObservationDomains,
-			coverageStates,
 			fmt.Sprintf("graph.nodes[%d].observation_domains", i),
 		)...)
 		errs = append(errs, validateNodePropertySemantics(node, i)...)
@@ -395,11 +389,6 @@ func (v *Validator) Validate(data *ingest.IngestData) error {
 		errs = append(errs, validateObservationDomains(
 			edge.ObservationDomains,
 			declaredCoverage,
-			fmt.Sprintf("graph.edges[%d].observation_domains", i),
-		)...)
-		errs = append(errs, validateCompleteObservationDomains(
-			edge.ObservationDomains,
-			coverageStates,
 			fmt.Sprintf("graph.edges[%d].observation_domains", i),
 		)...)
 		errs = append(errs, validateObservationSemantics(edge, i)...)
@@ -549,7 +538,6 @@ func preflightRegistryContracts(report *ingest.CollectionReport) error {
 	}
 
 	current := ingest.CurrentInstructionRegistryContract()
-	coverageStates := ingest.CoverageStates(report)
 	for i, root := range report.AuthoritativeRoots {
 		path := fmt.Sprintf("meta.collection.authoritative_roots[%d]", i)
 		expectedInstructionMethod := ""
@@ -594,18 +582,6 @@ func preflightRegistryContracts(report *ingest.CollectionReport) error {
 				Path:    path + ".child_coverage_keys",
 				Message: "instruction root with active children must have a recognized coverage state",
 			})
-		}
-		for childIndex, child := range root.ChildCoverageKeys {
-			if coverageStates[child] != ingest.OutcomeComplete {
-				errs = append(errs, FieldError{
-					Path: fmt.Sprintf(
-						"%s.child_coverage_keys[%d]",
-						path,
-						childIndex,
-					),
-					Message: "active instruction child must have complete coverage",
-				})
-			}
 		}
 	}
 	if len(errs) > 0 {
@@ -677,12 +653,6 @@ func validateInstructionChildren(
 			errs = append(errs, FieldError{
 				Path:    path + ".method",
 				Message: fmt.Sprintf("instruction source method must be %q", ingest.InstructionMethodSource),
-			})
-		}
-		if outcome.State != ingest.OutcomeComplete {
-			errs = append(errs, FieldError{
-				Path:    path + ".state",
-				Message: "an active instruction source must be complete",
 			})
 		}
 	}
@@ -1049,25 +1019,6 @@ func validateObservationDomains(
 				Message: fmt.Sprintf("domain %q is not declared in meta.collection.coverage_keys", domain),
 			})
 		}
-	}
-	return errs
-}
-
-func validateCompleteObservationDomains(
-	domains []string,
-	states map[string]ingest.OutcomeState,
-	path string,
-) []FieldError {
-	var errs []FieldError
-	for i, domain := range domains {
-		state, declared := states[domain]
-		if !declared || state == ingest.OutcomeComplete {
-			continue
-		}
-		errs = append(errs, FieldError{
-			Path:    fmt.Sprintf("%s[%d]", path, i),
-			Message: fmt.Sprintf("domain %q must be complete to own graph facts, got %q", domain, state),
-		})
 	}
 	return errs
 }

--- a/server/internal/ingest/validator_test.go
+++ b/server/internal/ingest/validator_test.go
@@ -1073,7 +1073,7 @@ func TestValidatorAllowsCompleteChildFactsUnderIncompleteInstructionRoot(t *test
 	}
 }
 
-func TestValidatorRejectsIncompleteInstructionChildAndRootOwnedFacts(t *testing.T) {
+func TestValidatorAcceptsIncompleteInstructionChildAndRootOwnedFacts(t *testing.T) {
 	data, _, child := validInstructionRootDataFor(
 		ingest.InstructionMethodExactUser,
 		ingest.OutcomePartial,
@@ -1085,11 +1085,9 @@ func TestValidatorRejectsIncompleteInstructionChildAndRootOwnedFacts(t *testing.
 		}
 	}
 	data.Meta.Collection.State = ingest.AggregateOutcomeState(data.Meta.Collection.Outcomes)
-	assertValidationError(
-		t,
-		NewValidator().Validate(data),
-		"meta.collection.authoritative_roots[1].child_coverage_keys[0]",
-	)
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("partial instruction child facts rejected: %v", err)
+	}
 
 	data, root, _ := validInstructionRootDataFor(
 		ingest.InstructionMethodExactUser,
@@ -1101,14 +1099,12 @@ func TestValidatorRejectsIncompleteInstructionChildAndRootOwnedFacts(t *testing.
 	for i := range data.Graph.Edges {
 		data.Graph.Edges[i].ObservationDomains = []string{root}
 	}
-	assertValidationError(
-		t,
-		NewValidator().Validate(data),
-		"graph.nodes[0].observation_domains[0]",
-	)
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("failed instruction root facts rejected: %v", err)
+	}
 }
 
-func TestValidatorRejectsFactsOwnedByIncompleteDomain(t *testing.T) {
+func TestValidatorAcceptsFactsOwnedByIncompleteDomain(t *testing.T) {
 	data := validIngestData()
 	child := data.Meta.Collection.Outcomes[0].CoverageKey
 	data.Meta.Collection.Outcomes[0].State = ingest.OutcomePartial
@@ -1121,11 +1117,9 @@ func TestValidatorRejectsFactsOwnedByIncompleteDomain(t *testing.T) {
 		data.Graph.Edges[i].ObservationDomains = []string{child}
 	}
 
-	assertValidationError(
-		t,
-		NewValidator().Validate(data),
-		"graph.nodes[0].observation_domains[0]",
-	)
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("partial-domain facts rejected: %v", err)
+	}
 }
 
 func TestValidatorRejectsOrphanInstructionSource(t *testing.T) {

--- a/server/internal/projection/guard.go
+++ b/server/internal/projection/guard.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	sdkingest "github.com/adithyan-ak/agenthound/sdk/ingest"
 	"github.com/adithyan-ak/agenthound/server/model"
 )
 
@@ -15,8 +16,10 @@ type StateReader interface {
 
 // Identity identifies one immutable published graph projection.
 type Identity struct {
-	ScanID   string `json:"scan_id"`
-	Revision int64  `json:"revision"`
+	ScanID                  string `json:"scan_id"`
+	Revision                int64  `json:"revision"`
+	CoverageLimited         bool   `json:"coverage_limited"`
+	CoverageLimitationCount int    `json:"coverage_limitation_count"`
 }
 
 // ConflictError reports why a stable complete published projection could not
@@ -107,8 +110,19 @@ func readable(state *model.ProjectionState) (Identity, error) {
 	if len(state.DirtyCoverage) != 0 {
 		return Identity{}, &ConflictError{Reason: "incomplete", State: state}
 	}
+	limitedScopes := make(map[string]bool, len(state.ActiveCoverageLimitations))
+	for _, limitation := range state.ActiveCoverageLimitations {
+		limitedScopes[limitation.CoverageKey] = true
+	}
+	for _, root := range state.ActiveCoverageRoots {
+		if root.State != sdkingest.OutcomeComplete || !root.ContractCurrent {
+			limitedScopes[root.CoverageKey] = true
+		}
+	}
 	return Identity{
-		ScanID:   state.PublishedScanID,
-		Revision: *state.PublishedRevision,
+		ScanID:                  state.PublishedScanID,
+		Revision:                *state.PublishedRevision,
+		CoverageLimited:         len(limitedScopes) > 0,
+		CoverageLimitationCount: len(limitedScopes),
 	}, nil
 }

--- a/server/internal/projection/guard_test.go
+++ b/server/internal/projection/guard_test.go
@@ -1,0 +1,47 @@
+package projection
+
+import (
+	"testing"
+	"time"
+
+	sdkingest "github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/adithyan-ak/agenthound/server/model"
+)
+
+func TestReadableCountsGenericAndRegisteredSourceLimitationsOnce(t *testing.T) {
+	revision := int64(4)
+	now := time.Now().UTC()
+	state := &model.ProjectionState{
+		Status:            model.ProjectionComplete,
+		ScanID:            "scan-4",
+		PublishedScanID:   "scan-4",
+		PublishedRevision: &revision,
+		ActiveCoverageLimitations: []model.PostureCoverageLimitation{{
+			CoverageKey: "config:instruction-deep:sha256:root",
+			State:       sdkingest.OutcomePartial,
+			ScanID:      "scan-4",
+			ObservedAt:  now,
+		}},
+		ActiveCoverageRoots: []model.PostureCoverageRoot{{
+			CoverageKey:     "config:instruction-deep:sha256:root",
+			State:           sdkingest.OutcomePartial,
+			ScanID:          "scan-4",
+			ObservedAt:      now,
+			ContractCurrent: true,
+		}, {
+			CoverageKey:     "config:instruction-exact-user:sha256:old",
+			State:           sdkingest.OutcomeComplete,
+			ScanID:          "scan-3",
+			ObservedAt:      now,
+			ContractCurrent: false,
+		}},
+	}
+
+	identity, err := readable(state)
+	if err != nil {
+		t.Fatalf("readable: %v", err)
+	}
+	if !identity.CoverageLimited || identity.CoverageLimitationCount != 2 {
+		t.Fatalf("limited identity = %+v", identity)
+	}
+}

--- a/server/model/posture.go
+++ b/server/model/posture.go
@@ -6,7 +6,9 @@ import (
 	sdkingest "github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
-const PostureExportSchemaVersion = 3
+const PostureExportSchemaVersion = 4
+
+const PostureExportPreviousSchemaVersion = 3
 
 // GraphSnapshot is a frozen public-inventory count captured in one Neo4j read
 // transaction. It is intentionally distinct from scan write-row counts.
@@ -18,14 +20,15 @@ type GraphSnapshot struct {
 }
 
 type PostureScope struct {
-	ScanID              string                `json:"scan_id"`
-	Revision            int64                 `json:"revision"`
-	CoverageKeys        []string              `json:"coverage_keys"`
-	ActiveCoverageKeys  []string              `json:"active_coverage_keys"`
-	ActiveCoverageRoots []PostureCoverageRoot `json:"active_coverage_roots"`
-	DirtyCoverage       []string              `json:"dirty_coverage"`
-	ComparisonKey       string                `json:"comparison_key,omitempty"`
-	ProjectionState     string                `json:"projection_state"`
+	ScanID                    string                      `json:"scan_id"`
+	Revision                  int64                       `json:"revision"`
+	CoverageKeys              []string                    `json:"coverage_keys"`
+	ActiveCoverageKeys        []string                    `json:"active_coverage_keys"`
+	ActiveCoverageRoots       []PostureCoverageRoot       `json:"active_coverage_roots"`
+	ActiveCoverageLimitations []PostureCoverageLimitation `json:"active_coverage_limitations"`
+	DirtyCoverage             []string                    `json:"dirty_coverage"`
+	ComparisonKey             string                      `json:"comparison_key,omitempty"`
+	ProjectionState           string                      `json:"projection_state"`
 }
 
 type PostureCoverageRoot struct {
@@ -36,6 +39,18 @@ type PostureCoverageRoot struct {
 	ObservedAt       time.Time                         `json:"observed_at"`
 	RegistryContract sdkingest.RegistryContract        `json:"registry_contract"`
 	ContractCurrent  bool                              `json:"contract_current"`
+}
+
+// PostureCoverageLimitation records a scope whose latest published
+// observation could not establish absence authority. It deliberately omits
+// targets and error text so persistent posture metadata cannot leak sensitive
+// collector input.
+type PostureCoverageLimitation struct {
+	CoverageKey       string                 `json:"coverage_key"`
+	ParentCoverageKey string                 `json:"parent_coverage_key,omitempty"`
+	State             sdkingest.OutcomeState `json:"state"`
+	ScanID            string                 `json:"scan_id"`
+	ObservedAt        time.Time              `json:"observed_at"`
 }
 
 type PostureCompleteness struct {
@@ -118,13 +133,14 @@ type PostureExport struct {
 }
 
 type ProjectionState struct {
-	Status              string                `json:"status"`
-	ScanID              string                `json:"scan_id,omitempty"`
-	Error               string                `json:"error,omitempty"`
-	DirtyCoverage       []string              `json:"dirty_coverage"`
-	ActiveCoverageRoots []PostureCoverageRoot `json:"active_coverage_roots"`
-	UpdatedAt           time.Time             `json:"updated_at"`
-	PublishedScanID     string                `json:"published_scan_id,omitempty"`
-	PublishedRevision   *int64                `json:"published_revision,omitempty"`
-	PublishedAt         *time.Time            `json:"published_at,omitempty"`
+	Status                    string                      `json:"status"`
+	ScanID                    string                      `json:"scan_id,omitempty"`
+	Error                     string                      `json:"error,omitempty"`
+	DirtyCoverage             []string                    `json:"dirty_coverage"`
+	ActiveCoverageRoots       []PostureCoverageRoot       `json:"active_coverage_roots"`
+	ActiveCoverageLimitations []PostureCoverageLimitation `json:"active_coverage_limitations"`
+	UpdatedAt                 time.Time                   `json:"updated_at"`
+	PublishedScanID           string                      `json:"published_scan_id,omitempty"`
+	PublishedRevision         *int64                      `json:"published_revision,omitempty"`
+	PublishedAt               *time.Time                  `json:"published_at,omitempty"`
 }

--- a/server/ui/src/__tests__/Dashboard.test.tsx
+++ b/server/ui/src/__tests__/Dashboard.test.tsx
@@ -492,6 +492,48 @@ describe("Dashboard", () => {
     expect(screen.queryByText(/^Low Risk$/)).not.toBeInTheDocument();
   });
 
+  it("qualifies posture values for a persisted non-instruction limitation", async () => {
+    mockedUseProjectionState.mockReturnValue({
+      ...completeProjectionState(),
+      data: {
+        ...completeProjectionState().data,
+        active_coverage_limitations: [
+          {
+            coverage_key: "mcp:target:sha256:limited",
+            state: "failed",
+            scan_id: "scan-1",
+            observed_at: "2026-07-11T00:00:00Z",
+          },
+        ],
+      },
+    } as ReturnType<typeof useProjectionState>);
+    mockedUseGraphStats.mockReturnValue({
+      data: {
+        node_counts: { MCPServer: 1 },
+        edge_counts: {},
+        total_nodes: 1,
+        total_edges: 0,
+        projection: { scanId: "scan-1", revision: 1 },
+      },
+      isLoading: false,
+      error: null,
+      isError: false,
+      isPending: false,
+    } as unknown as ReturnType<typeof useGraphStats>);
+
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    expect(
+      await screen.findByText("Low Risk · Limited Coverage"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Published posture has coverage limitations"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/missing evidence is not proof of absence/i),
+    ).toBeInTheDocument();
+  });
+
   it("renders a usable published posture with a deep-coverage warning", async () => {
     publishedScan.collection_status = "truncated";
     mockedUseGraphStats.mockReturnValue({

--- a/server/ui/src/__tests__/Dashboard.test.tsx
+++ b/server/ui/src/__tests__/Dashboard.test.tsx
@@ -147,7 +147,12 @@ function nodeCollection(items: ReturnType<typeof observedAnonymousNode>[]) {
     total: items.length,
     complete: true,
     revision: "graph-revision",
-    projection: { scanId: "scan-1", revision: 1 },
+    projection: {
+      scanId: "scan-1",
+      revision: 1,
+      coverageLimited: false,
+      coverageLimitationCount: 0,
+    },
   };
 }
 

--- a/server/ui/src/__tests__/QueryLibrary.test.tsx
+++ b/server/ui/src/__tests__/QueryLibrary.test.tsx
@@ -103,7 +103,12 @@ describe("QueryLibrary", () => {
     mockedRunQuery.mockResolvedValue({
       query: mockQueries[0]!,
       rows: [{ name: "test-server", risk: 85 }],
-      projection: { scanId: "scan-1", revision: 1 },
+      projection: {
+        scanId: "scan-1",
+        revision: 1,
+        coverageLimited: false,
+        coverageLimitationCount: 0,
+      },
     });
 
     render(<QueryLibrary />, { wrapper: createWrapper() });

--- a/server/ui/src/entities/edge/api.test.ts
+++ b/server/ui/src/entities/edge/api.test.ts
@@ -15,6 +15,8 @@ function pageResponse({
   revision = "rev-1",
   projectionScanId = "scan-1",
   projectionRevision = 1,
+  coverageLimited = false,
+  coverageLimitationCount = 0,
 }: {
   offset: number;
   total: number;
@@ -22,6 +24,8 @@ function pageResponse({
   revision?: string;
   projectionScanId?: string;
   projectionRevision?: number;
+  coverageLimited?: boolean;
+  coverageLimitationCount?: number;
 }): Response {
   return new Response(
     JSON.stringify({
@@ -43,6 +47,8 @@ function pageResponse({
         projection: {
           scan_id: projectionScanId,
           revision: projectionRevision,
+          coverage_limited: coverageLimited,
+          coverage_limitation_count: coverageLimitationCount,
         },
       },
     }),
@@ -92,7 +98,12 @@ describe("fetchEdgeCollection", () => {
     await expect(fetchEdgeCollection(undefined, 1)).resolves.toMatchObject({
       complete: true,
       revision: "rev-1",
-      projection: { scanId: "scan-1", revision: 1 },
+      projection: {
+        scanId: "scan-1",
+        revision: 1,
+        coverageLimited: false,
+        coverageLimitationCount: 0,
+      },
     });
     expect(getMock.mock.calls[1]?.[1]?.searchParams).toMatchObject({
       offset: "1",
@@ -118,7 +129,12 @@ describe("fetchEdgeCollection", () => {
     await expect(fetchEdgeCollection(undefined, 1)).resolves.toMatchObject({
       complete: false,
       incompleteReason: "projection-changed",
-      projection: { scanId: "scan-1", revision: 1 },
+      projection: {
+        scanId: "scan-1",
+        revision: 1,
+        coverageLimited: false,
+        coverageLimitationCount: 0,
+      },
     });
   });
 

--- a/server/ui/src/entities/finding/api.test.ts
+++ b/server/ui/src/entities/finding/api.test.ts
@@ -123,6 +123,15 @@ describe("published finding scope", () => {
         snapshot_status: "complete",
         available: true,
         stale: false,
+        coverage_limited: true,
+        active_coverage_limitations: [
+          {
+            coverage_key: "mcp:target:sha256:limited",
+            state: "failed",
+            scan_id: "scan-1",
+            observed_at: "2026-07-11T00:00:00Z",
+          },
+        ],
       },
     });
   });
@@ -142,6 +151,13 @@ describe("published finding scope", () => {
       revision: 7,
       available: true,
       stale: false,
+      coverageLimited: true,
+      activeCoverageLimitations: [
+        expect.objectContaining({
+          coverageKey: "mcp:target:sha256:limited",
+          state: "failed",
+        }),
+      ],
     });
   });
 

--- a/server/ui/src/entities/finding/api.ts
+++ b/server/ui/src/entities/finding/api.ts
@@ -6,6 +6,7 @@ import type {
   Finding,
   FindingDetail,
   FindingEvidence,
+  PublishedCoverageLimitation,
   PublishedFindingScope,
   PublishedFindings,
   RemediationStep,
@@ -94,6 +95,34 @@ export function decodePublishedFindingScope(
           scope.published_at,
           "findings response.scope.published_at",
         );
+  const activeCoverageLimitations = collection(
+    scope.active_coverage_limitations ?? [],
+    "findings response.scope.active_coverage_limitations",
+  ).map((value, index): PublishedCoverageLimitation => {
+    const path = `findings response.scope.active_coverage_limitations[${index}]`;
+    const limitation = record(value, path);
+    if (
+      limitation.state !== "unknown" &&
+      limitation.state !== "partial" &&
+      limitation.state !== "failed" &&
+      limitation.state !== "truncated"
+    ) {
+      throw new TypeError(`${path}.state is invalid`);
+    }
+    return {
+      coverageKey: requiredString(limitation.coverage_key, `${path}.coverage_key`),
+      parentCoverageKey:
+        limitation.parent_coverage_key == null
+          ? undefined
+          : requiredString(
+              limitation.parent_coverage_key,
+              `${path}.parent_coverage_key`,
+            ),
+      state: limitation.state as PublishedCoverageLimitation["state"],
+      scanId: requiredString(limitation.scan_id, `${path}.scan_id`),
+      observedAt: requiredString(limitation.observed_at, `${path}.observed_at`),
+    };
+  });
   return {
     mode: scope.mode,
     scanId,
@@ -112,6 +141,14 @@ export function decodePublishedFindingScope(
       "findings response.scope.available",
     ),
     stale: requiredBoolean(scope.stale, "findings response.scope.stale"),
+    coverageLimited:
+      scope.coverage_limited == null
+        ? activeCoverageLimitations.length > 0
+        : requiredBoolean(
+            scope.coverage_limited,
+            "findings response.scope.coverage_limited",
+          ),
+    activeCoverageLimitations,
   };
 }
 

--- a/server/ui/src/entities/finding/model.ts
+++ b/server/ui/src/entities/finding/model.ts
@@ -81,6 +81,16 @@ export interface PublishedFindingScope {
   snapshotStatus: string;
   available: boolean;
   stale: boolean;
+  coverageLimited?: boolean;
+  activeCoverageLimitations?: PublishedCoverageLimitation[];
+}
+
+export interface PublishedCoverageLimitation {
+  coverageKey: string;
+  parentCoverageKey?: string;
+  state: "unknown" | "partial" | "failed" | "truncated";
+  scanId: string;
+  observedAt: string;
 }
 
 export interface PublishedFindings {

--- a/server/ui/src/entities/graph-stats/api.test.ts
+++ b/server/ui/src/entities/graph-stats/api.test.ts
@@ -23,13 +23,23 @@ describe("fetchGraphStats", () => {
         edge_counts: {},
         total_nodes: 1,
         total_edges: 0,
-        projection: { scan_id: "scan-4", revision: 4 },
+        projection: {
+          scan_id: "scan-4",
+          revision: 4,
+          coverage_limited: true,
+          coverage_limitation_count: 2,
+        },
       }),
     );
 
     await expect(fetchGraphStats()).resolves.toMatchObject({
       total_nodes: 1,
-      projection: { scanId: "scan-4", revision: 4 },
+      projection: {
+        scanId: "scan-4",
+        revision: 4,
+        coverageLimited: true,
+        coverageLimitationCount: 2,
+      },
     });
   });
 

--- a/server/ui/src/entities/graph-stats/api.ts
+++ b/server/ui/src/entities/graph-stats/api.ts
@@ -10,6 +10,8 @@ export interface GraphStats {
   projection: {
     scanId: string;
     revision: number;
+    coverageLimited: boolean;
+    coverageLimitationCount: number;
   };
 }
 
@@ -31,6 +33,13 @@ function positiveInteger(value: unknown, path: string): number {
   const result = nonNegativeInteger(value, path);
   if (result < 1) throw new TypeError(`${path} must be positive`);
   return result;
+}
+
+function requiredBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${path} must be a boolean`);
+  }
+  return value;
 }
 
 function counts(value: unknown, path: string): Record<string, number> {
@@ -64,6 +73,14 @@ export async function fetchGraphStats(): Promise<GraphStats> {
       revision: positiveInteger(
         projection.revision,
         "graph stats.projection.revision",
+      ),
+      coverageLimited: requiredBoolean(
+        projection.coverage_limited,
+        "graph stats.projection.coverage_limited",
+      ),
+      coverageLimitationCount: nonNegativeInteger(
+        projection.coverage_limitation_count,
+        "graph stats.projection.coverage_limitation_count",
       ),
     },
   };

--- a/server/ui/src/entities/graph/dto.ts
+++ b/server/ui/src/entities/graph/dto.ts
@@ -88,6 +88,8 @@ export interface APIEdge {
 export interface ProjectionIdentity {
   scanId: string;
   revision: number;
+  coverageLimited: boolean;
+  coverageLimitationCount: number;
 }
 
 export function sameProjectionIdentity(
@@ -98,7 +100,9 @@ export function sameProjectionIdentity(
     left != null &&
     right != null &&
     left.scanId === right.scanId &&
-    left.revision === right.revision
+    left.revision === right.revision &&
+    left.coverageLimited === right.coverageLimited &&
+    left.coverageLimitationCount === right.coverageLimitationCount
   );
 }
 
@@ -123,6 +127,20 @@ function requiredString(value: unknown, field: string): string {
   return value;
 }
 
+function requiredBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${field} must be a boolean`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new TypeError(`${field} must be a non-negative integer`);
+  }
+  return value as number;
+}
+
 export function parseProjectionIdentity(
   value: unknown,
   field: string,
@@ -137,6 +155,14 @@ export function parseProjectionIdentity(
   return {
     scanId: requiredString(projection.scan_id, `${field}.scan_id`),
     revision: projection.revision as number,
+    coverageLimited: requiredBoolean(
+      projection.coverage_limited,
+      `${field}.coverage_limited`,
+    ),
+    coverageLimitationCount: nonNegativeInteger(
+      projection.coverage_limitation_count,
+      `${field}.coverage_limitation_count`,
+    ),
   };
 }
 

--- a/server/ui/src/entities/node/api.test.ts
+++ b/server/ui/src/entities/node/api.test.ts
@@ -17,6 +17,8 @@ function pageResponse(
     revision = "rev-1",
     projectionScanId = "scan-1",
     projectionRevision = 1,
+    coverageLimited = false,
+    coverageLimitationCount = 0,
   }: {
     offset: number;
     total: number;
@@ -24,6 +26,8 @@ function pageResponse(
     revision?: string;
     projectionScanId?: string;
     projectionRevision?: number;
+    coverageLimited?: boolean;
+    coverageLimitationCount?: number;
   },
 ): Response {
   return new Response(JSON.stringify({
@@ -38,6 +42,8 @@ function pageResponse(
       projection: {
         scan_id: projectionScanId,
         revision: projectionRevision,
+        coverage_limited: coverageLimited,
+        coverage_limitation_count: coverageLimitationCount,
       },
     },
   }), {
@@ -78,7 +84,12 @@ describe("fetchNodeCollection", () => {
 
     expect(result.complete).toBe(true);
     expect(result.items.map((item) => item.id)).toEqual(["a", "b", "c"]);
-    expect(result.projection).toEqual({ scanId: "scan-1", revision: 1 });
+    expect(result.projection).toEqual({
+      scanId: "scan-1",
+      revision: 1,
+      coverageLimited: false,
+      coverageLimitationCount: 0,
+    });
     expect(getMock).toHaveBeenCalledTimes(2);
     expect(getMock.mock.calls[1]?.[1]?.searchParams).toMatchObject({
       offset: "2",
@@ -118,7 +129,12 @@ describe("fetchNodeCollection", () => {
     await expect(fetchNodeCollection(undefined, 2)).resolves.toMatchObject({
       complete: false,
       incompleteReason: "projection-changed",
-      projection: { scanId: "scan-1", revision: 1 },
+      projection: {
+        scanId: "scan-1",
+        revision: 1,
+        coverageLimited: false,
+        coverageLimitationCount: 0,
+      },
     });
   });
 

--- a/server/ui/src/entities/posture/api.test.ts
+++ b/server/ui/src/entities/posture/api.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchProjectionState,
+  hasLimitedPublishedCoverage,
   hasLimitedPublishedInstructionCoverage,
   type ProjectionState,
 } from "./api";
@@ -35,6 +36,15 @@ describe("fetchProjectionState", () => {
             contract_current: true,
           },
         ],
+        active_coverage_limitations: [
+          {
+            coverage_key: `mcp:target:sha256:${"c".repeat(64)}`,
+            state: "partial",
+            scan_id: "scan-mcp",
+            observed_at: "2026-07-24T18:00:00Z",
+          },
+        ],
+        published_scan_id: "scan-mcp",
         updated_at: "2026-07-24T18:00:01Z",
       }),
     });
@@ -49,6 +59,13 @@ describe("fetchProjectionState", () => {
         contract_current: true,
       }),
     ]);
+    expect(posture.active_coverage_limitations).toEqual([
+      expect.objectContaining({
+        state: "partial",
+        scan_id: "scan-mcp",
+      }),
+    ]);
+    expect(hasLimitedPublishedCoverage(posture, "scan-mcp")).toBe(true);
   });
 
   it("rejects malformed root contracts", async () => {

--- a/server/ui/src/entities/posture/api.ts
+++ b/server/ui/src/entities/posture/api.ts
@@ -8,6 +8,7 @@ export interface ProjectionState {
   error?: string;
   dirty_coverage: string[];
   active_coverage_roots: PostureCoverageRoot[];
+  active_coverage_limitations?: PostureCoverageLimitation[];
   updated_at: string;
   published_scan_id?: string;
   published_revision?: number;
@@ -25,6 +26,38 @@ export interface PostureCoverageRoot {
     digest: string;
   };
   contract_current: boolean;
+}
+
+export interface PostureCoverageLimitation {
+  coverage_key: string;
+  parent_coverage_key?: string;
+  state: "unknown" | "partial" | "failed" | "truncated";
+  scan_id: string;
+  observed_at: string;
+}
+
+export function activePublishedCoverageLimitations(
+  posture: ProjectionState | undefined,
+  scanID = posture?.published_scan_id,
+): PostureCoverageLimitation[] {
+  if (
+    posture?.status !== "complete" ||
+    !posture.published_scan_id ||
+    scanID !== posture.published_scan_id
+  ) {
+    return [];
+  }
+  return posture.active_coverage_limitations ?? [];
+}
+
+export function hasLimitedPublishedCoverage(
+  posture: ProjectionState | undefined,
+  scanID = posture?.published_scan_id,
+): boolean {
+  return (
+    activePublishedCoverageLimitations(posture, scanID).length > 0 ||
+    hasLimitedPublishedInstructionCoverage(posture, scanID)
+  );
 }
 
 export function limitedPublishedInstructionRoots(
@@ -120,6 +153,50 @@ function coverageRoots(value: unknown): PostureCoverageRoot[] {
   });
 }
 
+function coverageLimitations(value: unknown): PostureCoverageLimitation[] {
+  if (value == null) return [];
+  if (!Array.isArray(value)) {
+    throw new TypeError("active_coverage_limitations must be an array");
+  }
+  return value.map((entry, index) => {
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new TypeError(
+        `active_coverage_limitations[${index}] must be an object`,
+      );
+    }
+    const limitation = entry as Record<string, unknown>;
+    if (
+      limitation.state !== "unknown" &&
+      limitation.state !== "partial" &&
+      limitation.state !== "failed" &&
+      limitation.state !== "truncated"
+    ) {
+      throw new TypeError(
+        `active_coverage_limitations[${index}].state is invalid`,
+      );
+    }
+    if (
+      typeof limitation.coverage_key !== "string" ||
+      typeof limitation.scan_id !== "string" ||
+      typeof limitation.observed_at !== "string" ||
+      (limitation.parent_coverage_key != null &&
+        typeof limitation.parent_coverage_key !== "string")
+    ) {
+      throw new TypeError(`active_coverage_limitations[${index}] is invalid`);
+    }
+    return {
+      coverage_key: limitation.coverage_key,
+      parent_coverage_key:
+        typeof limitation.parent_coverage_key === "string"
+          ? limitation.parent_coverage_key
+          : undefined,
+      state: limitation.state,
+      scan_id: limitation.scan_id,
+      observed_at: limitation.observed_at,
+    };
+  });
+}
+
 export async function fetchProjectionState(): Promise<ProjectionState> {
   const raw = await api.get("posture").json<unknown>();
   if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
@@ -144,6 +221,9 @@ export async function fetchProjectionState(): Promise<ProjectionState> {
     error: typeof body.error === "string" ? body.error : undefined,
     dirty_coverage: stringArray(body.dirty_coverage, "dirty_coverage"),
     active_coverage_roots: coverageRoots(body.active_coverage_roots),
+    active_coverage_limitations: coverageLimitations(
+      body.active_coverage_limitations,
+    ),
     updated_at: body.updated_at,
     published_scan_id:
       typeof body.published_scan_id === "string"

--- a/server/ui/src/entities/prebuilt/api.test.ts
+++ b/server/ui/src/entities/prebuilt/api.test.ts
@@ -45,7 +45,12 @@ describe("runPreBuiltQuery", () => {
         query,
         rows: [],
         metadata,
-        projection: { scan_id: "scan-7", revision: 7 },
+        projection: {
+          scan_id: "scan-7",
+          revision: 7,
+          coverage_limited: true,
+          coverage_limitation_count: 1,
+        },
       }),
     );
 
@@ -56,7 +61,12 @@ describe("runPreBuiltQuery", () => {
         expansionLimit: 100,
         incompleteReason: "expansion limit reached",
       },
-      projection: { scanId: "scan-7", revision: 7 },
+      projection: {
+        scanId: "scan-7",
+        revision: 7,
+        coverageLimited: true,
+        coverageLimitationCount: 1,
+      },
     });
   });
 
@@ -65,7 +75,12 @@ describe("runPreBuiltQuery", () => {
       response({
         query,
         rows: [],
-        projection: { scan_id: "scan-7", revision: 7 },
+        projection: {
+          scan_id: "scan-7",
+          revision: 7,
+          coverage_limited: false,
+          coverage_limitation_count: 0,
+        },
       }),
     );
 
@@ -80,7 +95,12 @@ describe("runPreBuiltQuery", () => {
         query,
         rows: [],
         metadata: { ...metadata, complete: "yes" },
-        projection: { scan_id: "scan-7", revision: 7 },
+        projection: {
+          scan_id: "scan-7",
+          revision: 7,
+          coverage_limited: false,
+          coverage_limitation_count: 0,
+        },
       }),
     );
 

--- a/server/ui/src/entities/prebuilt/api.ts
+++ b/server/ui/src/entities/prebuilt/api.ts
@@ -13,6 +13,8 @@ export interface PreBuiltQuery {
 export interface ProjectionIdentity {
   scanId: string;
   revision: number;
+  coverageLimited: boolean;
+  coverageLimitationCount: number;
 }
 
 export interface TraversalMetadata {
@@ -99,6 +101,14 @@ function decodeProjection(value: unknown): ProjectionIdentity {
       projection.revision,
       "prebuilt result.projection.revision",
       1,
+    ),
+    coverageLimited: boolean(
+      projection.coverage_limited,
+      "prebuilt result.projection.coverage_limited",
+    ),
+    coverageLimitationCount: integer(
+      projection.coverage_limitation_count,
+      "prebuilt result.projection.coverage_limitation_count",
     ),
   };
 }

--- a/server/ui/src/features/dashboard/ui/Dashboard.tsx
+++ b/server/ui/src/features/dashboard/ui/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
   useScans,
 } from "@entities/scan";
 import {
+  activePublishedCoverageLimitations,
   limitedPublishedInstructionRoots,
   useProjectionState,
 } from "@entities/posture";
@@ -165,17 +166,20 @@ export function Dashboard() {
     latestPublished.snapshot_status === "complete" &&
     latestPublished.projection_status === "complete";
   const limitedCoverageRoots = limitedPublishedInstructionRoots(posture);
+  const activeCoverageLimitations =
+    activePublishedCoverageLimitations(posture);
   const exactCoverageNeedsRefresh = limitedCoverageRoots.some(
     (root) => root.mode !== "deep",
   );
   const latestCollectionLimited =
     latestPublished != null &&
     latestPublished.collection_status !== "complete";
-  const coverageLimitationDetail = exactCoverageNeedsRefresh
-    ? "Registered user or project instruction coverage uses an incomplete or outdated source contract. Run a new config scan before treating missing registered sources as absent."
-    : limitedCoverageRoots.length > 0
-      ? "The current exact registered-source posture is usable, but retained nested coverage is truncated or uses an older source contract. Run a new config scan with --deep before treating missing nested evidence as absent."
-      : "The current exact registered-source posture is usable, but the latest nested discovery attempt did not complete. Retained evidence remains visible; missing nested evidence is not a clean absence.";
+  const coverageLimitationDetail =
+    activeCoverageLimitations.length > 0
+      ? "Confirmed evidence is retained, but one or more collection scopes were incomplete. Missing evidence is not proof of absence; rerun the affected collection before treating gaps as clean."
+      : exactCoverageNeedsRefresh
+        ? "Registered user or project instruction coverage uses an incomplete or outdated source contract. Run a new config scan before treating missing registered sources as absent."
+        : "The current exact registered-source posture is usable, but retained nested coverage is truncated or uses an older source contract. Run a new config scan with --deep before treating missing nested evidence as absent.";
   const projectionIncomplete =
     posture?.status === "updating" || posture?.status === "incomplete";
   const unknownProjectionWithInventory =
@@ -257,7 +261,9 @@ export function Dashboard() {
         )}
 
         {publishedStagesComplete &&
-          (latestCollectionLimited || limitedCoverageRoots.length > 0) && (
+          (latestCollectionLimited ||
+            activeCoverageLimitations.length > 0 ||
+            limitedCoverageRoots.length > 0) && (
             <DataStateNotice
               tone="warning"
               title="Published posture has coverage limitations"

--- a/server/ui/src/features/dashboard/ui/DashboardHeader.tsx
+++ b/server/ui/src/features/dashboard/ui/DashboardHeader.tsx
@@ -16,7 +16,7 @@ import { useGraphStats } from "@entities/graph-stats";
 import { useNodes, isUnauth } from "@entities/node";
 import { useHealth } from "@entities/health";
 import {
-  hasLimitedPublishedInstructionCoverage,
+  hasLimitedPublishedCoverage,
   useProjectionState,
 } from "@entities/posture";
 import {
@@ -113,8 +113,7 @@ export function DashboardHeader() {
   const findings = findingsQuery.data;
   const nodes = nodesQuery.data;
   const posture = postureQuery.data;
-  const limitedInstructionCoverage =
-    hasLimitedPublishedInstructionCoverage(posture);
+  const limitedCoverage = hasLimitedPublishedCoverage(posture);
 
   const componentStatus = (
     component: "neo4j" | "postgres",
@@ -349,7 +348,7 @@ export function DashboardHeader() {
             label="Threat"
             value={
               verdictAvailable
-                ? limitedInstructionCoverage
+                ? limitedCoverage
                   ? `${threatLabel} · Limited`
                   : threatLabel
                 : "withheld"
@@ -362,8 +361,8 @@ export function DashboardHeader() {
             pulse={verdictAvailable && exposure >= 50}
             title={
               verdictAvailable
-                ? limitedInstructionCoverage
-                  ? "Calculated from observed positives in the published snapshot; instruction coverage is limited"
+                ? limitedCoverage
+                  ? "Calculated from observed positives in the published snapshot; collection coverage is limited"
                   : "Calculated from the complete published snapshot"
                 : "Unavailable until collection, projection, analysis, and publication are complete"
             }

--- a/server/ui/src/features/dashboard/ui/ExposureGauge.tsx
+++ b/server/ui/src/features/dashboard/ui/ExposureGauge.tsx
@@ -3,7 +3,7 @@ import { useNodes, isUnauth } from "@entities/node";
 import { useFindings, severityCounts } from "@entities/finding";
 import { comparablePublishedNodeDelta, useScans } from "@entities/scan";
 import {
-  hasLimitedPublishedInstructionCoverage,
+  hasLimitedPublishedCoverage,
   useProjectionState,
 } from "@entities/posture";
 import {
@@ -69,9 +69,8 @@ export function ExposureGauge() {
   const score = exposureScore({ critical, high, unauthServers });
   const pointer = exposureColor(score);
   const color = pointer;
-  const limitedInstructionCoverage =
-    hasLimitedPublishedInstructionCoverage(posture);
-  const label = limitedInstructionCoverage
+  const limitedCoverage = hasLimitedPublishedCoverage(posture);
+  const label = limitedCoverage
     ? `${GAUGE_LABELS[exposureBand(score)]} · Limited Coverage`
     : GAUGE_LABELS[exposureBand(score)];
 
@@ -104,7 +103,7 @@ export function ExposureGauge() {
           value={score}
           valueColor={pointer}
           caption={
-            limitedInstructionCoverage ? "observed score of 100" : "of 100"
+            limitedCoverage ? "observed score of 100" : "of 100"
           }
         />
         <div

--- a/server/ui/src/features/explorer/ExplorerPage.tsx
+++ b/server/ui/src/features/explorer/ExplorerPage.tsx
@@ -37,11 +37,13 @@ function ExplorerWorkspace() {
     (state) => state.blastRadiusSourceId,
   );
   const verdictsAvailable = vm.data?.collection.complete === true;
-  const verdictUnavailableReason = vm.error
-    ? vm.error.message
-    : vm.isLoading
-      ? "The published graph and finding snapshot are still loading."
-      : "Graph completeness or publication scope is unknown.";
+  const verdictUnavailableReason =
+    vm.data?.collection.incompleteReason ??
+    (vm.error
+      ? vm.error.message
+      : vm.isLoading
+        ? "The published graph and finding snapshot are still loading."
+        : "Graph completeness or publication scope is unknown.");
 
   return (
     <>
@@ -70,7 +72,7 @@ function ExplorerWorkspace() {
         activeLens !== "blast-radius" && (
           <DataStateNotice
             tone="warning"
-            title="Explorer conclusions withheld"
+            title="Published coverage is limited"
             className="pointer-events-auto absolute right-4 top-20 z-40 max-w-sm bg-card/95 backdrop-blur-md"
           >
             {verdictUnavailableReason}

--- a/server/ui/src/features/explorer/model/__tests__/useExplorerGraph.test.ts
+++ b/server/ui/src/features/explorer/model/__tests__/useExplorerGraph.test.ts
@@ -19,9 +19,13 @@ vi.mock("@entities/finding/api", () => ({
   fetchAllFindings: mocks.fetchFindings,
 }));
 
-vi.mock("@entities/posture/api", () => ({
-  fetchProjectionState: mocks.fetchProjectionState,
-}));
+vi.mock("@entities/posture/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@entities/posture/api")>();
+  return {
+    ...actual,
+    fetchProjectionState: mocks.fetchProjectionState,
+  };
+});
 
 import {
   ExplorerPublicationError,
@@ -38,6 +42,8 @@ function findingScope(scanId = "scan-1", revision = 1) {
     snapshotStatus: "complete",
     available: true,
     stale: false,
+    coverageLimited: false,
+    activeCoverageLimitations: [],
   };
 }
 
@@ -46,6 +52,8 @@ function projectionState(scanId = "scan-1", revision = 1) {
     status: "complete" as const,
     scan_id: scanId,
     dirty_coverage: [],
+    active_coverage_roots: [],
+    active_coverage_limitations: [],
     updated_at: "2026-07-11T00:00:00Z",
     published_scan_id: scanId,
     published_revision: revision,
@@ -60,14 +68,24 @@ describe("fetchExplorerGraph publication coherence", () => {
       total: 0,
       complete: true,
       revision: "graph-revision",
-      projection: { scanId: "scan-1", revision: 1 },
+      projection: {
+        scanId: "scan-1",
+        revision: 1,
+        coverageLimited: false,
+        coverageLimitationCount: 0,
+      },
     });
     mocks.fetchEdges.mockReset().mockResolvedValue({
       items: [],
       total: 0,
       complete: true,
       revision: "graph-revision",
-      projection: { scanId: "scan-1", revision: 1 },
+      projection: {
+        scanId: "scan-1",
+        revision: 1,
+        coverageLimited: false,
+        coverageLimitationCount: 0,
+      },
     });
     mocks.fetchFindings.mockReset().mockResolvedValue({
       findings: [],
@@ -80,13 +98,82 @@ describe("fetchExplorerGraph publication coherence", () => {
 
   it("returns graph data only when all four sources share one publication", async () => {
     await expect(fetchExplorerGraph()).resolves.toMatchObject({
-      publication: { scanId: "scan-1", revision: 1 },
+      publication: {
+        scanId: "scan-1",
+        revision: 1,
+        coverageLimited: false,
+        coverageLimitationCount: 0,
+      },
       findingScope: { scanId: "scan-1", revision: 1 },
       projectionState: {
         published_scan_id: "scan-1",
         published_revision: 1,
       },
-      collection: { complete: true, revision: "graph-revision" },
+      collection: {
+        complete: true,
+        coverageLimited: false,
+        revision: "graph-revision",
+      },
+    });
+  });
+
+  it("keeps a limited graph usable while withholding absence verdicts", async () => {
+    const limitation = {
+      coverageKey: "mcp:target:sha256:limited",
+      state: "partial" as const,
+      scanId: "scan-1",
+      observedAt: "2026-07-11T00:00:00Z",
+    };
+    const limitedProjection = {
+      scanId: "scan-1",
+      revision: 1,
+      coverageLimited: true,
+      coverageLimitationCount: 1,
+    };
+    mocks.fetchNodes.mockResolvedValue({
+      items: [],
+      total: 0,
+      complete: true,
+      revision: "graph-revision",
+      projection: limitedProjection,
+    });
+    mocks.fetchEdges.mockResolvedValue({
+      items: [],
+      total: 0,
+      complete: true,
+      revision: "graph-revision",
+      projection: limitedProjection,
+    });
+    mocks.fetchFindings.mockResolvedValue({
+      findings: [],
+      scope: {
+        ...findingScope(),
+        coverageLimited: true,
+        activeCoverageLimitations: [limitation],
+      },
+    });
+    mocks.fetchProjectionState.mockResolvedValue({
+      ...projectionState(),
+      active_coverage_limitations: [
+        {
+          coverage_key: limitation.coverageKey,
+          state: limitation.state,
+          scan_id: limitation.scanId,
+          observed_at: limitation.observedAt,
+        },
+      ],
+    });
+
+    await expect(fetchExplorerGraph()).resolves.toMatchObject({
+      nodes: [],
+      edges: [],
+      collection: {
+        complete: false,
+        coverageLimited: true,
+        incompleteReason: expect.stringContaining(
+          "absence-based conclusions are withheld",
+        ),
+      },
     });
   });
 
@@ -99,7 +186,12 @@ describe("fetchExplorerGraph publication coherence", () => {
           total: 0,
           complete: true,
           revision: "graph-revision",
-          projection: { scanId: "scan-2", revision: 2 },
+          projection: {
+            scanId: "scan-2",
+            revision: 2,
+            coverageLimited: false,
+            coverageLimitationCount: 0,
+          },
         }),
     },
     {

--- a/server/ui/src/features/explorer/model/__tests__/useExplorerViewModel.test.ts
+++ b/server/ui/src/features/explorer/model/__tests__/useExplorerViewModel.test.ts
@@ -26,7 +26,12 @@ const cachedData: ExplorerRawData = {
   nodes: [],
   edges: [],
   findings: [],
-  publication: { scanId: "scan-1", revision: 1 },
+  publication: {
+    scanId: "scan-1",
+    revision: 1,
+    coverageLimited: false,
+    coverageLimitationCount: 0,
+  },
   findingScope: {
     mode: "published",
     scanId: "scan-1",
@@ -48,6 +53,7 @@ const cachedData: ExplorerRawData = {
   },
   collection: {
     complete: true,
+    coverageLimited: false,
     revision: "graph-revision",
     nodeTotal: 0,
     edgeTotal: 0,

--- a/server/ui/src/features/explorer/model/__tests__/view-model.test.ts
+++ b/server/ui/src/features/explorer/model/__tests__/view-model.test.ts
@@ -64,7 +64,12 @@ const DATA: ExplorerRawData = {
   nodes: NODES,
   edges: EDGES,
   findings: FINDINGS,
-  publication: { scanId: "scan-1", revision: 1 },
+  publication: {
+    scanId: "scan-1",
+    revision: 1,
+    coverageLimited: false,
+    coverageLimitationCount: 0,
+  },
   findingScope: {
     mode: "published",
     scanId: "scan-1",
@@ -87,6 +92,7 @@ const DATA: ExplorerRawData = {
   },
   collection: {
     complete: true,
+    coverageLimited: false,
     revision: "rev-1",
     nodeTotal: NODES.length,
     edgeTotal: EDGES.length,
@@ -135,6 +141,7 @@ describe("explorer view-model — three distinct shapes", () => {
           edges: EDGES.slice(0, 1),
           collection: {
             complete: false,
+            coverageLimited: false,
             revision: null,
             nodeTotal: NODES.length,
             edgeTotal: EDGES.length,

--- a/server/ui/src/features/explorer/model/useExplorerGraph.ts
+++ b/server/ui/src/features/explorer/model/useExplorerGraph.ts
@@ -16,6 +16,7 @@ import {
 } from "@entities/finding/model";
 import {
   fetchProjectionState,
+  hasLimitedPublishedCoverage,
   type ProjectionState,
 } from "@entities/posture/api";
 
@@ -28,6 +29,7 @@ export interface ExplorerRawData {
   projectionState: ProjectionState;
   collection: {
     complete: boolean;
+    coverageLimited: boolean;
     revision: string | null;
     nodeTotal: number;
     edgeTotal: number;
@@ -81,11 +83,10 @@ export async function fetchExplorerGraph(): Promise<ExplorerRawData> {
       "finding snapshot is unavailable, stale, or incomplete",
     );
   }
-  const findingIdentity: ProjectionIdentity = {
-    scanId: findingResult.scope.scanId,
-    revision: findingResult.scope.revision!,
-  };
-  if (!sameProjectionIdentity(nodeResult.projection, findingIdentity)) {
+  if (
+    nodeResult.projection.scanId !== findingResult.scope.scanId ||
+    nodeResult.projection.revision !== findingResult.scope.revision
+  ) {
     throw new ExplorerPublicationError(
       "graph and finding publication identities differ",
     );
@@ -103,17 +104,22 @@ export async function fetchExplorerGraph(): Promise<ExplorerRawData> {
       "published projection state is unavailable or incomplete",
     );
   }
-  const projectionStateIdentity: ProjectionIdentity = {
-    scanId: projectionState.published_scan_id,
-    revision: projectionState.published_revision,
-  };
   if (
-    !sameProjectionIdentity(nodeResult.projection, projectionStateIdentity)
+    nodeResult.projection.scanId !== projectionState.published_scan_id ||
+    nodeResult.projection.revision !== projectionState.published_revision
   ) {
     throw new ExplorerPublicationError(
       "graph and projection-state publication identities differ",
     );
   }
+  const coverageLimited =
+    nodeResult.projection.coverageLimited ||
+    findingResult.scope.coverageLimited === true ||
+    (findingResult.scope.activeCoverageLimitations?.length ?? 0) > 0 ||
+    hasLimitedPublishedCoverage(
+      projectionState,
+      projectionState.published_scan_id,
+    );
 
   return {
     nodes: nodeResult.items,
@@ -123,10 +129,14 @@ export async function fetchExplorerGraph(): Promise<ExplorerRawData> {
     findingScope: findingResult.scope,
     projectionState,
     collection: {
-      complete: true,
+      complete: !coverageLimited,
+      coverageLimited,
       revision: nodeResult.revision,
       nodeTotal: nodeResult.total,
       edgeTotal: edgeResult.total,
+      incompleteReason: coverageLimited
+        ? "Published coverage is limited; graph facts remain usable, but absence-based conclusions are withheld."
+        : undefined,
     },
   };
 }

--- a/server/ui/src/features/findings/ui/FindingsListPage.test.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.test.tsx
@@ -157,10 +157,39 @@ describe("FindingsListPage request and snapshot states", () => {
 
     expect(
       screen.getByText(
-        "No findings observed; instruction coverage is limited",
+        "No findings observed; collection coverage is limited",
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText(/No findings detected/i)).not.toBeInTheDocument();
+  });
+
+  it("qualifies an empty snapshot from its persisted coverage limitations", () => {
+    mocks.useFindings.mockReturnValue({
+      data: [],
+      snapshot: {
+        ...currentScope,
+        activeCoverageLimitations: [
+          {
+            coverageKey: "mcp:target:sha256:limited",
+            state: "failed",
+            scanId: "scan-1",
+            observedAt: "2026-07-11T00:00:00Z",
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      dataUpdatedAt: Date.now(),
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByText("No findings observed; collection coverage is limited"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Published coverage is limited"),
+    ).toBeInTheDocument();
   });
 
   it("withholds a clean empty claim while posture is loading", () => {

--- a/server/ui/src/features/findings/ui/FindingsListPage.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.tsx
@@ -307,9 +307,12 @@ export function FindingsListPage() {
     postureQuery.data.published_revision === snapshot?.revision;
   const canShowSnapshotCounts =
     hasCachedFindings && snapshot?.available === true;
-  const limitedInstructionCoverage =
-    postureReadyForCurrentSnapshot &&
-    hasLimitedPublishedInstructionCoverage(postureQuery.data, snapshot?.scanId);
+  const limitedCoverage =
+    (findingScopeCurrent &&
+      (snapshot?.coverageLimited === true ||
+        (snapshot?.activeCoverageLimitations?.length ?? 0) > 0)) ||
+    (postureReadyForCurrentSnapshot &&
+      hasLimitedPublishedInstructionCoverage(postureQuery.data, snapshot?.scanId));
 
   // Number of *secondary* filters active (everything that lives in the rail).
   const activeFacetCount =
@@ -438,8 +441,8 @@ export function FindingsListPage() {
     total > 0
       ? "No findings match the current filters"
       : postureReadyForCurrentSnapshot
-        ? limitedInstructionCoverage
-          ? "No findings observed; instruction coverage is limited"
+        ? limitedCoverage
+          ? "No findings observed; collection coverage is limited"
           : "No findings detected in the current published snapshot"
         : scopeUnavailable
           ? "No published finding snapshot is available"
@@ -549,6 +552,13 @@ export function FindingsListPage() {
           Showing snapshot {snapshot?.scanId ?? "with unknown scan ID"}. The live
           projection is not aligned with this revision, so these findings are not
           a current-state verdict.
+        </DataStateNotice>
+      )}
+      {!cachedRefreshError && findingScopeCurrent && limitedCoverage && (
+        <DataStateNotice tone="warning" title="Published coverage is limited">
+          Confirmed findings are retained, but missing evidence is not proof of
+          absence. Rerun the affected collection before treating an empty result
+          as clean.
         </DataStateNotice>
       )}
       {registerContent}

--- a/server/ui/src/features/scans/ui/ScanImport.test.tsx
+++ b/server/ui/src/features/scans/ui/ScanImport.test.tsx
@@ -267,7 +267,7 @@ describe("ScanImport", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveClass("border-amber-400/30");
     expect(
-      screen.getByText(/missing instruction evidence is not a clean absence/i),
+      screen.getByText(/missing evidence is not proof of absence/i),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /view findings/i }),
@@ -331,7 +331,7 @@ describe("ScanImport", () => {
     expect(screen.getByRole("alert")).toHaveClass("border-amber-400/30");
     expect(
       screen.getByText(
-        /observed instruction positives were published.*missing instruction evidence is not a clean absence/i,
+        /confirmed positives were published.*missing evidence is not proof of absence/i,
       ),
     ).toBeInTheDocument();
     expect(

--- a/server/ui/src/features/scans/ui/ScanImport.tsx
+++ b/server/ui/src/features/scans/ui/ScanImport.tsx
@@ -197,29 +197,13 @@ function completedStage(result: IngestResult, name: string): boolean {
   ) ?? false;
 }
 
-function hasLimitedInstructionCoverage(result: IngestResult): boolean {
-  const rootKinds: Record<string, string> = {
-    instruction_exact_user: "instruction-exact-user",
-    instruction_exact_project: "instruction-exact-project",
-    instruction_deep: "instruction-deep",
-  };
-  return (result.collection.authoritative_roots ?? []).some((root) => {
-    if (!root.registry_contract) {
-      return false;
-    }
-    return result.collection.outcomes.some(
-      (outcome) => {
-        const rootKind = rootKinds[outcome.method];
-        return (
-          rootKind !== undefined &&
-          root.coverage_key.startsWith(`config:${rootKind}:sha256:`) &&
-          outcome.coverage_key === root.coverage_key &&
-          outcome.collector === "config" &&
-          ["truncated", "partial", "failed"].includes(outcome.state)
-        );
-      },
-    );
-  });
+function hasLimitedCoverage(result: IngestResult): boolean {
+  return (
+    result.collection.state !== "complete" ||
+    (result.warnings ?? []).includes(
+      "coverage is limited; missing evidence is not proof of absence",
+    )
+  );
 }
 
 const ghostBtn =
@@ -390,7 +374,7 @@ export function ScanImport({ open, onClose, onSuccess }: ScanImportProps) {
     result.projection_status === "complete" &&
     incompleteStages.length === 0;
   const limitedCoverage =
-    publishedOutcome && result != null && hasLimitedInstructionCoverage(result);
+    publishedOutcome && result != null && hasLimitedCoverage(result);
   const completeOutcome =
     publishedOutcome && warnings.length === 0 && !limitedCoverage;
   const canOpenGraph =
@@ -582,8 +566,8 @@ export function ScanImport({ open, onClose, onSuccess }: ScanImportProps) {
                 </p>
                 {limitedCoverage && (
                   <p className="text-xs text-muted-foreground">
-                    Observed instruction positives were published and remain
-                    usable; missing instruction evidence is not a clean absence.
+                    Confirmed positives were published and remain usable;
+                    missing evidence is not proof of absence.
                   </p>
                 )}
                 {!completeOutcome && !limitedCoverage && (


### PR DESCRIPTION
## Summary

- publish confirmed facts from incomplete collection without granting absence authority
- keep graph mutations dirty until analysis, snapshot, and PostgreSQL publication complete
- persist coverage limitations per revision and surface them in API, CLI, UI, CI gates, and comparison guards
- restore a shared owner’s complete fingerprint after a compatible partial refresh
- preserve projection coverage identity through the strict OpenAPI contract and Explorer client
- preserve existing limited instruction-root warnings across database upgrades

## Safety semantics

- partial writes are additive and cannot remove omitted properties, labels, owners, edges, or child scopes
- complete coverage remains the only path that can reconcile absence
- failed publication cannot be laundered by an unrelated later scan
- empty results remain qualified while any published limitation is active
- Explorer keeps confirmed graph facts usable while withholding absence-based verdicts under limited coverage

## Validation

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test -timeout 20m ./... -race`
- `make docs-check`
- UI: 253 tests and production build passed
- isolated Neo4j 4.4 and 5.x shared-owner recovery and incompatible-retry integration regressions passed
- full `make prerelease` passes on the stacked final source

A separate stacked PR makes scanner probe outcomes classify complete, partial, failed, and unknown consistently.