### PR TITLE
Fix release E2E contract defects

### DIFF
--- a/server/internal/api/handlers/docs_test.go
+++ b/server/internal/api/handlers/docs_test.go
@@ -140,8 +140,23 @@ func TestOpenAPIRuntimeParityContracts(t *testing.T) {
 	if got := scanListPage["$ref"]; got != "#/components/schemas/ScanPageMetadata" {
 		t.Fatalf("ScanListResponse.page ref = %v, want ScanPageMetadata", got)
 	}
+	requireSchemaFields(t, schemas, "RuleListResponse", "rules", "total")
 
 	paths := nestedMap(t, spec, "paths")
+	ruleListSchema := nestedMap(
+		t,
+		paths,
+		"/rules",
+		"get",
+		"responses",
+		"200",
+		"content",
+		"application/json",
+		"schema",
+	)
+	if got := ruleListSchema["$ref"]; got != "#/components/schemas/RuleListResponse" {
+		t.Fatalf("GET /rules 200 schema ref = %v, want RuleListResponse", got)
+	}
 	searchLimit := operationParameter(t, paths, "/graph/search", "get", "limit")
 	requireIntegerContract(
 		t,

--- a/server/internal/api/handlers/health.go
+++ b/server/internal/api/handlers/health.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -11,38 +12,64 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+const healthCheckTimeout = 5 * time.Second
+
+type healthPinger interface {
+	Ping(context.Context) error
+}
+
 type HealthHandler struct {
-	reader *graph.Reader
-	pgPool *pgxpool.Pool
+	reader  healthPinger
+	pgPool  healthPinger
+	timeout time.Duration
 }
 
 func NewHealthHandler(reader *graph.Reader, pgPool *pgxpool.Pool) *HealthHandler {
-	return &HealthHandler{reader: reader, pgPool: pgPool}
+	handler := &HealthHandler{timeout: healthCheckTimeout}
+	if reader != nil {
+		handler.reader = reader
+	}
+	if pgPool != nil {
+		handler.pgPool = pgPool
+	}
+	return handler
 }
 
 func (h *HealthHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), h.timeout)
 	defer cancel()
 
 	resp := map[string]string{"status": "ok"}
 	statusCode := http.StatusOK
 
-	if err := h.reader.Ping(ctx); err != nil {
-		slog.Error("neo4j health check failed", "error", err)
-		resp["neo4j"] = "unavailable"
-		resp["status"] = "degraded"
-		statusCode = http.StatusServiceUnavailable
-	} else {
-		resp["neo4j"] = "ok"
+	type result struct {
+		dependency string
+		err        error
 	}
+	results := make(chan result, 2)
+	probe := func(dependency string, pinger healthPinger) {
+		if pinger == nil {
+			results <- result{
+				dependency: dependency,
+				err:        errors.New("dependency is not configured"),
+			}
+			return
+		}
+		results <- result{dependency: dependency, err: pinger.Ping(ctx)}
+	}
+	go probe("neo4j", h.reader)
+	go probe("postgres", h.pgPool)
 
-	if err := h.pgPool.Ping(ctx); err != nil {
-		slog.Error("postgres health check failed", "error", err)
-		resp["postgres"] = "unavailable"
-		resp["status"] = "degraded"
-		statusCode = http.StatusServiceUnavailable
-	} else {
-		resp["postgres"] = "ok"
+	for range 2 {
+		check := <-results
+		if check.err != nil {
+			slog.Error(check.dependency+" health check failed", "error", check.err)
+			resp[check.dependency] = "unavailable"
+			resp["status"] = "degraded"
+			statusCode = http.StatusServiceUnavailable
+		} else {
+			resp[check.dependency] = "ok"
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/api/handlers/health_test.go
+++ b/server/internal/api/handlers/health_test.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type healthPingerFunc func(context.Context) error
+
+func (f healthPingerFunc) Ping(ctx context.Context) error {
+	return f(ctx)
+}
+
+func TestHealthHandlerProbesDependenciesConcurrently(t *testing.T) {
+	postgresStarted := make(chan struct{})
+	handler := &HealthHandler{
+		reader: healthPingerFunc(func(ctx context.Context) error {
+			select {
+			case <-postgresStarted:
+				return errors.New("neo4j unavailable")
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}),
+		pgPool: healthPingerFunc(func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				close(postgresStarted)
+				return nil
+			}
+		}),
+		timeout: 100 * time.Millisecond,
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	handler.Handle(recorder, request)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	var response map[string]string
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if response["status"] != "degraded" ||
+		response["neo4j"] != "unavailable" ||
+		response["postgres"] != "ok" {
+		t.Fatalf("health response = %v", response)
+	}
+}
+
+func TestHealthHandlerReportsMissingDependencies(t *testing.T) {
+	handler := NewHealthHandler(nil, nil)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	handler.Handle(recorder, request)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	var response map[string]string
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if response["status"] != "degraded" ||
+		response["neo4j"] != "unavailable" ||
+		response["postgres"] != "unavailable" {
+		t.Fatalf("health response = %v", response)
+	}
+}

--- a/server/internal/api/handlers/openapi.yaml
+++ b/server/internal/api/handlers/openapi.yaml
@@ -1233,6 +1233,19 @@ components:
         source:
           type: string
 
+    RuleListResponse:
+      type: object
+      additionalProperties: false
+      required: [rules, total]
+      properties:
+        rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/Rule"
+        total:
+          type: integer
+          minimum: 0
+
     NormalizationWarning:
       type: object
       additionalProperties: false
@@ -2605,9 +2618,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Rule"
+                $ref: "#/components/schemas/RuleListResponse"
 
   /rules/{id}:
     get:

--- a/server/internal/appdb/coverage_state.go
+++ b/server/internal/appdb/coverage_state.go
@@ -23,7 +23,7 @@ type coverageHead struct {
 
 func normalizeCoverageKeys(groups ...[]string) []string {
 	seen := make(map[string]bool)
-	var keys []string
+	keys := make([]string, 0)
 	for _, group := range groups {
 		for _, key := range group {
 			key = strings.TrimSpace(key)

--- a/server/internal/appdb/publication_store_test.go
+++ b/server/internal/appdb/publication_store_test.go
@@ -1058,6 +1058,46 @@ func TestBuildPostureExportDeclaresHealthAndCompleteState(t *testing.T) {
 	}
 }
 
+func TestBuildPostureExportUsesNonNullEmptyCoverageArrays(t *testing.T) {
+	now := time.Now().UTC()
+	export := buildPostureExport(
+		FinalizeScanParams{
+			Scan: model.Scan{
+				ID:          "scan-empty-coverage",
+				StartedAt:   now,
+				CompletedAt: &now,
+			},
+		},
+		1,
+		now,
+		nil,
+		model.PostureComparison{},
+		nil,
+		nil,
+		nil,
+	)
+
+	encoded, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal posture export: %v", err)
+	}
+	var payload struct {
+		Scope struct {
+			CoverageKeys       json.RawMessage `json:"coverage_keys"`
+			ActiveCoverageKeys json.RawMessage `json:"active_coverage_keys"`
+		} `json:"scope"`
+	}
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("unmarshal posture export: %v", err)
+	}
+	if got := string(payload.Scope.CoverageKeys); got != "[]" {
+		t.Fatalf("coverage_keys = %s, want []", got)
+	}
+	if got := string(payload.Scope.ActiveCoverageKeys); got != "[]" {
+		t.Fatalf("active_coverage_keys = %s, want []", got)
+	}
+}
+
 func TestCoverageRootHeadsAcceptsRegisteredInstructionRootStates(t *testing.T) {
 	contract := sdkingest.CurrentInstructionRegistryContract()
 	for _, mode := range []struct {


### PR DESCRIPTION
## What changed

- Serialize empty posture coverage-key sets as `[]` instead of `null`.
- Align the `GET /rules` OpenAPI response with the runtime `{rules, total}` envelope.
- Probe Neo4j and Postgres concurrently within the existing five-second health-check budget.
- Add focused regressions for empty export coverage, OpenAPI parity, concurrent health probes, and missing dependencies.

## Why

Release E2E validation confirmed three true positives:

1. A first publication with no active coverage heads could persist `active_coverage_keys: null`, which the posture export validator rejected.
2. The OpenAPI contract declared `GET /rules` as a top-level array while the handler returns an object envelope.
3. Sequential health probes let a slow Neo4j check consume the shared deadline before Postgres was checked, falsely reporting Postgres unavailable.

## Impact

Posture exports remain valid for empty coverage, generated API clients see the actual rules response shape, and health output attributes dependency failures accurately. Runtime behavior for the two findings classified as intentional remains unchanged.

## Validation

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./... -race`
