### PR TITLE
Report scanner coverage truthfully

### DIFF
--- a/collector/cli/discover.go
+++ b/collector/cli/discover.go
@@ -161,17 +161,40 @@ func runDiscover(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	envelope := buildDiscoverEnvelope(spec, targets, authzFile, authzHash, allowPublic)
+	envelope := buildDiscoverEnvelope(
+		spec,
+		targets,
+		authzFile,
+		authzHash,
+		allowPublic,
+		scanner.LastReport(),
+	)
 	if output == "" {
 		output = fmt.Sprintf("discover-%s.json", envelope.Meta.ScanID)
 	}
+	var writeErr error
 	if output == "-" {
-		return writeCollectorOutputStdout(envelope)
+		writeErr = writeCollectorOutputStdout(envelope)
+	} else {
+		writeErr = writeCollectorOutput(envelope, output)
 	}
-	return writeCollectorOutput(envelope, output)
+	if writeErr != nil {
+		return writeErr
+	}
+	assessment := assessScanCoverage(envelope.Meta.Collection)
+	writeScanCoverageWarnings(cmd.ErrOrStderr(), envelope.Meta.Collection, assessment)
+	writeScanNextStep(cmd.ErrOrStderr(), output, assessment, false)
+	return nil
 }
 
-func buildDiscoverEnvelope(spec string, targets []action.Target, authzFile, authzHash string, allowPublic bool) *ingest.IngestData {
+func buildDiscoverEnvelope(
+	spec string,
+	targets []action.Target,
+	authzFile,
+	authzHash string,
+	allowPublic bool,
+	report protoscan.ProbeReport,
+) *ingest.IngestData {
 	scanID := uuid.New().String()
 	env := common.NewIngestData("scan", scanID)
 	env.Meta.Extra = map[string]any{
@@ -180,16 +203,28 @@ func buildDiscoverEnvelope(spec string, targets []action.Target, authzFile, auth
 		"allow_public_targets": allowPublic,
 	}
 	coverageKey := ingest.CanonicalCoverageKey("scan", "discover", spec)
+	state := report.State()
+	errorText := ""
+	if report.Total == 0 {
+		errorText = "zero protocol probes scheduled"
+	} else if unknown := report.Unknown(); unknown > 0 {
+		errorText = fmt.Sprintf(
+			"%d of %d protocol probe(s) inconclusive",
+			unknown,
+			report.Total,
+		)
+	}
 	env.Meta.Collection = &ingest.CollectionReport{
-		State:        ingest.OutcomeComplete,
+		State:        state,
 		CoverageKeys: []string{coverageKey},
 		Outcomes: []ingest.CollectionOutcome{{
 			Collector:   "scan",
 			CoverageKey: coverageKey,
 			Target:      spec,
 			Method:      "protocol_discovery",
-			State:       ingest.OutcomeComplete,
+			State:       state,
 			Items:       len(targets),
+			Error:       errorText,
 		}},
 	}
 	if authzFile != "" {

--- a/collector/cli/discover.go
+++ b/collector/cli/discover.go
@@ -184,7 +184,7 @@ func runDiscover(cmd *cobra.Command, args []string) error {
 	if output == "-" {
 		writeErr = writeCollectorOutputStdout(envelope)
 	} else {
-		writeErr = writeCollectorOutput(envelope, output)
+		writeErr = writeCollectorOutputFile(envelope, output)
 	}
 	if writeErr != nil {
 		return writeErr

--- a/collector/cli/discover.go
+++ b/collector/cli/discover.go
@@ -161,13 +161,21 @@ func runDiscover(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	report := scanner.LastReport()
+	contract := buildProtocolProbeContract(report)
+	contractIdentity, contractErr := identifyProbeContract("discover", contract)
+	if contractErr != nil {
+		return fmt.Errorf("identify protocol probe contract: %w", contractErr)
+	}
 	envelope := buildDiscoverEnvelope(
 		spec,
 		targets,
 		authzFile,
 		authzHash,
 		allowPublic,
-		scanner.LastReport(),
+		report,
+		contractIdentity,
+		contract,
 	)
 	if output == "" {
 		output = fmt.Sprintf("discover-%s.json", envelope.Meta.ScanID)
@@ -194,15 +202,18 @@ func buildDiscoverEnvelope(
 	authzHash string,
 	allowPublic bool,
 	report protoscan.ProbeReport,
+	contractIdentity probeContractIdentity,
+	contract protocolProbeContract,
 ) *ingest.IngestData {
 	scanID := uuid.New().String()
 	env := common.NewIngestData("scan", scanID)
 	env.Meta.Extra = map[string]any{
-		"discover_spec":        spec,
-		"discover_targets":     len(targets),
-		"allow_public_targets": allowPublic,
+		"discover_spec":         spec,
+		"discover_targets":      len(targets),
+		"allow_public_targets":  allowPublic,
+		"probe_contract":        contract,
+		"probe_contract_digest": contractIdentity.Digest,
 	}
-	coverageKey := ingest.CanonicalCoverageKey("scan", "discover", spec)
 	state := report.State()
 	errorText := ""
 	if report.Total == 0 {
@@ -216,10 +227,10 @@ func buildDiscoverEnvelope(
 	}
 	env.Meta.Collection = &ingest.CollectionReport{
 		State:        state,
-		CoverageKeys: []string{coverageKey},
+		CoverageKeys: []string{contractIdentity.CoverageKey},
 		Outcomes: []ingest.CollectionOutcome{{
 			Collector:   "scan",
-			CoverageKey: coverageKey,
+			CoverageKey: contractIdentity.CoverageKey,
 			Target:      spec,
 			Method:      "protocol_discovery",
 			State:       state,
@@ -232,6 +243,6 @@ func buildDiscoverEnvelope(
 		env.Meta.Extra["authorization_file_sha256"] = authzHash
 	}
 	env.Graph = protoscan.EmitDiscoveryNodes(targets)
-	ingest.TagObservationDomain(&env.Graph, coverageKey)
+	ingest.TagObservationDomain(&env.Graph, contractIdentity.CoverageKey)
 	return env
 }

--- a/collector/cli/discover_test.go
+++ b/collector/cli/discover_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/adithyan-ak/agenthound/modules/protoscan"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
 // joinPorts renders a port slice in the "/"-separated form used in the
@@ -33,5 +34,56 @@ func TestDiscoverLongHelpMatchesDefaultPorts(t *testing.T) {
 	}
 	if !strings.Contains(discoverCmd.Long, a2a) {
 		t.Errorf("discover long help missing A2A default ports %q\nLong:\n%s", a2a, discoverCmd.Long)
+	}
+}
+
+func TestBuildDiscoverEnvelopeUsesProbeCoverage(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		report protoscan.ProbeReport
+		want   ingest.OutcomeState
+	}{
+		{
+			name:   "all conclusive",
+			report: protoscan.ProbeReport{Total: 4, Conclusive: 4},
+			want:   ingest.OutcomeComplete,
+		},
+		{
+			name:   "mixed",
+			report: protoscan.ProbeReport{Total: 4, Conclusive: 2},
+			want:   ingest.OutcomePartial,
+		},
+		{
+			name:   "nothing conclusive",
+			report: protoscan.ProbeReport{Total: 4},
+			want:   ingest.OutcomeFailed,
+		},
+		{
+			name:   "zero probes",
+			report: protoscan.ProbeReport{},
+			want:   ingest.OutcomeFailed,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			envelope := buildDiscoverEnvelope(
+				"127.0.0.1",
+				nil,
+				"",
+				"",
+				false,
+				tt.report,
+			)
+			if envelope.Meta.Collection.State != tt.want {
+				t.Fatalf("collection state = %q, want %q",
+					envelope.Meta.Collection.State, tt.want)
+			}
+			outcome := envelope.Meta.Collection.Outcomes[0]
+			if outcome.State != tt.want {
+				t.Fatalf("protocol outcome = %+v, want %q", outcome, tt.want)
+			}
+			if tt.want != ingest.OutcomeComplete && outcome.Error == "" {
+				t.Fatalf("incomplete protocol outcome lacks diagnostic: %+v", outcome)
+			}
+		})
 	}
 }

--- a/collector/cli/discover_test.go
+++ b/collector/cli/discover_test.go
@@ -65,6 +65,11 @@ func TestBuildDiscoverEnvelopeUsesProbeCoverage(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			contract := buildProtocolProbeContract(tt.report)
+			identity, err := identifyProbeContract("discover", contract)
+			if err != nil {
+				t.Fatalf("identify probe contract: %v", err)
+			}
 			envelope := buildDiscoverEnvelope(
 				"127.0.0.1",
 				nil,
@@ -72,6 +77,8 @@ func TestBuildDiscoverEnvelopeUsesProbeCoverage(t *testing.T) {
 				"",
 				false,
 				tt.report,
+				identity,
+				contract,
 			)
 			if envelope.Meta.Collection.State != tt.want {
 				t.Fatalf("collection state = %q, want %q",

--- a/collector/cli/discover_test.go
+++ b/collector/cli/discover_test.go
@@ -1,13 +1,24 @@
 package cli
 
 import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/adithyan-ak/agenthound/modules/protoscan"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/spf13/cobra"
 )
+
+const discoverInitializeOK = `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","serverInfo":{"name":"discover-test","version":"1.0.0"},"capabilities":{}}}`
 
 // joinPorts renders a port slice in the "/"-separated form used in the
 // discover long-help prose (e.g. {3000,8000} -> "3000/8000").
@@ -93,4 +104,130 @@ func TestBuildDiscoverEnvelopeUsesProbeCoverage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunDiscoverPrintsOneCoverageAwareIngestInstruction(t *testing.T) {
+	positive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(discoverInitializeOK))
+	}))
+	defer positive.Close()
+	concealed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer concealed.Close()
+
+	positivePort := discoverTestPort(t, positive.URL)
+	concealedPort := discoverTestPort(t, concealed.URL)
+	for _, tt := range []struct {
+		name          string
+		ports         []int
+		wantWarning   string
+		wantQualified bool
+	}{
+		{
+			name:  "complete",
+			ports: []int{positivePort},
+		},
+		{
+			name:          "partial",
+			ports:         []int{positivePort, concealedPort},
+			wantWarning:   "WARNING: Scan artifact is partial",
+			wantQualified: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			outputPath := filepath.Join(t.TempDir(), "discover.json")
+			var output bytes.Buffer
+			cmd := discoverGuidanceTestCommand(outputPath, tt.ports)
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+
+			var runErr error
+			processStderr := captureDiscoverProcessStderr(t, func() {
+				runErr = runDiscover(cmd, []string{"127.0.0.1"})
+			})
+			if runErr != nil {
+				t.Fatalf("runDiscover: %v", runErr)
+			}
+			text := processStderr + output.String()
+			if count := strings.Count(text, "agenthound-server ingest "); count != 1 {
+				t.Fatalf("ingest instruction count = %d, want 1:\n%s", count, text)
+			}
+			plain := "Next: agenthound-server ingest " + outputPath
+			qualified := "Next (after reviewing incomplete coverage): agenthound-server ingest " + outputPath
+			if tt.wantQualified {
+				if strings.Contains(text, plain) {
+					t.Fatalf("partial output contains unqualified instruction:\n%s", text)
+				}
+				if !strings.Contains(text, qualified) {
+					t.Fatalf("partial output lacks qualified instruction:\n%s", text)
+				}
+			} else {
+				if !strings.Contains(text, plain) || strings.Contains(text, "Next (") {
+					t.Fatalf("complete output does not contain one plain instruction:\n%s", text)
+				}
+			}
+			if tt.wantWarning != "" && !strings.Contains(text, tt.wantWarning) {
+				t.Fatalf("output lacks warning %q:\n%s", tt.wantWarning, text)
+			}
+		})
+	}
+}
+
+func captureDiscoverProcessStderr(t *testing.T, run func()) string {
+	t.Helper()
+	previous := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr capture pipe: %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = previous
+		_ = writer.Close()
+		_ = reader.Close()
+	}()
+
+	run()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr capture: %v", err)
+	}
+	os.Stderr = previous
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr capture: %v", err)
+	}
+	return string(output)
+}
+
+func discoverGuidanceTestCommand(output string, ports []int) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.PersistentFlags().Bool("quiet", true, "")
+	cmd.Flags().Bool("mcp", true, "")
+	cmd.Flags().Bool("a2a", false, "")
+	cmd.Flags().IntSlice("mcp-ports", ports, "")
+	cmd.Flags().IntSlice("a2a-ports", nil, "")
+	cmd.Flags().Int("network-scan-concurrency", 2, "")
+	cmd.Flags().Duration("timeout", time.Second, "")
+	cmd.Flags().Bool("insecure", false, "")
+	cmd.Flags().Bool("allow-public-targets", false, "")
+	cmd.Flags().Bool("allow-large-cidr", false, "")
+	cmd.Flags().String("authorization-file", "", "")
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().String("scan-output", output, "")
+	return cmd
+}
+
+func discoverTestPort(t *testing.T, rawURL string) int {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	return port
 }

--- a/collector/cli/probe_contract.go
+++ b/collector/cli/probe_contract.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"sort"
+
+	"github.com/adithyan-ak/agenthound/modules/networkscan"
+	"github.com/adithyan-ak/agenthound/modules/protoscan"
+	"github.com/adithyan-ak/agenthound/sdk/common"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+)
+
+const probeContractVersion = 1
+
+type probeFingerprinter struct {
+	ModuleID string `json:"module_id"`
+	Target   string `json:"target"`
+	Version  string `json:"version"`
+}
+
+type probeSemantic struct {
+	Type           string `json:"type"`
+	ID             string `json:"id"`
+	Version        int    `json:"version"`
+	SemanticSHA256 string `json:"semantic_sha256"`
+}
+
+type networkProbeContract struct {
+	Version        int                           `json:"version"`
+	Scanner        string                        `json:"scanner"`
+	Targets        networkscan.TargetSetIdentity `json:"targets"`
+	Ports          []int                         `json:"ports"`
+	Fingerprinters []probeFingerprinter          `json:"fingerprinters"`
+	Semantics      []probeSemantic               `json:"semantics"`
+}
+
+type protocolProbeContract struct {
+	Version   int                           `json:"version"`
+	Scanner   string                        `json:"scanner"`
+	Targets   networkscan.TargetSetIdentity `json:"targets"`
+	Protocols []protoscan.ProtocolSurface   `json:"protocols"`
+}
+
+type probeContractIdentity struct {
+	CoverageKey string
+	Digest      string
+}
+
+func buildNetworkProbeContract(
+	report networkscan.ProbeReport,
+	candidates []fingerprintCandidate,
+	ruleset *ingest.RulesetManifest,
+) networkProbeContract {
+	fingerprinters := make([]probeFingerprinter, 0, len(candidates))
+	targets := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		fingerprinters = append(fingerprinters, probeFingerprinter{
+			ModuleID: candidate.id,
+			Target:   candidate.target,
+			Version:  candidate.version,
+		})
+		targets[candidate.target] = true
+	}
+	sort.Slice(fingerprinters, func(i, j int) bool {
+		if fingerprinters[i].ModuleID != fingerprinters[j].ModuleID {
+			return fingerprinters[i].ModuleID < fingerprinters[j].ModuleID
+		}
+		if fingerprinters[i].Target != fingerprinters[j].Target {
+			return fingerprinters[i].Target < fingerprinters[j].Target
+		}
+		return fingerprinters[i].Version < fingerprinters[j].Version
+	})
+
+	var semantics []probeSemantic
+	if ruleset != nil {
+		for _, entry := range ruleset.Entries {
+			if entry.Type == "fingerprint" && !targets[entry.ID] {
+				continue
+			}
+			if entry.Type != "fingerprint" && entry.Type != "detector" {
+				continue
+			}
+			semantics = append(semantics, probeSemantic{
+				Type:           entry.Type,
+				ID:             entry.ID,
+				Version:        entry.Version,
+				SemanticSHA256: entry.SemanticSHA256,
+			})
+		}
+	}
+	sort.Slice(semantics, func(i, j int) bool {
+		if semantics[i].Type != semantics[j].Type {
+			return semantics[i].Type < semantics[j].Type
+		}
+		if semantics[i].ID != semantics[j].ID {
+			return semantics[i].ID < semantics[j].ID
+		}
+		if semantics[i].Version != semantics[j].Version {
+			return semantics[i].Version < semantics[j].Version
+		}
+		return semantics[i].SemanticSHA256 < semantics[j].SemanticSHA256
+	})
+
+	ports := append([]int(nil), report.Ports...)
+	sort.Ints(ports)
+	return networkProbeContract{
+		Version:        probeContractVersion,
+		Scanner:        "network-fingerprint",
+		Targets:        report.Targets,
+		Ports:          ports,
+		Fingerprinters: fingerprinters,
+		Semantics:      semantics,
+	}
+}
+
+func buildProtocolProbeContract(report protoscan.ProbeReport) protocolProbeContract {
+	protocols := make([]protoscan.ProtocolSurface, len(report.Protocols))
+	for i, protocol := range report.Protocols {
+		protocols[i] = protocol
+		protocols[i].Ports = append([]int(nil), protocol.Ports...)
+		sort.Ints(protocols[i].Ports)
+	}
+	sort.Slice(protocols, func(i, j int) bool {
+		return protocols[i].Protocol < protocols[j].Protocol
+	})
+	return protocolProbeContract{
+		Version:   probeContractVersion,
+		Scanner:   "protocol-discovery",
+		Targets:   report.Targets,
+		Protocols: protocols,
+	}
+}
+
+func identifyProbeContract(scope string, contract any) (probeContractIdentity, error) {
+	digest, err := common.CanonicalJSONHash(contract)
+	if err != nil {
+		return probeContractIdentity{}, err
+	}
+	digest = "sha256:" + digest
+	return probeContractIdentity{
+		CoverageKey: ingest.CanonicalCoverageKey("scan", scope, digest),
+		Digest:      digest,
+	}, nil
+}

--- a/collector/cli/probe_contract_test.go
+++ b/collector/cli/probe_contract_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/adithyan-ak/agenthound/modules/networkscan"
+	"github.com/adithyan-ak/agenthound/modules/protoscan"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
+)
+
+func contractKey(t *testing.T, scope string, contract any) string {
+	t.Helper()
+	identity, err := identifyProbeContract(scope, contract)
+	if err != nil {
+		t.Fatalf("identify probe contract: %v", err)
+	}
+	return identity.CoverageKey
+}
+
+func TestNetworkProbeContractIdentityUsesExecutedSurface(t *testing.T) {
+	report := networkscan.ProbeReport{
+		Targets: networkscan.LogicalTargetSetIdentity([]string{"10.0.0.2", "10.0.0.1"}),
+		Ports:   []int{4000, 11434},
+	}
+	candidates := []fingerprintCandidate{
+		{id: "ollama-fingerprint", target: "ollama", version: "1.0.0"},
+		{id: "jupyter-fingerprint", target: "jupyter", version: "2.0.0"},
+	}
+	manifest := &ingest.RulesetManifest{Entries: []ingest.RuleManifestEntry{
+		{Type: "text", ID: "prompt-injection", Version: 1, SemanticSHA256: "sha256:text-a"},
+		{Type: "fingerprint", ID: "unregistered", Version: 1, SemanticSHA256: "sha256:unused"},
+		{Type: "fingerprint", ID: "ollama", Version: 1, SemanticSHA256: "sha256:ollama-a"},
+		{Type: "detector", ID: "jupyter-native", Version: 1, SemanticSHA256: "sha256:jupyter-a"},
+	}}
+	base := buildNetworkProbeContract(report, candidates, manifest)
+	baseKey := contractKey(t, "network", base)
+
+	reordered := report
+	reordered.Ports = []int{11434, 4000}
+	reorderedContract := buildNetworkProbeContract(
+		reordered,
+		[]fingerprintCandidate{candidates[1], candidates[0]},
+		&ingest.RulesetManifest{Entries: []ingest.RuleManifestEntry{
+			manifest.Entries[3],
+			manifest.Entries[2],
+			{Type: "text", ID: "prompt-injection", Version: 1, SemanticSHA256: "sha256:text-b"},
+			manifest.Entries[1],
+		}},
+	)
+	if got := contractKey(t, "network", reorderedContract); got != baseKey {
+		t.Fatalf("irrelevant ordering/text semantics changed key: got %q want %q", got, baseKey)
+	}
+
+	changedDetector := buildNetworkProbeContract(report, candidates, &ingest.RulesetManifest{
+		Entries: []ingest.RuleManifestEntry{
+			manifest.Entries[2],
+			{Type: "detector", ID: "jupyter-native", Version: 1, SemanticSHA256: "sha256:jupyter-b"},
+		},
+	})
+	if got := contractKey(t, "network", changedDetector); got == baseKey {
+		t.Fatal("executed detector semantics did not change key")
+	}
+
+	changedVersion := append([]fingerprintCandidate(nil), candidates...)
+	changedVersion[0].version = "1.0.1"
+	if got := contractKey(
+		t,
+		"network",
+		buildNetworkProbeContract(report, changedVersion, manifest),
+	); got == baseKey {
+		t.Fatal("fingerprinter version did not change key")
+	}
+}
+
+func TestProtocolProbeContractIdentityIgnoresInactivePortFlags(t *testing.T) {
+	targets := networkscan.LogicalTargetSetIdentity([]string{"127.0.0.1"})
+	first := protoscan.ProbeReport{
+		Targets: targets,
+		Protocols: []protoscan.ProtocolSurface{{
+			Protocol: "mcp",
+			Ports:    []int{8000, 3000},
+		}},
+	}
+	second := protoscan.ProbeReport{
+		Targets: targets,
+		Protocols: []protoscan.ProtocolSurface{{
+			Protocol: "mcp",
+			Ports:    []int{3000, 8000},
+		}},
+	}
+	firstKey := contractKey(t, "discover", buildProtocolProbeContract(first))
+	if got := contractKey(t, "discover", buildProtocolProbeContract(second)); got != firstKey {
+		t.Fatalf("equivalent active surface changed key: got %q want %q", got, firstKey)
+	}
+
+	second.Protocols[0].Ports = append(second.Protocols[0].Ports, 8443)
+	if got := contractKey(t, "discover", buildProtocolProbeContract(second)); got == firstKey {
+		t.Fatal("active MCP port change did not change key")
+	}
+}
+
+func TestProbeContractIdentityTracksExpandedTargets(t *testing.T) {
+	first := networkscan.ProbeReport{
+		Targets: networkscan.LogicalTargetSetIdentity([]string{"10.0.0.1"}),
+		Ports:   []int{4000},
+	}
+	second := first
+	second.Targets = networkscan.LogicalTargetSetIdentity([]string{"10.0.0.2"})
+
+	firstKey := contractKey(
+		t,
+		"network",
+		buildNetworkProbeContract(first, nil, ingest.EmptyRulesetManifest()),
+	)
+	secondKey := contractKey(
+		t,
+		"network",
+		buildNetworkProbeContract(second, nil, ingest.EmptyRulesetManifest()),
+	)
+	if firstKey == secondKey {
+		t.Fatal("different expanded target sets produced the same key")
+	}
+}

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -1072,22 +1072,25 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 	}
 
 	// Configure the registered concrete scanner and retain it so its bounded
-	// coverage counts can be attached to the artifact.
+	// coverage counts and exact scheduled surface can be attached to the
+	// artifact. A different implementation cannot provide that lifecycle
+	// identity safely.
 	reporter := newProgressReporter(cmd.OutOrStderr(), "[scan] probing "+spec, quiet)
-	var networkScanner *networkscan.Scanner
-	if ns, ok := mod.(*networkscan.Scanner); ok {
-		networkScanner = ns
-		if len(ports) > 0 {
-			ns.Ports = ports
-		}
-		ns.Concurrency = concurrency
-		ns.ExpandOpts = networkscan.ExpandOptions{
-			AllowLargeCIDR:     allowLarge,
-			AllowPublicTargets: allowPublic,
-		}
-		ns.Timeout = tcpTimeout
-		ns.Progress = reporter.update
+	networkScanner, ok := mod.(*networkscan.Scanner)
+	if !ok {
+		return fmt.Errorf(
+			"registered network module %q cannot report its scheduled probe surface",
+			mod.ID(),
+		)
 	}
+	networkScanner.Ports = append([]int(nil), ports...)
+	networkScanner.Concurrency = concurrency
+	networkScanner.ExpandOpts = networkscan.ExpandOptions{
+		AllowLargeCIDR:     allowLarge,
+		AllowPublicTargets: allowPublic,
+	}
+	networkScanner.Timeout = tcpTimeout
+	networkScanner.Progress = reporter.update
 
 	ctx, stop := signalContext()
 	defer stop()
@@ -1123,31 +1126,39 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 	// PortToKind is an ordering hint only, so a real service on a custom port is
 	// still discoverable. Operationally indeterminate probes make this domain
 	// partial and therefore cannot retire a previously observed service.
-	envelope := buildNetworkScanEnvelope(spec, targets, authzFile, authzHash, allowPublic)
+	report := networkScanner.LastReport()
+	candidates := registeredFingerprinters()
 	_, ruleset := loadEffectiveRules()
+	contract := buildNetworkProbeContract(report, candidates, ruleset)
+	contractIdentity, contractErr := identifyProbeContract("network", contract)
+	if contractErr != nil {
+		return fmt.Errorf("identify network probe contract: %w", contractErr)
+	}
+	envelope := buildNetworkScanEnvelope(
+		spec,
+		targets,
+		authzFile,
+		authzHash,
+		allowPublic,
+		contractIdentity,
+		contract,
+	)
 	envelope.Meta.Ruleset = ruleset
-	var networkState ingest.OutcomeState
+	networkState := report.State()
 	networkError := ""
-	if networkScanner != nil {
-		report := networkScanner.LastReport()
-		networkState = report.State()
-		if unknown := report.Unknown(); unknown > 0 {
-			networkError = fmt.Sprintf(
-				"%d of %d TCP probe(s) inconclusive",
-				unknown,
-				report.Total,
-			)
-		}
-	} else {
-		networkState = ingest.OutcomeFailed
-		networkError = "registered scanner did not report TCP probe coverage"
+	if unknown := report.Unknown(); unknown > 0 {
+		networkError = fmt.Sprintf(
+			"%d of %d TCP probe(s) inconclusive",
+			unknown,
+			report.Total,
+		)
 	}
 	envelope.Meta.Collection = &ingest.CollectionReport{
 		State:        networkState,
-		CoverageKeys: []string{ingest.CanonicalCoverageKey("scan", "network", spec)},
+		CoverageKeys: []string{contractIdentity.CoverageKey},
 		Outcomes: []ingest.CollectionOutcome{{
 			Collector:   "scan",
-			CoverageKey: ingest.CanonicalCoverageKey("scan", "network", spec),
+			CoverageKey: contractIdentity.CoverageKey,
 			Target:      spec,
 			Method:      "port_scan",
 			State:       networkState,
@@ -1169,9 +1180,10 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 			Error: "fingerprint phase canceled before dispatch",
 		})
 	} else {
-		dispatchFingerprints(
+		dispatchFingerprintCandidates(
 			ctx, cmd.OutOrStderr(), targets, envelope, quiet,
 			normalizeFingerprintWorkers(concurrency), fingerprintTimeout, spec,
+			candidates,
 		)
 	}
 	envelope.Meta.Collection.State = ingest.AggregateOutcomeState(envelope.Meta.Collection.Outcomes)
@@ -1199,16 +1211,23 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 // network scanner and subsequent fingerprint dispatch. The authorization
 // watermark lets downstream analysis tools refuse to operate on public-target
 // scans that lack an authorization record.
-func buildNetworkScanEnvelope(spec string, targets []action.Target, authzFile, authzHash string, allowPublic bool) *ingest.IngestData {
+func buildNetworkScanEnvelope(
+	spec string,
+	targets []action.Target,
+	authzFile,
+	authzHash string,
+	allowPublic bool,
+	contractIdentity probeContractIdentity,
+	contract networkProbeContract,
+) *ingest.IngestData {
 	scanID := uuid.New().String()
 	env := common.NewIngestData("scan", scanID)
-	coverageKey := ingest.CanonicalCoverageKey("scan", "network", spec)
 	env.Meta.Collection = &ingest.CollectionReport{
 		State:        ingest.OutcomeComplete,
-		CoverageKeys: []string{coverageKey},
+		CoverageKeys: []string{contractIdentity.CoverageKey},
 		Outcomes: []ingest.CollectionOutcome{{
 			Collector:   "scan",
-			CoverageKey: coverageKey,
+			CoverageKey: contractIdentity.CoverageKey,
 			Target:      spec,
 			Method:      "port_scan",
 			State:       ingest.OutcomeComplete,
@@ -1219,9 +1238,11 @@ func buildNetworkScanEnvelope(spec string, targets []action.Target, authzFile, a
 	// a property on the envelope. Fingerprinters append nodes/edges
 	// to env.Graph; the watermark is independent of the graph payload.
 	env.Meta.Extra = map[string]any{
-		"network_scan_spec":    spec,
-		"network_scan_targets": len(targets),
-		"allow_public_targets": allowPublic,
+		"network_scan_spec":     spec,
+		"network_scan_targets":  len(targets),
+		"allow_public_targets":  allowPublic,
+		"probe_contract":        contract,
+		"probe_contract_digest": contractIdentity.Digest,
 	}
 	if authzFile != "" {
 		env.Meta.Extra["authorization_file_path"] = authzFile
@@ -1271,9 +1292,10 @@ func sha256OfFile(path string) (string, error) {
 // endpoint. Port mappings only prioritize likely matches. Failures are
 // retained as partial fingerprint coverage rather than authoritative absence.
 type fingerprintCandidate struct {
-	id     string
-	target string
-	fp     action.Fingerprinter
+	id      string
+	target  string
+	version string
+	fp      action.Fingerprinter
 }
 
 type fingerprintTask struct {
@@ -1306,7 +1328,9 @@ func registeredFingerprinters() []fingerprintCandidate {
 		if !ok {
 			continue
 		}
-		candidates = append(candidates, fingerprintCandidate{id: mod.ID(), target: mod.Target(), fp: fp})
+		candidates = append(candidates, fingerprintCandidate{
+			id: mod.ID(), target: mod.Target(), version: mod.Version(), fp: fp,
+		})
 	}
 	return candidates
 }
@@ -1356,19 +1380,6 @@ func fingerprintEndpoints(targets []action.Target) []fingerprintEndpoint {
 		}
 	}
 	return endpoints
-}
-
-func dispatchFingerprints(
-	ctx context.Context,
-	stderr io.Writer,
-	targets []action.Target,
-	envelope *ingest.IngestData,
-	quiet bool,
-	workers int,
-	timeout time.Duration,
-	scopeTarget string,
-) {
-	dispatchFingerprintCandidates(ctx, stderr, targets, envelope, quiet, workers, timeout, scopeTarget, registeredFingerprinters())
 }
 
 func dispatchFingerprintCandidates(

--- a/collector/cli/scan.go
+++ b/collector/cli/scan.go
@@ -1071,12 +1071,12 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 		return fmt.Errorf("registered network module %q is not a Scanner", mod.ID())
 	}
 
-	// Configure runtime overrides directly on the *networkscan.Scanner if
-	// possible — avoids constructing a parallel options struct. We don't
-	// type-assert here because module.Get returns the concrete value the
-	// init() registered.
+	// Configure the registered concrete scanner and retain it so its bounded
+	// coverage counts can be attached to the artifact.
 	reporter := newProgressReporter(cmd.OutOrStderr(), "[scan] probing "+spec, quiet)
+	var networkScanner *networkscan.Scanner
 	if ns, ok := mod.(*networkscan.Scanner); ok {
+		networkScanner = ns
 		if len(ports) > 0 {
 			ns.Ports = ports
 		}
@@ -1126,9 +1126,21 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 	envelope := buildNetworkScanEnvelope(spec, targets, authzFile, authzHash, allowPublic)
 	_, ruleset := loadEffectiveRules()
 	envelope.Meta.Ruleset = ruleset
-	networkState := ingest.OutcomeComplete
-	if ctx.Err() != nil {
-		networkState = ingest.OutcomePartial
+	var networkState ingest.OutcomeState
+	networkError := ""
+	if networkScanner != nil {
+		report := networkScanner.LastReport()
+		networkState = report.State()
+		if unknown := report.Unknown(); unknown > 0 {
+			networkError = fmt.Sprintf(
+				"%d of %d TCP probe(s) inconclusive",
+				unknown,
+				report.Total,
+			)
+		}
+	} else {
+		networkState = ingest.OutcomeFailed
+		networkError = "registered scanner did not report TCP probe coverage"
 	}
 	envelope.Meta.Collection = &ingest.CollectionReport{
 		State:        networkState,
@@ -1140,6 +1152,7 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 			Method:      "port_scan",
 			State:       networkState,
 			Items:       len(targets),
+			Error:       networkError,
 		}},
 	}
 	// On cancellation (Ctrl-C), every fingerprint probe would immediately fail
@@ -1152,7 +1165,7 @@ func runNetworkScan(cmd *cobra.Command, spec string) error {
 		}
 		envelope.Meta.Collection.Outcomes = append(envelope.Meta.Collection.Outcomes, ingest.CollectionOutcome{
 			Collector: "scan", CoverageKey: envelope.Meta.Collection.CoverageKeys[0],
-			Target: spec, Method: "fingerprint", State: ingest.OutcomePartial,
+			Target: spec, Method: "fingerprint", State: ingest.OutcomeFailed,
 			Error: "fingerprint phase canceled before dispatch",
 		})
 	} else {
@@ -1377,10 +1390,18 @@ func dispatchFingerprintCandidates(
 	total := len(endpoints) * len(candidates)
 	reporter := newProgressReporter(stderr, "[scan] fingerprinting", quiet)
 	coverageKey := envelope.Meta.Collection.CoverageKeys[0]
-	if total == 0 {
+	if len(endpoints) == 0 {
 		envelope.Meta.Collection.Outcomes = append(envelope.Meta.Collection.Outcomes, ingest.CollectionOutcome{
 			Collector: "scan", CoverageKey: coverageKey, Target: scopeTarget,
-			Method: "fingerprint", State: ingest.OutcomeComplete,
+			Method: "fingerprint", State: ingest.OutcomeNotApplicable,
+		})
+		return
+	}
+	if len(candidates) == 0 {
+		envelope.Meta.Collection.Outcomes = append(envelope.Meta.Collection.Outcomes, ingest.CollectionOutcome{
+			Collector: "scan", CoverageKey: coverageKey, Target: scopeTarget,
+			Method: "fingerprint", State: ingest.OutcomeFailed,
+			Error: "no registered fingerprinters; zero probes scheduled",
 		})
 		return
 	}
@@ -1496,15 +1517,21 @@ func dispatchFingerprintCandidates(
 	}
 	scheduled := <-producerDone
 	unstarted := total - scheduled
-	state := ingest.OutcomeComplete
+	conclusive := completed - failures
+	state := ingest.ProbeOutcomeState(total, conclusive)
 	errorText := ""
-	if failures > 0 || unstarted > 0 || ctx.Err() != nil {
-		state = ingest.OutcomePartial
-		errorText = fmt.Sprintf("%d probe(s) failed, %d not started", failures, max(0, unstarted))
+	if state != ingest.OutcomeComplete {
+		errorText = fmt.Sprintf(
+			"%d of %d probe(s) inconclusive (%d failed, %d not started)",
+			total-conclusive,
+			total,
+			failures,
+			max(0, unstarted),
+		)
 	}
 	envelope.Meta.Collection.Outcomes = append(envelope.Meta.Collection.Outcomes, ingest.CollectionOutcome{
 		Collector: "scan", CoverageKey: coverageKey, Target: scopeTarget,
-		Method: "fingerprint", State: state, Items: completed - failures, Error: errorText,
+		Method: "fingerprint", State: state, Items: conclusive, Error: errorText,
 	})
 	reporter.clear()
 	if !quiet {

--- a/collector/cli/scan_fixes_test.go
+++ b/collector/cli/scan_fixes_test.go
@@ -234,12 +234,59 @@ func TestFingerprintCoverageDistinguishesFailureFromNoMatch(t *testing.T) {
 		id: failure.ID(), target: failure.Target(), fp: failure,
 	}})
 	outcome = envelope.Meta.Collection.Outcomes[len(envelope.Meta.Collection.Outcomes)-1]
-	if outcome.State != ingest.OutcomePartial || outcome.Items != 0 {
+	if outcome.State != ingest.OutcomeFailed || outcome.Items != 0 {
 		t.Fatalf("operational failure outcome = %+v", outcome)
 	}
 	if len(ingest.CompleteCoverageDomains(envelope.Meta.Collection)) != 0 {
 		t.Fatalf("indeterminate fingerprint could reconcile prior services: %+v", envelope.Meta.Collection)
 	}
+}
+
+func TestFingerprintCoverageZeroProbeClassification(t *testing.T) {
+	t.Run("no open endpoint is not applicable", func(t *testing.T) {
+		envelope := fingerprintTestEnvelope()
+		dispatchFingerprintCandidates(
+			context.Background(),
+			io.Discard,
+			nil,
+			envelope,
+			true,
+			1,
+			time.Second,
+			"test",
+			[]fingerprintCandidate{{
+				id: "candidate", target: "candidate",
+				fp: &conditionalFingerprinter{targetKind: "candidate"},
+			}},
+		)
+		outcome := envelope.Meta.Collection.Outcomes[len(envelope.Meta.Collection.Outcomes)-1]
+		if outcome.State != ingest.OutcomeNotApplicable {
+			t.Fatalf("no-endpoint outcome = %+v, want not_applicable", outcome)
+		}
+	})
+
+	t.Run("open endpoint without fingerprinter is failed", func(t *testing.T) {
+		envelope := fingerprintTestEnvelope()
+		dispatchFingerprintCandidates(
+			context.Background(),
+			io.Discard,
+			[]action.Target{{
+				Kind: "host", Address: "10.0.0.9",
+				Meta: map[string]string{"open_ports": "9999"},
+			}},
+			envelope,
+			true,
+			1,
+			time.Second,
+			"test",
+			nil,
+		)
+		outcome := envelope.Meta.Collection.Outcomes[len(envelope.Meta.Collection.Outcomes)-1]
+		if outcome.State != ingest.OutcomeFailed ||
+			!strings.Contains(outcome.Error, "zero probes") {
+			t.Fatalf("no-fingerprinter outcome = %+v, want failed zero-probe error", outcome)
+		}
+	})
 }
 
 func TestFingerprintDeadlineStartsWhenWorkerDequeues(t *testing.T) {

--- a/collector/cli/version_provenance_test.go
+++ b/collector/cli/version_provenance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/adithyan-ak/agenthound/modules/networkscan"
 	"github.com/adithyan-ak/agenthound/modules/protoscan"
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/campaign"
@@ -29,16 +30,56 @@ func TestCollectionEnvelopesPreserveInjectedCollectorVersion(t *testing.T) {
 		t.Fatalf("empty combined collection = %d enabled / %d failed, want 0 / 0", enabled, failed)
 	}
 
+	networkReport := networkscan.ProbeReport{
+		Total:      1,
+		Conclusive: 1,
+		Targets:    networkscan.LogicalTargetSetIdentity([]string{"127.0.0.1"}),
+		Ports:      []int{1},
+	}
+	networkContract := buildNetworkProbeContract(
+		networkReport,
+		nil,
+		ingest.EmptyRulesetManifest(),
+	)
+	networkIdentity, err := identifyProbeContract("network", networkContract)
+	if err != nil {
+		t.Fatalf("identify network probe contract: %v", err)
+	}
+	protocolReport := protoscan.ProbeReport{
+		Total:      1,
+		Conclusive: 1,
+		Targets:    networkscan.LogicalTargetSetIdentity([]string{"127.0.0.1"}),
+		Protocols: []protoscan.ProtocolSurface{{
+			Protocol: "mcp",
+			Ports:    []int{1},
+		}},
+	}
+	protocolContract := buildProtocolProbeContract(protocolReport)
+	protocolIdentity, err := identifyProbeContract("discover", protocolContract)
+	if err != nil {
+		t.Fatalf("identify protocol probe contract: %v", err)
+	}
+
 	envelopes := map[string]*ingest.IngestData{
 		"combined scan": combined,
-		"network scan":  buildNetworkScanEnvelope("127.0.0.1:1", nil, "", "", false),
+		"network scan": buildNetworkScanEnvelope(
+			"127.0.0.1:1",
+			nil,
+			"",
+			"",
+			false,
+			networkIdentity,
+			networkContract,
+		),
 		"discover": buildDiscoverEnvelope(
 			"127.0.0.1:1",
 			nil,
 			"",
 			"",
 			false,
-			protoscan.ProbeReport{Total: 1, Conclusive: 1},
+			protocolReport,
+			protocolIdentity,
+			protocolContract,
 		),
 		"loot":     buildLootEnvelope("http://127.0.0.1", "jupyter", "ENG", &action.LootResult{}),
 		"extract":  buildExtractEnvelope(ingest.ComputeNodeID("AIModel", "instance", "model"), "embedding-inversion", "ENG", &action.ExtractResult{}),

--- a/collector/cli/version_provenance_test.go
+++ b/collector/cli/version_provenance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/adithyan-ak/agenthound/modules/protoscan"
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/campaign"
 	"github.com/adithyan-ak/agenthound/sdk/common"
@@ -31,10 +32,17 @@ func TestCollectionEnvelopesPreserveInjectedCollectorVersion(t *testing.T) {
 	envelopes := map[string]*ingest.IngestData{
 		"combined scan": combined,
 		"network scan":  buildNetworkScanEnvelope("127.0.0.1:1", nil, "", "", false),
-		"discover":      buildDiscoverEnvelope("127.0.0.1:1", nil, "", "", false),
-		"loot":          buildLootEnvelope("http://127.0.0.1", "jupyter", "ENG", &action.LootResult{}),
-		"extract":       buildExtractEnvelope(ingest.ComputeNodeID("AIModel", "instance", "model"), "embedding-inversion", "ENG", &action.ExtractResult{}),
-		"campaign":      buildCampaignEnvelope("cred-reach", 1, "ENG", campTestEvidence(campaign.OutcomeNotObserved)),
+		"discover": buildDiscoverEnvelope(
+			"127.0.0.1:1",
+			nil,
+			"",
+			"",
+			false,
+			protoscan.ProbeReport{Total: 1, Conclusive: 1},
+		),
+		"loot":     buildLootEnvelope("http://127.0.0.1", "jupyter", "ENG", &action.LootResult{}),
+		"extract":  buildExtractEnvelope(ingest.ComputeNodeID("AIModel", "instance", "model"), "embedding-inversion", "ENG", &action.ExtractResult{}),
+		"campaign": buildCampaignEnvelope("cred-reach", 1, "ENG", campTestEvidence(campaign.OutcomeNotObserved)),
 	}
 	for name, envelope := range envelopes {
 		if got := envelope.Meta.CollectorVersion; got != releaseVersion {

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -149,6 +149,14 @@ into the v5 projection. Preserve the old deployment or a coordinated backup as
 read-only evidence, then start v5 with fresh PostgreSQL and Neo4j volumes and
 recollect.
 
+The unreleased binding-v3 line also changes network scanner ownership from a
+raw target expression to the exact expanded probe contract. Development
+databases created from an earlier binding-v3 build must likewise be reset and
+recollected; legacy target-only scanner owners are not migrated. This remains
+safe only while binding v3 is unreleased. After a binding version is deployed,
+any incompatible ownership-contract change requires an explicit migration or a
+new documented reset boundary.
+
 Back up the deployment, preserve any source artifacts needed for recollection,
 then recreate both development databases before starting this release:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -278,6 +278,21 @@ endpoint with no registered fingerprinter is a failed zero-probe condition.
 Confirmed service nodes remain in the artifact in partial runs, while the
 coverage warning prevents unchecked services from being presented as absent.
 
+Network `scan` and `discover` bind lifecycle ownership to a versioned probe
+contract recorded as `meta.extra.probe_contract` plus
+`meta.extra.probe_contract_digest`. The contract hashes the exact sorted,
+deduplicated logical target set expanded for scheduling; a changed `@file`
+therefore creates a different owner even when its path is unchanged, while
+reordered or repeated entries do not. Hostnames remain logical hostnames and
+are not replaced by unstable DNS results. Network fingerprint contracts also
+include the scheduled ports, the exact dispatched module ID/target/version set,
+and only the fingerprint/native-detector semantic hashes those candidates
+execute. Protocol discovery contracts include only active protocols and their
+scheduled ports, so an A2A port flag cannot change an MCP-only contract. A
+complete result may retire earlier observations only for this exact contract; a
+different target, port, protocol, candidate, or executed detection surface
+cannot prove them absent.
+
 #### Shared Flags
 
 | Flag | Default | Description |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -263,10 +263,12 @@ mappings prioritize likely candidates but are not eligibility gates, so a real
 service on a custom port remains discoverable. TCP connect success and explicit
 connection refusal are conclusive; timeout, DNS, reset, panic, cancellation,
 and unstarted TCP probes are unknown. For HTTP fingerprinting, a complete
-response that fails its matcher, canonical 404/405, or explicit connection
-refusal is a definitive no-match. TLS/timeouts and other transport failures,
-redirects, authentication challenges, other non-2xx statuses, incomplete or
-oversized bodies, and matcher runtime failures are unknown.
+2xx response that fails its matcher or explicit connection refusal is a
+definitive no-match. Bare 404/405 responses are unknown because an access
+gateway can conceal a protected route and a method rejection does not prove
+the service is absent. TLS/timeouts and other transport failures, redirects,
+authentication challenges, other non-2xx statuses, incomplete or oversized
+bodies, and matcher runtime failures are also unknown.
 
 Each port-scan, fingerprint, and protocol-discovery outcome is `complete` only
 when every scheduled probe is conclusive, `partial` when conclusive and unknown
@@ -348,13 +350,13 @@ agenthound scan --output - | agenthound-server ingest -
 Protocol-shape probes against a network to discover MCP servers (JSON-RPC initialize) and A2A agents (well-known agent-card). Unlike `scan` which fingerprints fixed AI-service ports, `discover` issues protocol-specific HTTP probes against likely web ports.
 
 Discovery preserves every positive MCP/A2A match while recording truthful
-coverage. A canonical 404/405, a complete non-matching protocol response, and
-explicit connection refusal are conclusive negatives. Authentication blocks,
-redirects, other non-2xx statuses, TLS/timeouts and other transport failures,
-and incomplete or oversized responses are unknown. Mixed scans are marked
-`partial`; an all-unknown or zero-probe run is `failed`. The artifact is still
-written and the CLI prints a coverage warning so retained positives can be
-ingested without treating unchecked endpoints as absent.
+coverage. A complete non-matching 2xx protocol response and explicit connection
+refusal are conclusive negatives. Bare 404/405 responses, authentication
+blocks, redirects, other non-2xx statuses, TLS/timeouts and other transport
+failures, and incomplete or oversized responses are unknown. Mixed scans are
+marked `partial`; an all-unknown or zero-probe run is `failed`. The artifact is
+still written and the CLI prints a coverage warning so retained positives can
+be ingested without treating unchecked endpoints as absent.
 
 ```
 agenthound discover <cidr|host|@file> [flags]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -260,11 +260,21 @@ By default network-mode `scan` prints a one-line summary (`N host(s) with at lea
 
 Every registered fingerprinter runs once against every open endpoint. Port
 mappings prioritize likely candidates but are not eligibility gates, so a real
-service on a custom port remains discoverable. A complete response that fails
-its matcher is a definitive no-match. Transport/TLS/timeouts, redirects,
-authentication challenges, transient statuses, incomplete or oversized bodies,
-and matcher runtime failures are indeterminate and make fingerprint coverage
-partial, preventing lifecycle reconciliation from deleting prior service facts.
+service on a custom port remains discoverable. TCP connect success and explicit
+connection refusal are conclusive; timeout, DNS, reset, panic, cancellation,
+and unstarted TCP probes are unknown. For HTTP fingerprinting, a complete
+response that fails its matcher, canonical 404/405, or explicit connection
+refusal is a definitive no-match. TLS/timeouts and other transport failures,
+redirects, authentication challenges, other non-2xx statuses, incomplete or
+oversized bodies, and matcher runtime failures are unknown.
+
+Each port-scan, fingerprint, and protocol-discovery outcome is `complete` only
+when every scheduled probe is conclusive, `partial` when conclusive and unknown
+results are mixed, and `failed` when nothing is conclusive. Fingerprinting is
+`not_applicable` when the conclusive TCP sweep found no open endpoint. An open
+endpoint with no registered fingerprinter is a failed zero-probe condition.
+Confirmed service nodes remain in the artifact in partial runs, while the
+coverage warning prevents unchecked services from being presented as absent.
 
 #### Shared Flags
 
@@ -336,6 +346,15 @@ agenthound scan --output - | agenthound-server ingest -
 ### `agenthound discover`
 
 Protocol-shape probes against a network to discover MCP servers (JSON-RPC initialize) and A2A agents (well-known agent-card). Unlike `scan` which fingerprints fixed AI-service ports, `discover` issues protocol-specific HTTP probes against likely web ports.
+
+Discovery preserves every positive MCP/A2A match while recording truthful
+coverage. A canonical 404/405, a complete non-matching protocol response, and
+explicit connection refusal are conclusive negatives. Authentication blocks,
+redirects, other non-2xx statuses, TLS/timeouts and other transport failures,
+and incomplete or oversized responses are unknown. Mixed scans are marked
+`partial`; an all-unknown or zero-probe run is `failed`. The artifact is still
+written and the CLI prints a coverage warning so retained positives can be
+ingested without treating unchecked endpoints as absent.
 
 ```
 agenthound discover <cidr|host|@file> [flags]

--- a/modules/jupyterfp/fingerprinter.go
+++ b/modules/jupyterfp/fingerprinter.go
@@ -109,6 +109,9 @@ func (f *Fingerprinter) Fingerprint(
 		baseURL+"/api",
 	)
 	if err != nil {
+		if common.IsConnectionRefused(err) {
+			return &action.FingerprintResult{Matched: false}, nil
+		}
 		return &action.FingerprintResult{Matched: false}, err
 	}
 	if err := indeterminateHTTPStatus(apiStatus, false); err != nil {
@@ -132,6 +135,9 @@ func (f *Fingerprinter) Fingerprint(
 		baseURL+"/api/status",
 	)
 	if err != nil {
+		if common.IsConnectionRefused(err) {
+			return &action.FingerprintResult{Matched: false}, nil
+		}
 		return &action.FingerprintResult{Matched: false}, err
 	}
 	if err := indeterminateHTTPStatus(statusCode, true); err != nil {
@@ -330,18 +336,15 @@ func probe(
 
 func indeterminateHTTPStatus(status int, allowAuthChallenge bool) error {
 	switch {
-	case status >= 300 && status < 400:
-		return fmt.Errorf("redirect response status %d", status)
-	case status == http.StatusProxyAuthRequired:
-		return fmt.Errorf("authentication challenge status %d", status)
-	case status == http.StatusRequestTimeout || status == http.StatusTooEarly ||
-		status == http.StatusTooManyRequests || status >= 500:
-		return fmt.Errorf("transient response status %d", status)
-	case !allowAuthChallenge &&
-		(status == http.StatusUnauthorized || status == http.StatusForbidden):
-		return fmt.Errorf("authentication challenge status %d", status)
-	default:
+	case status >= 200 && status < 300:
 		return nil
+	case status == http.StatusNotFound || status == http.StatusMethodNotAllowed:
+		return nil
+	case allowAuthChallenge &&
+		(status == http.StatusUnauthorized || status == http.StatusForbidden):
+		return nil
+	default:
+		return fmt.Errorf("indeterminate response status %d", status)
 	}
 }
 

--- a/modules/jupyterfp/fingerprinter.go
+++ b/modules/jupyterfp/fingerprinter.go
@@ -338,8 +338,6 @@ func indeterminateHTTPStatus(status int, allowAuthChallenge bool) error {
 	switch {
 	case status >= 200 && status < 300:
 		return nil
-	case status == http.StatusNotFound || status == http.StatusMethodNotAllowed:
-		return nil
 	case allowAuthChallenge &&
 		(status == http.StatusUnauthorized || status == http.StatusForbidden):
 		return nil

--- a/modules/jupyterfp/fingerprinter_test.go
+++ b/modules/jupyterfp/fingerprinter_test.go
@@ -139,8 +139,8 @@ func TestIndeterminateHTTPStatus(t *testing.T) {
 		wantErr            bool
 	}{
 		{status: http.StatusOK},
-		{status: http.StatusNotFound},
-		{status: http.StatusMethodNotAllowed},
+		{status: http.StatusNotFound, wantErr: true},
+		{status: http.StatusMethodNotAllowed, wantErr: true},
 		{status: http.StatusUnauthorized, wantErr: true},
 		{status: http.StatusUnauthorized, allowAuthChallenge: true},
 		{status: http.StatusForbidden, allowAuthChallenge: true},
@@ -165,6 +165,7 @@ func TestFingerprintStatusDecision(t *testing.T) {
 		wantMatch        bool
 		wantStatusAccess string
 		wantAnonymous    bool
+		wantErr          bool
 	}{
 		{
 			name:             "canonical anonymous success",
@@ -196,6 +197,7 @@ func TestFingerprintStatusDecision(t *testing.T) {
 			status:      http.StatusNotFound,
 			contentType: "text/plain",
 			body:        "not found",
+			wantErr:     true,
 		},
 		{
 			name:        "malformed status",
@@ -221,7 +223,23 @@ func TestFingerprintStatusDecision(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			res := fingerprintTarget(t, srv)
+			fingerprinter, err := New()
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			res, err := fingerprinter.Fingerprint(context.Background(), action.Target{
+				Kind:    "host",
+				Address: strings.TrimPrefix(srv.URL, "http://"),
+			})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("concealed status route must remain indeterminate")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Fingerprint: %v", err)
+			}
 			if res.Matched != tt.wantMatch {
 				t.Fatalf("Matched = %v, want %v", res.Matched, tt.wantMatch)
 			}
@@ -412,7 +430,7 @@ func TestValidateBundleOverrideRequiresExactNodeKindTuple(t *testing.T) {
 	}
 }
 
-func TestFingerprintExcludesKernelGatewayCollision(t *testing.T) {
+func TestFingerprintKernelGatewayCollisionWithMissingStatusIsIndeterminate(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api":
@@ -426,8 +444,16 @@ func TestFingerprintExcludesKernelGatewayCollision(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if res := fingerprintTarget(t, srv); res.Matched {
-		t.Fatal("Kernel Gateway public /api collision was identified as JupyterServer")
+	fingerprinter, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = fingerprinter.Fingerprint(context.Background(), action.Target{
+		Kind:    "host",
+		Address: strings.TrimPrefix(srv.URL, "http://"),
+	})
+	if err == nil {
+		t.Fatal("missing status route must not become authoritative absence")
 	}
 }
 

--- a/modules/jupyterfp/fingerprinter_test.go
+++ b/modules/jupyterfp/fingerprinter_test.go
@@ -116,6 +116,46 @@ func TestFingerprintRequiresPublicAPICandidate(t *testing.T) {
 	}
 }
 
+func TestFingerprintConnectionRefusedIsDefinitiveNoMatch(t *testing.T) {
+	fingerprinter, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	result, err := fingerprinter.Fingerprint(context.Background(), action.Target{
+		Kind: "host", Address: "127.0.0.1:1",
+	})
+	if err != nil {
+		t.Fatalf("connection refusal should be a definitive no-match: %v", err)
+	}
+	if result.Matched {
+		t.Fatal("connection refusal matched Jupyter")
+	}
+}
+
+func TestIndeterminateHTTPStatus(t *testing.T) {
+	for _, tt := range []struct {
+		status             int
+		allowAuthChallenge bool
+		wantErr            bool
+	}{
+		{status: http.StatusOK},
+		{status: http.StatusNotFound},
+		{status: http.StatusMethodNotAllowed},
+		{status: http.StatusUnauthorized, wantErr: true},
+		{status: http.StatusUnauthorized, allowAuthChallenge: true},
+		{status: http.StatusForbidden, allowAuthChallenge: true},
+		{status: http.StatusBadRequest, wantErr: true},
+		{status: http.StatusFound, wantErr: true},
+		{status: http.StatusServiceUnavailable, wantErr: true},
+	} {
+		err := indeterminateHTTPStatus(tt.status, tt.allowAuthChallenge)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("status %d allow-auth=%v err=%v, wantErr=%v",
+				tt.status, tt.allowAuthChallenge, err, tt.wantErr)
+		}
+	}
+}
+
 func TestFingerprintStatusDecision(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/modules/networkscan/coverage.go
+++ b/modules/networkscan/coverage.go
@@ -1,0 +1,53 @@
+package networkscan
+
+import (
+	"sort"
+
+	"github.com/adithyan-ak/agenthound/sdk/common"
+)
+
+const logicalTargetSetVersion = 1
+
+// TargetSetIdentity describes the exact logical hosts expanded for scheduling
+// without retaining those hosts in artifact metadata.
+type TargetSetIdentity struct {
+	Count  int    `json:"count"`
+	Digest string `json:"digest"`
+}
+
+// LogicalTargetSetIdentity canonicalizes the expanded logical host set. It is
+// intentionally DNS-free: hostname literals remain hostname literals.
+func LogicalTargetSetIdentity(hosts []string) TargetSetIdentity {
+	canonical := append([]string(nil), hosts...)
+	sort.Strings(canonical)
+	canonical = compactSortedStrings(canonical)
+	digest, err := common.CanonicalJSONHash(struct {
+		Version int      `json:"version"`
+		Targets []string `json:"targets"`
+	}{
+		Version: logicalTargetSetVersion,
+		Targets: canonical,
+	})
+	if err != nil {
+		panic("hash logical target strings: " + err.Error())
+	}
+	return TargetSetIdentity{
+		Count:  len(canonical),
+		Digest: "sha256:" + digest,
+	}
+}
+
+func compactSortedStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	write := 1
+	for read := 1; read < len(values); read++ {
+		if values[read] == values[write-1] {
+			continue
+		}
+		values[write] = values[read]
+		write++
+	}
+	return values[:write]
+}

--- a/modules/networkscan/coverage_test.go
+++ b/modules/networkscan/coverage_test.go
@@ -1,0 +1,46 @@
+package networkscan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLogicalTargetSetIdentityTracksExpandedFileContents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "targets.txt")
+	writeTargets := func(contents string) TargetSetIdentity {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write targets: %v", err)
+		}
+		hosts, err := Expand("@"+path, ExpandOptions{})
+		if err != nil {
+			t.Fatalf("expand targets: %v", err)
+		}
+		return LogicalTargetSetIdentity(hosts)
+	}
+
+	first := writeTargets("10.0.0.1\n10.0.0.2\n")
+	reordered := writeTargets("10.0.0.2\n10.0.0.1\n10.0.0.1\n")
+	if first != reordered {
+		t.Fatalf("reordered duplicate targets changed identity: first=%+v reordered=%+v",
+			first, reordered)
+	}
+
+	changed := writeTargets("10.0.0.1\n10.0.0.3\n")
+	if first == changed {
+		t.Fatalf("changed contents retained target identity: %+v", first)
+	}
+}
+
+func TestLogicalTargetSetIdentityPreservesHostnames(t *testing.T) {
+	first := LogicalTargetSetIdentity([]string{"internal.example", "10.0.0.1"})
+	second := LogicalTargetSetIdentity([]string{"10.0.0.1", "internal.example"})
+	if first != second {
+		t.Fatalf("hostname identity depends on order: first=%+v second=%+v",
+			first, second)
+	}
+	if first.Count != 2 {
+		t.Fatalf("target count = %d, want 2", first.Count)
+	}
+}

--- a/modules/networkscan/scanner.go
+++ b/modules/networkscan/scanner.go
@@ -101,6 +101,8 @@ type Scanner struct {
 type ProbeReport struct {
 	Total      int
 	Conclusive int
+	Targets    TargetSetIdentity
+	Ports      []int
 }
 
 func (r ProbeReport) State() ingest.OutcomeState {
@@ -115,11 +117,14 @@ func (r ProbeReport) Unknown() int {
 func (s *Scanner) LastReport() ProbeReport {
 	s.reportMu.RLock()
 	defer s.reportMu.RUnlock()
-	return s.report
+	report := s.report
+	report.Ports = append([]int(nil), s.report.Ports...)
+	return report
 }
 
 func (s *Scanner) setReport(report ProbeReport) {
 	s.reportMu.Lock()
+	report.Ports = append([]int(nil), report.Ports...)
 	s.report = report
 	s.reportMu.Unlock()
 }
@@ -159,6 +164,8 @@ func (s *Scanner) Scan(ctx context.Context, cidr string) ([]action.Target, error
 	if len(ports) == 0 {
 		ports = DefaultPorts
 	}
+	ports = append([]int(nil), ports...)
+	targetSet := LogicalTargetSetIdentity(hosts)
 
 	concurrency := s.Concurrency
 	if concurrency <= 0 {
@@ -264,6 +271,8 @@ producer:
 	s.setReport(ProbeReport{
 		Total:      total,
 		Conclusive: int(conclusive.Load()),
+		Targets:    targetSet,
+		Ports:      ports,
 	})
 
 	if cancelled {

--- a/modules/networkscan/scanner.go
+++ b/modules/networkscan/scanner.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/common"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
 // DefaultPorts is the default AI-service port set. Order does not matter;
@@ -88,6 +90,38 @@ type Scanner struct {
 	// once at the end, so implementations may render directly without
 	// locking. nil disables progress reporting (the default).
 	Progress func(done, total int)
+
+	reportMu sync.RWMutex
+	report   ProbeReport
+}
+
+// ProbeReport records bounded TCP coverage from the most recent Scan.
+// Conclusive includes successful connects and explicit connection refusals.
+// All other failures, panics, and unstarted probes remain indeterminate.
+type ProbeReport struct {
+	Total      int
+	Conclusive int
+}
+
+func (r ProbeReport) State() ingest.OutcomeState {
+	return ingest.ProbeOutcomeState(r.Total, r.Conclusive)
+}
+
+func (r ProbeReport) Unknown() int {
+	return max(0, r.Total-r.Conclusive)
+}
+
+// LastReport returns the immutable coverage counts from the most recent Scan.
+func (s *Scanner) LastReport() ProbeReport {
+	s.reportMu.RLock()
+	defer s.reportMu.RUnlock()
+	return s.report
+}
+
+func (s *Scanner) setReport(report ProbeReport) {
+	s.reportMu.Lock()
+	s.report = report
+	s.reportMu.Unlock()
 }
 
 // hostResult aggregates open ports for a single host with mutex-protected
@@ -108,11 +142,14 @@ func (h *hostResult) appendPort(p int) {
 // parallel via a fixed-size worker pool. Hosts with no open ports are
 // dropped; hosts with at least one open port produce one Target.
 //
-// Returns the targets and a non-nil error only if the expansion itself
-// failed. Probe failures (connection refused, timeout) are normal and
-// silent. Context cancellation returns a partial result plus
-// context.Canceled so the operator's --output can still be written.
+// Returns the targets and a non-nil error only if expansion failed or the
+// context was canceled. Individual probe failures remain silent, while
+// LastReport distinguishes explicit refusal (conclusive closed) from timeout,
+// DNS, reset, panic, and unstarted probes (unknown). Context cancellation
+// returns the retained partial result plus context.Canceled so the operator's
+// output can still be written.
 func (s *Scanner) Scan(ctx context.Context, cidr string) ([]action.Target, error) {
+	s.setReport(ProbeReport{})
 	hosts, err := Expand(cidr, s.ExpandOpts)
 	if err != nil {
 		return nil, fmt.Errorf("expand %q: %w", cidr, err)
@@ -157,6 +194,7 @@ func (s *Scanner) Scan(ctx context.Context, cidr string) ([]action.Target, error
 	// contends with the worker pool. Guarded so a nil Progress costs nothing.
 	total := len(hosts) * len(ports)
 	var completed atomic.Int64
+	var conclusive atomic.Int64
 	var stopReporter, reporterDone chan struct{}
 	if s.Progress != nil && total > 0 {
 		stopReporter = make(chan struct{})
@@ -182,7 +220,9 @@ func (s *Scanner) Scan(ctx context.Context, cidr string) ([]action.Target, error
 		go func() {
 			defer wg.Done()
 			for t := range tasks {
-				probe(ctx, d, t.host, t.port, timeout, results[t.host])
+				if probe(ctx, d, t.host, t.port, timeout, results[t.host]) {
+					conclusive.Add(1)
+				}
 				completed.Add(1)
 			}
 		}()
@@ -221,6 +261,10 @@ producer:
 		}
 		out = append(out, hostResultToTarget(host, r.openPorts, ports))
 	}
+	s.setReport(ProbeReport{
+		Total:      total,
+		Conclusive: int(conclusive.Load()),
+	})
 
 	if cancelled {
 		return out, ctx.Err()
@@ -236,10 +280,18 @@ producer:
 // Wrapped in defer recover() so a misbehaving dialer can't crash the
 // worker pool — the surrounding Scan call should still return useful
 // partial results.
-func probe(ctx context.Context, d dialer, host string, port int, timeout time.Duration, r *hostResult) {
+func probe(
+	ctx context.Context,
+	d dialer,
+	host string,
+	port int,
+	timeout time.Duration,
+	r *hostResult,
+) (conclusive bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			slog.Error("scanner probe panicked", "host", host, "port", port, "panic", rec)
+			conclusive = false
 		}
 	}()
 
@@ -248,10 +300,11 @@ func probe(ctx context.Context, d dialer, host string, port int, timeout time.Du
 	address := net.JoinHostPort(host, strconv.Itoa(port))
 	conn, err := d.DialContext(dialCtx, "tcp", address)
 	if err != nil {
-		return
+		return common.IsConnectionRefused(err)
 	}
 	_ = conn.Close()
 	r.appendPort(port)
+	return true
 }
 
 // hostResultToTarget assembles the final Target per host. The

--- a/modules/networkscan/scanner_test.go
+++ b/modules/networkscan/scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -122,6 +123,18 @@ func TestScanner_NoOpenPorts(t *testing.T) {
 		report.Conclusive != report.Total {
 		t.Fatalf("refused-port report = %+v, want complete", report)
 	}
+	wantTargets := LogicalTargetSetIdentity([]string{
+		"10.0.0.0",
+		"10.0.0.1",
+		"10.0.0.2",
+		"10.0.0.3",
+	})
+	if report.Targets != wantTargets {
+		t.Fatalf("scheduled targets = %+v, want %+v", report.Targets, wantTargets)
+	}
+	if len(report.Ports) != len(DefaultPorts) {
+		t.Fatalf("scheduled ports = %v, want defaults %v", report.Ports, DefaultPorts)
+	}
 }
 
 func TestScanner_ProbeOutcomeAccounting(t *testing.T) {
@@ -178,6 +191,13 @@ func TestScanner_CustomPorts(t *testing.T) {
 	targets, err := s.Scan(context.Background(), "10.0.0.1")
 	if err != nil {
 		t.Fatalf("err = %v", err)
+	}
+	report := s.LastReport()
+	if !slices.Equal(report.Ports, []int{9999, 7777}) {
+		t.Fatalf("scheduled ports = %v, want [9999 7777]", report.Ports)
+	}
+	if report.Targets != LogicalTargetSetIdentity([]string{"10.0.0.1"}) {
+		t.Fatalf("scheduled targets = %+v", report.Targets)
 	}
 	if len(targets) != 1 {
 		t.Fatalf("got %d targets, want 1", len(targets))

--- a/modules/networkscan/scanner_test.go
+++ b/modules/networkscan/scanner_test.go
@@ -8,8 +8,11 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
 // fakeDialer simulates the result of a TCP connect probe without binding any
@@ -42,7 +45,15 @@ func (f *fakeDialer) DialContext(ctx context.Context, _, address string) (net.Co
 		_ = c2.Close()
 		return c1, nil
 	}
-	return nil, &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+	return nil, &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}
+}
+
+type outcomeDialer struct {
+	errors map[string]error
+}
+
+func (d *outcomeDialer) DialContext(_ context.Context, _, address string) (net.Conn, error) {
+	return nil, d.errors[address]
 }
 
 func TestScanner_HappyPath(t *testing.T) {
@@ -106,6 +117,51 @@ func TestScanner_NoOpenPorts(t *testing.T) {
 	if len(targets) != 0 {
 		t.Errorf("got %d targets, want 0", len(targets))
 	}
+	report := s.LastReport()
+	if report.State() != ingest.OutcomeComplete ||
+		report.Conclusive != report.Total {
+		t.Fatalf("refused-port report = %+v, want complete", report)
+	}
+}
+
+func TestScanner_ProbeOutcomeAccounting(t *testing.T) {
+	t.Run("mixed conclusive and unknown is partial", func(t *testing.T) {
+		s := &Scanner{
+			Ports: []int{7001, 7002},
+			Dialer: &outcomeDialer{errors: map[string]error{
+				"10.0.0.1:7001": syscall.ECONNREFUSED,
+				"10.0.0.1:7002": context.DeadlineExceeded,
+			}},
+		}
+		if _, err := s.Scan(context.Background(), "10.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		report := s.LastReport()
+		if report.State() != ingest.OutcomePartial ||
+			report.Total != 2 || report.Conclusive != 1 || report.Unknown() != 1 {
+			t.Fatalf("mixed report = %+v (unknown=%d), want partial 2/1/1",
+				report, report.Unknown())
+		}
+	})
+
+	t.Run("nothing conclusive is failed", func(t *testing.T) {
+		s := &Scanner{
+			Ports: []int{7001, 7002},
+			Dialer: &outcomeDialer{errors: map[string]error{
+				"10.0.0.1:7001": context.DeadlineExceeded,
+				"10.0.0.1:7002": context.DeadlineExceeded,
+			}},
+		}
+		if _, err := s.Scan(context.Background(), "10.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		report := s.LastReport()
+		if report.State() != ingest.OutcomeFailed ||
+			report.Total != 2 || report.Conclusive != 0 || report.Unknown() != 2 {
+			t.Fatalf("unknown-only report = %+v (unknown=%d), want failed 2/0/2",
+				report, report.Unknown())
+		}
+	})
 }
 
 func TestScanner_CustomPorts(t *testing.T) {

--- a/modules/ollamafp/fingerprinter_test.go
+++ b/modules/ollamafp/fingerprinter_test.go
@@ -129,18 +129,21 @@ func TestFingerprint_OpenWebUINearMiss(t *testing.T) {
 	}
 }
 
-func TestFingerprint_NetworkError(t *testing.T) {
+func TestFingerprint_ConnectionRefused(t *testing.T) {
 	f, err := New()
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	// Use a port that's surely closed on loopback.
-	_, err = f.Fingerprint(context.Background(), action.Target{
+	result, err := f.Fingerprint(context.Background(), action.Target{
 		Kind:    "host",
 		Address: "127.0.0.1:1",
 	})
-	if err == nil {
-		t.Fatal("closed-port transport failure must be operationally indeterminate")
+	if err != nil {
+		t.Fatalf("connection refusal should be a definitive no-match: %v", err)
+	}
+	if result.Matched {
+		t.Fatal("connection refusal matched Ollama")
 	}
 }
 

--- a/modules/protoscan/scanner.go
+++ b/modules/protoscan/scanner.go
@@ -96,6 +96,15 @@ type Scanner struct {
 type ProbeReport struct {
 	Total      int
 	Conclusive int
+	Targets    networkscan.TargetSetIdentity
+	Protocols  []ProtocolSurface
+}
+
+// ProtocolSurface is one protocol and the exact port list used to schedule
+// its probes. Inactive protocol port flags never appear.
+type ProtocolSurface struct {
+	Protocol string `json:"protocol"`
+	Ports    []int  `json:"ports"`
 }
 
 func (r ProbeReport) State() ingest.OutcomeState {
@@ -109,13 +118,23 @@ func (r ProbeReport) Unknown() int {
 func (s *Scanner) LastReport() ProbeReport {
 	s.reportMu.RLock()
 	defer s.reportMu.RUnlock()
-	return s.report
+	return cloneProbeReport(s.report)
 }
 
 func (s *Scanner) setReport(report ProbeReport) {
 	s.reportMu.Lock()
-	s.report = report
+	s.report = cloneProbeReport(report)
 	s.reportMu.Unlock()
+}
+
+func cloneProbeReport(report ProbeReport) ProbeReport {
+	cloned := report
+	cloned.Protocols = make([]ProtocolSurface, len(report.Protocols))
+	for i, protocol := range report.Protocols {
+		cloned.Protocols[i] = protocol
+		cloned.Protocols[i].Ports = append([]int(nil), protocol.Ports...)
+	}
+	return cloned
 }
 
 type probeDisposition uint8
@@ -181,6 +200,20 @@ func (s *Scanner) Scan(ctx context.Context, spec string) ([]action.Target, error
 	a2aPorts := s.A2APorts
 	if len(a2aPorts) == 0 {
 		a2aPorts = DefaultA2APorts
+	}
+	targetSet := networkscan.LogicalTargetSetIdentity(hosts)
+	var protocolSurfaces []ProtocolSurface
+	if wantMCP {
+		protocolSurfaces = append(protocolSurfaces, ProtocolSurface{
+			Protocol: "mcp",
+			Ports:    append([]int(nil), mcpPorts...),
+		})
+	}
+	if wantA2A {
+		protocolSurfaces = append(protocolSurfaces, ProtocolSurface{
+			Protocol: "a2a",
+			Ports:    append([]int(nil), a2aPorts...),
+		})
 	}
 
 	type job struct {
@@ -277,6 +310,8 @@ dispatch:
 	s.setReport(ProbeReport{
 		Total:      total,
 		Conclusive: int(conclusive.Load()),
+		Targets:    targetSet,
+		Protocols:  protocolSurfaces,
 	})
 
 	if cancelled {

--- a/modules/protoscan/scanner.go
+++ b/modules/protoscan/scanner.go
@@ -286,8 +286,8 @@ dispatch:
 }
 
 // probeOne issues the protocol-specific probe against host:port. Protocol
-// mismatches and canonical 404/405 responses are definitive negatives.
-// Authentication blocks, redirects, transient statuses, timeouts, TLS/read
+// mismatches in complete 2xx responses are definitive negatives.
+// Authentication blocks, redirects, non-2xx statuses, timeouts, TLS/read
 // failures, and other transport errors remain unknown.
 func (s *Scanner) probeOne(
 	ctx context.Context,
@@ -504,8 +504,6 @@ func classifyHTTPProbeStatus(status int) probeDisposition {
 	switch {
 	case status >= 200 && status < 300:
 		return probePositive
-	case status == http.StatusNotFound || status == http.StatusMethodNotAllowed:
-		return probeNegative
 	default:
 		return probeUnknown
 	}

--- a/modules/protoscan/scanner.go
+++ b/modules/protoscan/scanner.go
@@ -87,7 +87,44 @@ type Scanner struct {
 	Progress func(done, total int)
 
 	httpClient *http.Client
+	reportMu   sync.RWMutex
+	report     ProbeReport
 }
+
+// ProbeReport records endpoint/protocol coverage from the most recent Scan.
+// Conclusive includes positive protocol matches and definitive negatives.
+type ProbeReport struct {
+	Total      int
+	Conclusive int
+}
+
+func (r ProbeReport) State() ingest.OutcomeState {
+	return ingest.ProbeOutcomeState(r.Total, r.Conclusive)
+}
+
+func (r ProbeReport) Unknown() int {
+	return max(0, r.Total-r.Conclusive)
+}
+
+func (s *Scanner) LastReport() ProbeReport {
+	s.reportMu.RLock()
+	defer s.reportMu.RUnlock()
+	return s.report
+}
+
+func (s *Scanner) setReport(report ProbeReport) {
+	s.reportMu.Lock()
+	s.report = report
+	s.reportMu.Unlock()
+}
+
+type probeDisposition uint8
+
+const (
+	probeUnknown probeDisposition = iota
+	probeNegative
+	probePositive
+)
 
 // Mode selects MCP, A2A, or both.
 type Mode int
@@ -107,6 +144,7 @@ const (
 //	"meta.scheme"   = "http" or "https"
 //	"meta.url"      = full base URL
 func (s *Scanner) Scan(ctx context.Context, spec string) ([]action.Target, error) {
+	s.setReport(ProbeReport{})
 	hosts, err := networkscan.Expand(spec, s.ExpandOpts)
 	if err != nil {
 		return nil, err
@@ -172,6 +210,7 @@ func (s *Scanner) Scan(ctx context.Context, spec string) ([]action.Target, error
 	// contends with the worker pool. Guarded so a nil Progress costs nothing.
 	total := len(jobs)
 	var completed atomic.Int64
+	var conclusive atomic.Int64
 	var stopReporter, reporterDone chan struct{}
 	if s.Progress != nil && total > 0 {
 		stopReporter = make(chan struct{})
@@ -201,9 +240,13 @@ func (s *Scanner) Scan(ctx context.Context, spec string) ([]action.Target, error
 				if ctx.Err() != nil {
 					return
 				}
-				if t, ok := s.probeOne(ctx, j.host, j.port, j.protocol); ok {
+				target, disposition := s.probeOne(ctx, j.host, j.port, j.protocol)
+				if disposition != probeUnknown {
+					conclusive.Add(1)
+				}
+				if disposition == probePositive {
 					mu.Lock()
-					results = append(results, t)
+					results = append(results, target)
 					mu.Unlock()
 				}
 				completed.Add(1)
@@ -231,6 +274,10 @@ dispatch:
 		<-reporterDone
 		s.Progress(int(completed.Load()), total)
 	}
+	s.setReport(ProbeReport{
+		Total:      total,
+		Conclusive: int(conclusive.Load()),
+	})
 
 	if cancelled {
 		return results, ctx.Err()
@@ -238,10 +285,16 @@ dispatch:
 	return results, nil
 }
 
-// probeOne issues the protocol-specific probe against host:port. Returns
-// (target, true) on a positive match. Network errors and protocol-shape
-// mismatches both produce (zero, false).
-func (s *Scanner) probeOne(ctx context.Context, host string, port int, protocol string) (action.Target, bool) {
+// probeOne issues the protocol-specific probe against host:port. Protocol
+// mismatches and canonical 404/405 responses are definitive negatives.
+// Authentication blocks, redirects, transient statuses, timeouts, TLS/read
+// failures, and other transport errors remain unknown.
+func (s *Scanner) probeOne(
+	ctx context.Context,
+	host string,
+	port int,
+	protocol string,
+) (action.Target, probeDisposition) {
 	// Try HTTPS first when port suggests it (443/8443), else HTTP.
 	scheme := "http"
 	if port == 443 || port == 8443 {
@@ -250,7 +303,7 @@ func (s *Scanner) probeOne(ctx context.Context, host string, port int, protocol 
 	baseURL := fmt.Sprintf("%s://%s:%d", scheme, host, port)
 	switch protocol {
 	case "mcp":
-		if matchedPath, ok := s.probeMCP(ctx, baseURL); ok {
+		if matchedPath, disposition := s.probeMCP(ctx, baseURL); disposition == probePositive {
 			// Preserve the matched path so the emitted MCPServer endpoint
 			// (and thus its deterministic ID) matches what the mcp/config
 			// collectors hash via ingest.ComputeMCPServerID. Trim a lone
@@ -267,12 +320,14 @@ func (s *Scanner) probeOne(ctx context.Context, host string, port int, protocol 
 					"scheme":   scheme,
 					"url":      endpoint,
 				},
-			}, true
+			}, probePositive
+		} else {
+			return action.Target{}, disposition
 		}
 	case "a2a":
-		card, ok := s.probeA2A(ctx, baseURL)
-		if !ok {
-			return action.Target{}, false
+		card, disposition := s.probeA2A(ctx, baseURL)
+		if disposition != probePositive {
+			return action.Target{}, disposition
 		}
 		return action.Target{
 			Kind:    "host",
@@ -283,16 +338,19 @@ func (s *Scanner) probeOne(ctx context.Context, host string, port int, protocol 
 				"url":            baseURL,
 				"agent_card_url": card,
 			},
-		}, true
+		}, probePositive
 	}
-	return action.Target{}, false
+	return action.Target{}, probeUnknown
 }
 
 // probeMCP POSTs a JSON-RPC initialize at "/" and at "/mcp" (the two
 // most-common path conventions) and, on a canonical
 // {"jsonrpc":"2.0","id":1,"result":{...}} response shape, returns the
 // matched path and true. Returns ("", false) when no path matches.
-func (s *Scanner) probeMCP(ctx context.Context, baseURL string) (string, bool) {
+func (s *Scanner) probeMCP(
+	ctx context.Context,
+	baseURL string,
+) (string, probeDisposition) {
 	payload, _ := json.Marshal(map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -306,10 +364,12 @@ func (s *Scanner) probeMCP(ctx context.Context, baseURL string) (string, bool) {
 			},
 		},
 	})
+	disposition := probeNegative
 	for _, path := range []string{"/", "/mcp"} {
 		url := strings.TrimRight(baseURL, "/") + path
 		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
 		if err != nil {
+			disposition = probeUnknown
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
@@ -318,12 +378,23 @@ func (s *Scanner) probeMCP(ctx context.Context, baseURL string) (string, bool) {
 		req.Header.Set("Accept", "application/json, text/event-stream")
 		resp, err := s.httpClient.Do(req)
 		if err != nil {
+			if classifyProbeError(err) == probeUnknown {
+				disposition = probeUnknown
+			}
 			continue
 		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		body, readErr := readProbeBody(resp.Body)
 		ctype := resp.Header.Get("Content-Type")
 		_ = resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if readErr != nil {
+			disposition = probeUnknown
+			continue
+		}
+		switch classifyHTTPProbeStatus(resp.StatusCode) {
+		case probeUnknown:
+			disposition = probeUnknown
+			continue
+		case probeNegative:
 			continue
 		}
 		// A Streamable HTTP server may frame the initialize response as a single
@@ -347,10 +418,10 @@ func (s *Scanner) probeMCP(ctx context.Context, baseURL string) (string, bool) {
 		}
 		if parsed.JSONRPC == "2.0" && parsed.Result != nil &&
 			(parsed.Result.ServerInfo != nil || parsed.Result.Capabilities != nil) {
-			return path, true
+			return path, probePositive
 		}
 	}
-	return "", false
+	return "", disposition
 }
 
 // extractSSEData concatenates the `data:` field values from an SSE event
@@ -380,21 +451,37 @@ func extractSSEData(body []byte) []byte {
 
 // probeA2A GETs /.well-known/agent-card.json and (on 404) the legacy
 // /.well-known/agent.json. Returns the card URL on a positive match.
-func (s *Scanner) probeA2A(ctx context.Context, baseURL string) (string, bool) {
+func (s *Scanner) probeA2A(
+	ctx context.Context,
+	baseURL string,
+) (string, probeDisposition) {
+	disposition := probeNegative
 	for _, path := range []string{"/.well-known/agent-card.json", "/.well-known/agent.json"} {
 		url := strings.TrimRight(baseURL, "/") + path
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
+			disposition = probeUnknown
 			continue
 		}
 		req.Header.Set("Accept", "application/json")
 		resp, err := s.httpClient.Do(req)
 		if err != nil {
+			if classifyProbeError(err) == probeUnknown {
+				disposition = probeUnknown
+			}
 			continue
 		}
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		body, readErr := readProbeBody(resp.Body)
 		_ = resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if readErr != nil {
+			disposition = probeUnknown
+			continue
+		}
+		switch classifyHTTPProbeStatus(resp.StatusCode) {
+		case probeUnknown:
+			disposition = probeUnknown
+			continue
+		case probeNegative:
 			continue
 		}
 		// Lenient agent-card shape: must have "name" AND ("url" OR
@@ -407,10 +494,40 @@ func (s *Scanner) probeA2A(ctx context.Context, baseURL string) (string, bool) {
 		_, hasURL := parsed["url"].(string)
 		_, hasIfaces := parsed["supportedInterfaces"].([]any)
 		if name != "" && (hasURL || hasIfaces) {
-			return url, true
+			return url, probePositive
 		}
 	}
-	return "", false
+	return "", disposition
+}
+
+func classifyHTTPProbeStatus(status int) probeDisposition {
+	switch {
+	case status >= 200 && status < 300:
+		return probePositive
+	case status == http.StatusNotFound || status == http.StatusMethodNotAllowed:
+		return probeNegative
+	default:
+		return probeUnknown
+	}
+}
+
+func classifyProbeError(err error) probeDisposition {
+	if common.IsConnectionRefused(err) {
+		return probeNegative
+	}
+	return probeUnknown
+}
+
+func readProbeBody(body io.Reader) ([]byte, error) {
+	const maxProbeBody = 1 << 20
+	data, err := io.ReadAll(io.LimitReader(body, maxProbeBody+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxProbeBody {
+		return nil, fmt.Errorf("probe response exceeds %d bytes", maxProbeBody)
+	}
+	return data, nil
 }
 
 // EmitDiscoveryNodes turns the Scanner's positive matches into ingest

--- a/modules/protoscan/scanner_test.go
+++ b/modules/protoscan/scanner_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adithyan-ak/agenthound/modules/networkscan"
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
@@ -86,9 +89,46 @@ func TestScan_DiscoversMCP(t *testing.T) {
 	if got := targets[0].Meta["protocol"]; got != "mcp" {
 		t.Errorf("protocol = %q, want mcp", got)
 	}
-	if report := s.LastReport(); report.State() != ingest.OutcomeComplete ||
+	report := s.LastReport()
+	if report.State() != ingest.OutcomeComplete ||
 		report.Total != 1 || report.Conclusive != 1 {
 		t.Fatalf("positive report = %+v, want complete 1/1", report)
+	}
+	if report.Targets != networkscan.LogicalTargetSetIdentity([]string{"127.0.0.1"}) {
+		t.Fatalf("scheduled targets = %+v", report.Targets)
+	}
+	if len(report.Protocols) != 1 ||
+		report.Protocols[0].Protocol != "mcp" ||
+		!slices.Equal(report.Protocols[0].Ports, s.MCPPorts) {
+		t.Fatalf("scheduled protocols = %+v, want only MCP %v",
+			report.Protocols, s.MCPPorts)
+	}
+}
+
+func TestScanReportExcludesInactiveProtocolPorts(t *testing.T) {
+	srv := mcpStub(t)
+	defer srv.Close()
+
+	activePort := portOf(t, srv)
+	first := &Scanner{
+		Mode:     ModeMCP,
+		MCPPorts: []int{activePort},
+		A2APorts: []int{10001},
+	}
+	if _, err := first.Scan(context.Background(), "127.0.0.1"); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	second := &Scanner{
+		Mode:     ModeMCP,
+		MCPPorts: []int{activePort},
+		A2APorts: []int{20002},
+	}
+	if _, err := second.Scan(context.Background(), "127.0.0.1"); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	if !reflect.DeepEqual(first.LastReport(), second.LastReport()) {
+		t.Fatalf("inactive A2A ports changed report: first=%+v second=%+v",
+			first.LastReport(), second.LastReport())
 	}
 }
 

--- a/modules/protoscan/scanner_test.go
+++ b/modules/protoscan/scanner_test.go
@@ -509,13 +509,18 @@ func TestProbe_RejectsNonMCP(t *testing.T) {
 
 func TestScan_ProtocolProbeOutcomeAccounting(t *testing.T) {
 	negative := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer negative.Close()
 	unknown := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer unknown.Close()
+	concealed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer concealed.Close()
 
 	t.Run("all definitive negatives are complete", func(t *testing.T) {
 		s := &Scanner{Mode: ModeMCP, MCPPorts: []int{portOf(t, negative)}}
@@ -553,6 +558,18 @@ func TestScan_ProtocolProbeOutcomeAccounting(t *testing.T) {
 		if report.State() != ingest.OutcomeFailed ||
 			report.Total != 1 || report.Conclusive != 0 || report.Unknown() != 1 {
 			t.Fatalf("unknown-only report = %+v, want failed 1/0", report)
+		}
+	})
+
+	t.Run("bare 404 is unknown", func(t *testing.T) {
+		s := &Scanner{Mode: ModeMCP, MCPPorts: []int{portOf(t, concealed)}}
+		if _, err := s.Scan(context.Background(), "127.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		report := s.LastReport()
+		if report.State() != ingest.OutcomeFailed ||
+			report.Total != 1 || report.Conclusive != 0 || report.Unknown() != 1 {
+			t.Fatalf("concealed report = %+v, want failed 1/0", report)
 		}
 	})
 
@@ -598,8 +615,8 @@ func TestProtocolProbeClassifiers(t *testing.T) {
 		want   probeDisposition
 	}{
 		{status: http.StatusOK, want: probePositive},
-		{status: http.StatusNotFound, want: probeNegative},
-		{status: http.StatusMethodNotAllowed, want: probeNegative},
+		{status: http.StatusNotFound, want: probeUnknown},
+		{status: http.StatusMethodNotAllowed, want: probeUnknown},
 		{status: http.StatusFound, want: probeUnknown},
 		{status: http.StatusBadRequest, want: probeUnknown},
 		{status: http.StatusUnauthorized, want: probeUnknown},

--- a/modules/protoscan/scanner_test.go
+++ b/modules/protoscan/scanner_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -21,6 +24,12 @@ import (
 
 const initializeOK = `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","serverInfo":{"name":"demo-mcp","version":"0.0.1"},"capabilities":{}}}`
 const a2aCard = `{"name":"demo-agent","url":"http://demo-agent.example/api","description":"demo"}`
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
 
 func mcpStub(t *testing.T) *httptest.Server {
 	t.Helper()
@@ -76,6 +85,10 @@ func TestScan_DiscoversMCP(t *testing.T) {
 	}
 	if got := targets[0].Meta["protocol"]; got != "mcp" {
 		t.Errorf("protocol = %q, want mcp", got)
+	}
+	if report := s.LastReport(); report.State() != ingest.OutcomeComplete ||
+		report.Total != 1 || report.Conclusive != 1 {
+		t.Fatalf("positive report = %+v, want complete 1/1", report)
 	}
 }
 
@@ -491,5 +504,123 @@ func TestProbe_RejectsNonMCP(t *testing.T) {
 	}
 	if len(targets) != 0 {
 		t.Errorf("expected 0 targets (vLLM-shaped body), got %d", len(targets))
+	}
+}
+
+func TestScan_ProtocolProbeOutcomeAccounting(t *testing.T) {
+	negative := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer negative.Close()
+	unknown := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer unknown.Close()
+
+	t.Run("all definitive negatives are complete", func(t *testing.T) {
+		s := &Scanner{Mode: ModeMCP, MCPPorts: []int{portOf(t, negative)}}
+		if _, err := s.Scan(context.Background(), "127.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		report := s.LastReport()
+		if report.State() != ingest.OutcomeComplete ||
+			report.Total != 1 || report.Conclusive != 1 || report.Unknown() != 0 {
+			t.Fatalf("negative report = %+v, want complete 1/1", report)
+		}
+	})
+
+	t.Run("mixed definitive and unknown is partial", func(t *testing.T) {
+		s := &Scanner{
+			Mode:     ModeMCP,
+			MCPPorts: []int{portOf(t, negative), portOf(t, unknown)},
+		}
+		if _, err := s.Scan(context.Background(), "127.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		report := s.LastReport()
+		if report.State() != ingest.OutcomePartial ||
+			report.Total != 2 || report.Conclusive != 1 || report.Unknown() != 1 {
+			t.Fatalf("mixed report = %+v, want partial 2/1", report)
+		}
+	})
+
+	t.Run("nothing conclusive is failed", func(t *testing.T) {
+		s := &Scanner{Mode: ModeMCP, MCPPorts: []int{portOf(t, unknown)}}
+		if _, err := s.Scan(context.Background(), "127.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		report := s.LastReport()
+		if report.State() != ingest.OutcomeFailed ||
+			report.Total != 1 || report.Conclusive != 0 || report.Unknown() != 1 {
+			t.Fatalf("unknown-only report = %+v, want failed 1/0", report)
+		}
+	})
+
+	t.Run("connection refused is a definitive negative", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		tcpAddress, ok := listener.Addr().(*net.TCPAddr)
+		if !ok {
+			t.Fatalf("listener address %T is not TCP", listener.Addr())
+		}
+		port := tcpAddress.Port
+		if err := listener.Close(); err != nil {
+			t.Fatalf("close listener: %v", err)
+		}
+		s := &Scanner{Mode: ModeMCP, MCPPorts: []int{port}}
+		if _, err := s.Scan(context.Background(), "127.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		report := s.LastReport()
+		if report.State() != ingest.OutcomeComplete ||
+			report.Total != 1 || report.Conclusive != 1 {
+			t.Fatalf("refused report = %+v, want complete 1/1", report)
+		}
+	})
+
+	t.Run("zero probes is failed", func(t *testing.T) {
+		s := &Scanner{Mode: Mode(99)}
+		if _, err := s.Scan(context.Background(), "127.0.0.1"); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		if report := s.LastReport(); report.State() != ingest.OutcomeFailed ||
+			report.Total != 0 {
+			t.Fatalf("zero-probe report = %+v, want failed", report)
+		}
+	})
+}
+
+func TestProtocolProbeClassifiers(t *testing.T) {
+	for _, tt := range []struct {
+		status int
+		want   probeDisposition
+	}{
+		{status: http.StatusOK, want: probePositive},
+		{status: http.StatusNotFound, want: probeNegative},
+		{status: http.StatusMethodNotAllowed, want: probeNegative},
+		{status: http.StatusFound, want: probeUnknown},
+		{status: http.StatusBadRequest, want: probeUnknown},
+		{status: http.StatusUnauthorized, want: probeUnknown},
+		{status: http.StatusForbidden, want: probeUnknown},
+		{status: http.StatusProxyAuthRequired, want: probeUnknown},
+		{status: http.StatusServiceUnavailable, want: probeUnknown},
+	} {
+		if got := classifyHTTPProbeStatus(tt.status); got != tt.want {
+			t.Errorf("status %d disposition = %v, want %v", tt.status, got, tt.want)
+		}
+	}
+	if got := classifyProbeError(syscall.ECONNREFUSED); got != probeNegative {
+		t.Errorf("connection-refused disposition = %v, want negative", got)
+	}
+	if got := classifyProbeError(context.DeadlineExceeded); got != probeUnknown {
+		t.Errorf("timeout disposition = %v, want unknown", got)
+	}
+	if _, err := readProbeBody(strings.NewReader(strings.Repeat("x", (1<<20)+1))); err == nil {
+		t.Fatal("oversized body was accepted")
+	}
+	if _, err := readProbeBody(failingReader{}); err == nil {
+		t.Fatal("incomplete body was accepted")
 	}
 }

--- a/modules/vllmfp/fingerprinter_test.go
+++ b/modules/vllmfp/fingerprinter_test.go
@@ -122,17 +122,20 @@ func TestFingerprint_LiteLLMNearMiss(t *testing.T) {
 	}
 }
 
-func TestFingerprint_NetworkError(t *testing.T) {
+func TestFingerprint_ConnectionRefused(t *testing.T) {
 	f, err := New()
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	_, err = f.Fingerprint(context.Background(), action.Target{
+	result, err := f.Fingerprint(context.Background(), action.Target{
 		Kind:    "host",
 		Address: "127.0.0.1:1",
 	})
-	if err == nil {
-		t.Fatal("closed-port transport failure must be operationally indeterminate")
+	if err != nil {
+		t.Fatalf("connection refusal should be a definitive no-match: %v", err)
+	}
+	if result.Matched {
+		t.Fatal("connection refusal matched vLLM")
 	}
 }
 

--- a/modules/vllmfp/fingerprinter_test.go
+++ b/modules/vllmfp/fingerprinter_test.go
@@ -83,15 +83,12 @@ func TestFingerprint_NotVLLM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	res, err := f.Fingerprint(context.Background(), action.Target{
+	_, err = f.Fingerprint(context.Background(), action.Target{
 		Kind:    "host",
 		Address: strings.TrimPrefix(srv.URL, "http://"),
 	})
-	if err != nil {
-		t.Fatalf("Fingerprint err = %v", err)
-	}
-	if res.Matched {
-		t.Error("expected no match for a generic OpenAI-compatible service")
+	if err == nil {
+		t.Fatal("concealed version route must remain indeterminate")
 	}
 }
 
@@ -113,12 +110,9 @@ func TestFingerprint_LiteLLMNearMiss(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	res, err := f.Fingerprint(context.Background(), action.Target{Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://")})
-	if err != nil {
-		t.Fatalf("Fingerprint: %v", err)
-	}
-	if res.Matched {
-		t.Fatal("LiteLLM-compatible OpenAI routes were misclassified as vLLM")
+	_, err = f.Fingerprint(context.Background(), action.Target{Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://")})
+	if err == nil {
+		t.Fatal("concealed version route must remain indeterminate")
 	}
 }
 

--- a/sdk/action/fingerprinter.go
+++ b/sdk/action/fingerprinter.go
@@ -21,9 +21,10 @@ type Fingerprinter interface {
 // return Matched=false with no error (a fingerprinter saying "this is
 // not my service" is normal, not a system failure).
 // A non-nil error means the target was not definitively evaluated (for
-// example transport, timeout, redirect, authentication challenge, bounded-body,
-// or matcher execution failure) and lifecycle-aware callers must treat the
-// corresponding coverage as incomplete.
+// example timeout, TLS/DNS/transport failure other than an explicit connection
+// refusal, redirect, authentication challenge, bounded-body, or matcher
+// execution failure) and lifecycle-aware callers must treat the corresponding
+// coverage as incomplete.
 //
 // IngestData carries the nodes and edges the fingerprinter wants merged into
 // the scan output. Current service fingerprinters emit a per-service,

--- a/sdk/common/network_error.go
+++ b/sdk/common/network_error.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	"errors"
+	"syscall"
+)
+
+// IsConnectionRefused reports whether err proves that the probed TCP endpoint
+// actively rejected the connection. Unlike timeouts, TLS failures, DNS
+// failures, and connection resets, an explicit refusal is a conclusive
+// negative for that host:port at probe time.
+func IsConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}

--- a/sdk/ingest/metadata.go
+++ b/sdk/ingest/metadata.go
@@ -53,6 +53,24 @@ type CollectionOutcome struct {
 	Error             string       `json:"error,omitempty"`
 }
 
+// ProbeOutcomeState classifies a bounded probe set from its total and
+// conclusive counts. Positive matches and definitive negatives are both
+// conclusive. Operationally indeterminate and unstarted probes are not.
+//
+// A zero-probe run is failed rather than complete: it did not establish
+// coverage. A run with no conclusive result is likewise failed. Mixed
+// conclusive and indeterminate results are partial.
+func ProbeOutcomeState(total, conclusive int) OutcomeState {
+	switch {
+	case total <= 0 || conclusive <= 0:
+		return OutcomeFailed
+	case conclusive < total:
+		return OutcomePartial
+	default:
+		return OutcomeComplete
+	}
+}
+
 // EnsureCoverageParentage serializes lifecycle ownership explicitly. It is
 // called by the collector immediately before encoding an artifact; the server
 // never reconstructs parentage by parsing opaque coverage-key strings.

--- a/sdk/ingest/probe_outcome_test.go
+++ b/sdk/ingest/probe_outcome_test.go
@@ -1,0 +1,25 @@
+package ingest
+
+import "testing"
+
+func TestProbeOutcomeState(t *testing.T) {
+	tests := []struct {
+		name       string
+		total      int
+		conclusive int
+		want       OutcomeState
+	}{
+		{name: "all conclusive", total: 4, conclusive: 4, want: OutcomeComplete},
+		{name: "mixed", total: 4, conclusive: 3, want: OutcomePartial},
+		{name: "none conclusive", total: 4, conclusive: 0, want: OutcomeFailed},
+		{name: "zero probes", total: 0, conclusive: 0, want: OutcomeFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProbeOutcomeState(tt.total, tt.conclusive); got != tt.want {
+				t.Fatalf("ProbeOutcomeState(%d, %d) = %q, want %q",
+					tt.total, tt.conclusive, got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/rules/fingerprint.go
+++ b/sdk/rules/fingerprint.go
@@ -297,9 +297,9 @@ func validateFingerprintMatcher(prefix string, m FingerprintMatch) []ValidationE
 // "http://10.0.0.42:11434") and returns the result. The returned
 // FingerprintResult.Matched is true only when every probe and every
 // matcher succeeds. A complete, bounded response whose matcher does not
-// match, a canonical 404/405, or an explicit connection refusal yields
-// Matched=false with a nil error. Other transport failures, redirects,
-// authentication challenges, and non-2xx responses return an error so
+// match or an explicit connection refusal yields Matched=false with a nil
+// error. Other transport failures, redirects, authentication challenges,
+// and non-2xx responses return an error so
 // lifecycle-aware callers do not turn an unevaluated endpoint into
 // authoritative absence.
 //
@@ -368,8 +368,8 @@ func RunFingerprint(ctx context.Context, client *http.Client, baseURL string, ru
 // runProbe issues one HTTP request, applies its matchers, and returns
 // (matched, captures, err). A non-nil error means the endpoint was not
 // definitively evaluated (transport other than explicit refusal, redirect,
-// authentication challenge, non-2xx status other than canonical 404/405,
-// incomplete body, or matcher runtime failure). A complete response that
+// authentication challenge, non-2xx status, incomplete body, or matcher
+// runtime failure). A complete response that
 // simply fails a matcher returns (false, nil, nil).
 func runProbe(ctx context.Context, client *http.Client, baseURL string, probe FingerprintProbe) (bool, map[string]string, error) {
 	// Concatenate baseURL and probe.Path with exactly one "/" between them.
@@ -390,9 +390,7 @@ func runProbe(ctx context.Context, client *http.Client, baseURL string, probe Fi
 		return false, nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if (resp.StatusCode < 200 || resp.StatusCode >= 300) &&
-		resp.StatusCode != http.StatusNotFound &&
-		resp.StatusCode != http.StatusMethodNotAllowed {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return false, nil, fmt.Errorf("indeterminate response status %d", resp.StatusCode)
 	}
 

--- a/sdk/rules/fingerprint.go
+++ b/sdk/rules/fingerprint.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"gopkg.in/yaml.v3"
 )
 
@@ -296,9 +297,10 @@ func validateFingerprintMatcher(prefix string, m FingerprintMatch) []ValidationE
 // "http://10.0.0.42:11434") and returns the result. The returned
 // FingerprintResult.Matched is true only when every probe and every
 // matcher succeeds. A complete, bounded response whose matcher does not
-// match yields Matched=false with a nil error. Operational failures,
-// redirects, authentication challenges, and transient responses return an
-// error so lifecycle-aware callers do not turn an unevaluated endpoint into
+// match, a canonical 404/405, or an explicit connection refusal yields
+// Matched=false with a nil error. Other transport failures, redirects,
+// authentication challenges, and non-2xx responses return an error so
+// lifecycle-aware callers do not turn an unevaluated endpoint into
 // authoritative absence.
 //
 // Captures are accumulated across probes; later captures with the same
@@ -365,9 +367,10 @@ func RunFingerprint(ctx context.Context, client *http.Client, baseURL string, ru
 
 // runProbe issues one HTTP request, applies its matchers, and returns
 // (matched, captures, err). A non-nil error means the endpoint was not
-// definitively evaluated (transport, redirect, authentication challenge,
-// transient status, incomplete body, or matcher runtime failure). A complete
-// response that simply fails a matcher returns (false, nil, nil).
+// definitively evaluated (transport other than explicit refusal, redirect,
+// authentication challenge, non-2xx status other than canonical 404/405,
+// incomplete body, or matcher runtime failure). A complete response that
+// simply fails a matcher returns (false, nil, nil).
 func runProbe(ctx context.Context, client *http.Client, baseURL string, probe FingerprintProbe) (bool, map[string]string, error) {
 	// Concatenate baseURL and probe.Path with exactly one "/" between them.
 	url := strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(probe.Path, "/")
@@ -381,19 +384,16 @@ func runProbe(ctx context.Context, client *http.Client, baseURL string, probe Fi
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		if common.IsConnectionRefused(err) {
+			return false, nil, nil
+		}
 		return false, nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-		return false, nil, fmt.Errorf("redirect response status %d", resp.StatusCode)
-	}
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden ||
-		resp.StatusCode == http.StatusProxyAuthRequired {
-		return false, nil, fmt.Errorf("authentication challenge status %d", resp.StatusCode)
-	}
-	if resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooEarly ||
-		resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-		return false, nil, fmt.Errorf("transient response status %d", resp.StatusCode)
+	if (resp.StatusCode < 200 || resp.StatusCode >= 300) &&
+		resp.StatusCode != http.StatusNotFound &&
+		resp.StatusCode != http.StatusMethodNotAllowed {
+		return false, nil, fmt.Errorf("indeterminate response status %d", resp.StatusCode)
 	}
 
 	// Read one byte beyond the 1 MiB cap so truncation cannot be evaluated as

--- a/sdk/rules/fingerprint_test.go
+++ b/sdk/rules/fingerprint_test.go
@@ -131,22 +131,6 @@ func TestRunFingerprint_OllamaHappyPath(t *testing.T) {
 }
 
 func TestRunFingerprint_NoMatch_WrongStatusOrShape(t *testing.T) {
-	t.Run("404 fails http_status matcher", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(404)
-		}))
-		defer srv.Close()
-		rule := minimalOllamaRule()
-		res, err := RunFingerprint(context.Background(),
-			DefaultFingerprintHTTPClient(2*time.Second), srv.URL, rule)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if res.Matched {
-			t.Error("expected no match on 404")
-		}
-	})
-
 	t.Run("malformed JSON fails json_path", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(200)
@@ -189,6 +173,8 @@ func TestRunFingerprint_OperationallyIndeterminateResponses(t *testing.T) {
 		{"unauthorized", http.StatusUnauthorized},
 		{"forbidden", http.StatusForbidden},
 		{"proxy authentication required", http.StatusProxyAuthRequired},
+		{"concealed not found", http.StatusNotFound},
+		{"method not allowed", http.StatusMethodNotAllowed},
 		{"bad request", http.StatusBadRequest},
 		{"not acceptable", http.StatusNotAcceptable},
 		{"request timeout", http.StatusRequestTimeout},

--- a/sdk/rules/fingerprint_test.go
+++ b/sdk/rules/fingerprint_test.go
@@ -164,14 +164,17 @@ func TestRunFingerprint_NoMatch_WrongStatusOrShape(t *testing.T) {
 		}
 	})
 
-	t.Run("network error is operationally indeterminate", func(t *testing.T) {
+	t.Run("connection refused is a definitive no-match", func(t *testing.T) {
 		// Use a port we know is closed.
 		rule := minimalOllamaRule()
-		_, err := RunFingerprint(context.Background(),
+		result, err := RunFingerprint(context.Background(),
 			DefaultFingerprintHTTPClient(500*time.Millisecond),
 			"http://127.0.0.1:1", rule)
-		if err == nil {
-			t.Fatal("expected an operational error for a failed connection")
+		if err != nil {
+			t.Fatalf("connection refusal returned an indeterminate error: %v", err)
+		}
+		if result.Matched {
+			t.Fatal("connection refusal matched")
 		}
 	})
 }
@@ -186,6 +189,8 @@ func TestRunFingerprint_OperationallyIndeterminateResponses(t *testing.T) {
 		{"unauthorized", http.StatusUnauthorized},
 		{"forbidden", http.StatusForbidden},
 		{"proxy authentication required", http.StatusProxyAuthRequired},
+		{"bad request", http.StatusBadRequest},
+		{"not acceptable", http.StatusNotAcceptable},
 		{"request timeout", http.StatusRequestTimeout},
 		{"too early", http.StatusTooEarly},
 		{"rate limited", http.StatusTooManyRequests},

--- a/server/internal/ingest/publication_integration_test.go
+++ b/server/internal/ingest/publication_integration_test.go
@@ -508,6 +508,92 @@ func TestIntegrationFreshSchemaEmptyIngestPublishesUnderThreeSeconds(t *testing.
 	}
 }
 
+func TestIntegrationProbeContractRetiresOnlyExactCoverageKey(t *testing.T) {
+	ctx, pipeline, db, _, _ := freshPublicationIntegrationHarness(t)
+	scopeA := sdkingest.CanonicalCoverageKey(
+		"scan",
+		"network",
+		"sha256:"+strings.Repeat("1", 64),
+	)
+	scopeB := sdkingest.CanonicalCoverageKey(
+		"scan",
+		"network",
+		"sha256:"+strings.Repeat("2", 64),
+	)
+	const endpoint = "http://127.0.0.1:18085/mcp"
+	nodeID := sdkingest.ComputeMCPServerID("http", endpoint)
+
+	artifact := func(scanID, scope string, nodes []sdkingest.Node) *sdkingest.IngestData {
+		data := newPublicationIntegrationData("scan", scanID)
+		data.Meta.Collection = &sdkingest.CollectionReport{
+			State:        sdkingest.OutcomeComplete,
+			CoverageKeys: []string{scope},
+			Outcomes: []sdkingest.CollectionOutcome{{
+				Collector:   "scan",
+				CoverageKey: scope,
+				Target:      "expanded-target-set",
+				Method:      "port_scan",
+				State:       sdkingest.OutcomeComplete,
+				Items:       len(nodes),
+			}},
+		}
+		data.Graph.Nodes = append([]sdkingest.Node{}, nodes...)
+		return data
+	}
+	nodePresent := func() bool {
+		t.Helper()
+		node, _, err := db.GetNode(ctx, nodeID)
+		if err != nil {
+			t.Fatalf("query service: %v", err)
+		}
+		return node != nil
+	}
+
+	first := artifact("probe-contract-a-positive", scopeA, []sdkingest.Node{{
+		ID:                 nodeID,
+		Kinds:              []string{"MCPServer"},
+		ObservationDomains: []string{scopeA},
+		Properties: map[string]any{
+			"name":      "probe-contract-service",
+			"transport": "http",
+			"endpoint":  endpoint,
+		},
+	}})
+	if result, err := pipeline.Ingest(ctx, first); err != nil {
+		t.Fatalf("initial contract ingest: %v", err)
+	} else if result.PublishedRevision == nil {
+		t.Fatalf("initial contract did not publish: %+v", result)
+	}
+	nodeID = first.Graph.Nodes[0].ID
+	if !nodePresent() {
+		t.Fatal("initial contract service was not retained")
+	}
+
+	if result, err := pipeline.Ingest(
+		ctx,
+		artifact("probe-contract-b-empty", scopeB, nil),
+	); err != nil {
+		t.Fatalf("different contract empty ingest: %v", err)
+	} else if result.PublishedRevision == nil {
+		t.Fatalf("different contract did not publish: %+v", result)
+	}
+	if !nodePresent() {
+		t.Fatal("different contract incorrectly retired retained service")
+	}
+
+	if result, err := pipeline.Ingest(
+		ctx,
+		artifact("probe-contract-a-empty", scopeA, nil),
+	); err != nil {
+		t.Fatalf("exact contract empty ingest: %v", err)
+	} else if result.PublishedRevision == nil {
+		t.Fatalf("exact contract did not publish: %+v", result)
+	}
+	if nodePresent() {
+		t.Fatal("exact contract did not retire absent service")
+	}
+}
+
 func TestIntegrationExhaustiveRootRemovesMissingChildAcrossGraphAndPublication(t *testing.T) {
 	ctx, pipeline, db, _, pool := freshPublicationIntegrationHarness(t)
 	root := sdkingest.CanonicalCoverageKey("mcp", "root", "collect")


### PR DESCRIPTION
## Summary

- classify TCP, HTTP fingerprint, and MCP/A2A discovery probes as conclusive or unknown
- report complete only when every scheduled probe is conclusive, partial for mixed coverage, and failed when nothing is conclusive
- preserve positive facts while marking auth blocks, bare 404/405 responses, TLS/timeouts, transient responses, incomplete bodies, and unstarted probes as incomplete coverage
- treat fully read non-matching 2xx responses and explicit connection refusal as definitive negatives
- make zero-probe fingerprint dispatch explicit instead of silently complete

## Scope

This is intentionally stacked on #121. It changes scanner coverage metadata and warnings only; emitted positive graph facts and matching identities are unchanged.

## Validation

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test -timeout 20m ./... -race`
- `make docs-check`
- `make prerelease` (all 13 gates pass)