### PR TITLE
Fix P1 A2A, Windows rules, and ingest recovery blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,18 @@ jobs:
           GOARCH: ${{ matrix.arch }}
         run: go build -trimpath -ldflags='-s -w' -o /dev/null ./server/cmd/agenthound-server
 
+  windows-rules:
+    if: github.event_name == 'pull_request'
+    runs-on: windows-latest
+    needs: [test-unit]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        with:
+          go-version: "1.25.12"
+      - name: Load embedded rules natively
+        run: go test ./sdk/rules -count=1
+
   docker:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,8 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version: "1.25.12"
-      - name: Load embedded rules natively
-        run: go test ./sdk/rules -count=1
+      - name: Exercise Windows rules support natively
+        run: go test ./sdk/common ./sdk/rules -count=1
 
   docker:
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@
   before the destination receives a request.
 - **Native Windows embedded rules.** Built-in detection and fingerprint rules
   use slash-based embedded filesystem paths and are exercised on a native
-  Windows CI runner.
+  Windows CI runner. Native fingerprint probes also recognize Winsock
+  connection refusals.
 - **Truthful interrupted-ingest recovery.** Server startup and an idle recovery
   loop terminalize orphaned running scans, retain the previous publication and
   dirty coverage, and leave the mutable projection safely incomplete until a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@
 - **Strict ingest-v1 boundary.** Wire version and registered-source contract
   mismatches are rejected before storage access. Storage binding v1 requires a
   clean paired PostgreSQL/Neo4j initialization.
+- **Origin-bound A2A bearer redirects.** Authenticated Agent Card requests now
+  reject host, port, or scheme changes, and all HTTPS-to-HTTP redirects fail
+  before the destination receives a request.
+- **Native Windows embedded rules.** Built-in detection and fingerprint rules
+  use slash-based embedded filesystem paths and are exercised on a native
+  Windows CI runner.
+- **Truthful interrupted-ingest recovery.** Server startup and an idle recovery
+  loop terminalize orphaned running scans, retain the previous publication and
+  dirty coverage, and leave the mutable projection safely incomplete until a
+  later authoritative ingest repairs it.
 - **No false clean instruction score.** Agent poisoning risk uses observed
   `LOADS_INSTRUCTIONS` relationships only; missing load relationships remain
   an assessment limitation. Published truncated posture remains visible in the

--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -420,8 +420,9 @@ Terminal statuses:
   coverage remains limited; or a required later stage failed and the previous
   published posture remains selected. Check `publication_status` and
   `published_revision` to distinguish those cases.
-- `failed` — a raw graph write failed; actual committed write rows and the
-  failed stage are persisted.
+- `failed` — a raw graph write failed, or the process stopped before it could
+  durably finalize the attempt. Actual committed write rows are persisted when
+  known; restart recovery conservatively treats unfinished stages as failed.
 
 The scan row stores summary lifecycle/publication state and frozen totals;
 metadata JSONB stores detailed coverage, rules, identity, normalization
@@ -432,6 +433,14 @@ each scope. A later published `complete` or `not_applicable` outcome clears that
 scope; an authoritative root also retires stale child limitations.
 `posture_state` separates the current mutable attempt from the selected
 published revision.
+
+The serving process checks for interrupted `running` attempts before accepting
+requests and periodically while the ingest pipeline is idle. Recovery marks
+those attempts `failed` and changes a stranded `updating` projection to
+`incomplete`. It preserves the prior publication, coverage state, and dirty
+coverage. Public graph reads remain conflict-blocked until a later
+authoritative ingest repairs the mutable Neo4j projection; restart recovery
+never assumes that partially committed graph writes are safe to publish.
 
 `DELETE /api/v1/scans/{id}` is history-only. It never mutates Neo4j and rejects
 pending/running, active coverage-head, active coverage-limitation, and currently

--- a/docs/operator/security.md
+++ b/docs/operator/security.md
@@ -423,6 +423,11 @@ A2A v1.0.1 signature verification separates cryptographic validity from identity
 
 Remote `jku` requires HTTPS on the initial request and every redirect, validates the certificate identity even when `--insecure` is used for card retrieval, blocks link-local/metadata destinations, rejects fragments, and bounds redirects, bytes, key count, signatures, unique remote sources, and aggregate verification time. Invalid, expired, or explicitly revoked key evidence is rejected. Operators needing private/self-signed key infrastructure must pin the key locally with `--a2a-trusted-keys`; `--insecure` is not a bypass.
 
+Bearer-authenticated Agent Card retrieval permits redirects only within the
+original HTTP origin: scheme, hostname, and effective port must all match.
+HTTPS-to-HTTP redirects are rejected even without a bearer credential.
+Redirect failures never include the credential in errors or logs.
+
 Card conformance and signature state qualify functional A2A edges. Invalid
 cards are retained for visibility, but declarations alone do not create active
 authentication identities or edges. A v1.0.1 empty security requirement is a

--- a/modules/a2a/fetch.go
+++ b/modules/a2a/fetch.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/adithyan-ak/agenthound/sdk/common"
@@ -44,7 +46,7 @@ func FetchAgentCard(ctx context.Context, targetURL string, authToken string, ins
 			if len(via) >= 5 {
 				return fmt.Errorf("too many redirects (max 5)")
 			}
-			return nil
+			return validateAgentCardRedirect(req, via, authToken != "")
 		},
 	}
 
@@ -61,6 +63,45 @@ func FetchAgentCard(ctx context.Context, targetURL string, authToken string, ins
 	}
 
 	return card, nil
+}
+
+func validateAgentCardRedirect(
+	req *http.Request,
+	via []*http.Request,
+	credentialed bool,
+) error {
+	if len(via) == 0 {
+		return nil
+	}
+	original := via[0].URL
+	if strings.EqualFold(original.Scheme, "https") &&
+		!strings.EqualFold(req.URL.Scheme, "https") {
+		return fmt.Errorf("agent card redirect cannot downgrade from HTTPS")
+	}
+	if credentialed && !sameHTTPOrigin(original, req.URL) {
+		return fmt.Errorf("agent card redirect cannot change bearer credential origin")
+	}
+	return nil
+}
+
+func sameHTTPOrigin(left, right *url.URL) bool {
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) &&
+		effectiveHTTPPort(left) == effectiveHTTPPort(right)
+}
+
+func effectiveHTTPPort(parsed *url.URL) string {
+	if port := parsed.Port(); port != "" {
+		return port
+	}
+	switch {
+	case strings.EqualFold(parsed.Scheme, "http"):
+		return "80"
+	case strings.EqualFold(parsed.Scheme, "https"):
+		return "443"
+	default:
+		return ""
+	}
 }
 
 type FetchError struct {

--- a/modules/a2a/fetch_test.go
+++ b/modules/a2a/fetch_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -126,6 +127,140 @@ func TestFetchAgentCard_AuthHeader(t *testing.T) {
 	}
 	if gotAuth != "Bearer test-token-123" {
 		t.Errorf("expected Authorization header 'Bearer test-token-123', got %q", gotAuth)
+	}
+}
+
+func TestFetchAgentCard_CredentialedSameOriginRedirect(t *testing.T) {
+	body := loadFixture(t, "agent_card_v10.json")
+	var redirectedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case v10Path:
+			http.Redirect(w, r, "/redirected-card", http.StatusTemporaryRedirect)
+		case "/redirected-card":
+			redirectedAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := FetchAgentCard(
+		context.Background(),
+		srv.URL,
+		"same-origin-token",
+		false,
+		time.Second,
+	); err != nil {
+		t.Fatalf("same-origin redirect: %v", err)
+	}
+	if redirectedAuth != "Bearer same-origin-token" {
+		t.Fatalf("redirected Authorization = %q", redirectedAuth)
+	}
+}
+
+func TestFetchAgentCard_RejectsCredentialedCrossPortRedirect(t *testing.T) {
+	var destinationRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		destinationRequests.Add(1)
+	}))
+	t.Cleanup(destination.Close)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(source.Close)
+
+	_, err := FetchAgentCard(
+		context.Background(),
+		source.URL,
+		"cross-port-token",
+		false,
+		time.Second,
+	)
+	if err == nil || !strings.Contains(err.Error(), "credential origin") {
+		t.Fatalf("expected credential-origin redirect error, got %v", err)
+	}
+	if destinationRequests.Load() != 0 {
+		t.Fatalf("cross-port destination received %d requests", destinationRequests.Load())
+	}
+}
+
+func TestFetchAgentCard_RejectsCredentialedCrossHostRedirect(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	var source *httptest.Server
+	source = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == v10Path {
+			redirectURL := strings.Replace(source.URL, "127.0.0.1", "localhost", 1) + "/redirected-card"
+			http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+			return
+		}
+		redirectedRequests.Add(1)
+	}))
+	t.Cleanup(source.Close)
+
+	_, err := FetchAgentCard(
+		context.Background(),
+		source.URL,
+		"cross-host-token",
+		false,
+		time.Second,
+	)
+	if err == nil || !strings.Contains(err.Error(), "credential origin") {
+		t.Fatalf("expected credential-origin redirect error, got %v", err)
+	}
+	if redirectedRequests.Load() != 0 {
+		t.Fatalf("cross-host destination received %d requests", redirectedRequests.Load())
+	}
+}
+
+func TestFetchAgentCard_RejectsHTTPSDowngradeRedirect(t *testing.T) {
+	var destinationRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		destinationRequests.Add(1)
+	}))
+	t.Cleanup(destination.Close)
+	source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(source.Close)
+
+	_, err := FetchAgentCard(
+		context.Background(),
+		source.URL,
+		"downgrade-token",
+		true,
+		time.Second,
+	)
+	if err == nil || !strings.Contains(err.Error(), "downgrade") {
+		t.Fatalf("expected HTTPS downgrade error, got %v", err)
+	}
+	if destinationRequests.Load() != 0 {
+		t.Fatalf("downgraded destination received %d requests", destinationRequests.Load())
+	}
+}
+
+func TestFetchAgentCard_CredentialFreeCrossPortRedirect(t *testing.T) {
+	body := loadFixture(t, "agent_card_v10.json")
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(destination.Close)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL, http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(source.Close)
+
+	if _, err := FetchAgentCard(
+		context.Background(),
+		source.URL,
+		"",
+		false,
+		time.Second,
+	); err != nil {
+		t.Fatalf("credential-free cross-port redirect: %v", err)
 	}
 }
 

--- a/sdk/common/network_error.go
+++ b/sdk/common/network_error.go
@@ -2,13 +2,21 @@ package common
 
 import (
 	"errors"
+	"runtime"
 	"syscall"
 )
+
+// windowsWSAConnectionRefused is WSAECONNREFUSED. Go's
+// syscall.ECONNREFUSED is a synthesized compatibility value on Windows and is
+// not the error returned by Winsock.
+const windowsWSAConnectionRefused syscall.Errno = 10061
 
 // IsConnectionRefused reports whether err proves that the probed TCP endpoint
 // actively rejected the connection. Unlike timeouts, TLS failures, DNS
 // failures, and connection resets, an explicit refusal is a conclusive
 // negative for that host:port at probe time.
 func IsConnectionRefused(err error) bool {
-	return errors.Is(err, syscall.ECONNREFUSED)
+	return errors.Is(err, syscall.ECONNREFUSED) ||
+		(runtime.GOOS == "windows" &&
+			errors.Is(err, windowsWSAConnectionRefused))
 }

--- a/sdk/common/network_error_test.go
+++ b/sdk/common/network_error_test.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+)
+
+func TestIsConnectionRefused(t *testing.T) {
+	if !IsConnectionRefused(
+		fmt.Errorf("wrapped dial error: %w", syscall.ECONNREFUSED),
+	) {
+		t.Fatal("wrapped connection refusal was not recognized")
+	}
+	if IsConnectionRefused(syscall.ECONNRESET) {
+		t.Fatal("connection reset was classified as connection refusal")
+	}
+}

--- a/sdk/common/network_error_windows_test.go
+++ b/sdk/common/network_error_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package common
+
+import (
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestIsConnectionRefusedRecognizesWinsockError(t *testing.T) {
+	err := &url.Error{
+		Op:  "Get",
+		URL: "http://127.0.0.1:1",
+		Err: &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: os.NewSyscallError(
+				"connectex",
+				syscall.Errno(10061),
+			),
+		},
+	}
+	if !IsConnectionRefused(err) {
+		t.Fatalf("wrapped WSAECONNREFUSED was not recognized: %v", err)
+	}
+}

--- a/sdk/rules/fingerprint.go
+++ b/sdk/rules/fingerprint.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -189,7 +189,7 @@ func loadEmbeddedFingerprints() ([]FingerprintRule, error) {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 			continue
 		}
-		data, err := fs.ReadFile(builtinFS, filepath.Join(dir, e.Name()))
+		data, err := fs.ReadFile(builtinFS, path.Join(dir, e.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", e.Name(), err)
 		}

--- a/sdk/rules/fingerprint_test.go
+++ b/sdk/rules/fingerprint_test.go
@@ -11,6 +11,21 @@ import (
 	"time"
 )
 
+func TestLoadEmbeddedFingerprints(t *testing.T) {
+	fingerprints, err := loadEmbeddedFingerprints()
+	if err != nil {
+		t.Fatalf("loadEmbeddedFingerprints: %v", err)
+	}
+	if len(fingerprints) == 0 {
+		t.Fatal("expected embedded fingerprint rules")
+	}
+	for _, fingerprint := range fingerprints {
+		if fingerprint.Source != "builtin" {
+			t.Fatalf("fingerprint %q source = %q, want builtin", fingerprint.ID, fingerprint.Source)
+		}
+	}
+}
+
 func TestRunFingerprintUsesPostInitBundleOverride(t *testing.T) {
 	SetBundleOverridePath("")
 	builtin, err := LoadFingerprints()

--- a/sdk/rules/loader.go
+++ b/sdk/rules/loader.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -42,7 +43,7 @@ func loadRulesFromFSWithFailures(
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
 			continue
 		}
-		data, err := fs.ReadFile(fsys, filepath.Join(root, entry.Name()))
+		data, err := fs.ReadFile(fsys, path.Join(root, entry.Name()))
 		if err != nil {
 			failures = append(
 				failures,

--- a/server/cli/serve.go
+++ b/server/cli/serve.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
@@ -12,7 +13,13 @@ import (
 
 	"github.com/adithyan-ak/agenthound/sdk/rules"
 	"github.com/adithyan-ak/agenthound/server/internal/api"
+	"github.com/adithyan-ak/agenthound/server/internal/ingest"
 	"github.com/spf13/cobra"
+)
+
+const (
+	interruptedIngestRecoveryInterval = 5 * time.Second
+	interruptedIngestRecoveryTimeout  = 3 * time.Second
 )
 
 var serveCmd = &cobra.Command{
@@ -27,6 +34,13 @@ var serveCmd = &cobra.Command{
 			return err
 		}
 		defer cleanup()
+
+		if err := recoverInterruptedIngestsOnce(ctx, infra.Pipeline); err != nil {
+			return err
+		}
+		recoveryCtx, cancelRecovery := context.WithCancel(ctx)
+		defer cancelRecovery()
+		go runInterruptedIngestRecovery(recoveryCtx, infra.Pipeline)
 
 		rulesEngine, err := rules.NewEngine(rules.LoadOptions{})
 		if err != nil {
@@ -69,6 +83,44 @@ var serveCmd = &cobra.Command{
 			return server.Shutdown(shutdownCtx)
 		}
 	},
+}
+
+func recoverInterruptedIngestsOnce(
+	ctx context.Context,
+	pipeline *ingest.Pipeline,
+) error {
+	recoveryCtx, cancel := context.WithTimeout(ctx, interruptedIngestRecoveryTimeout)
+	defer cancel()
+	recovered, err := pipeline.RecoverInterruptedIngests(recoveryCtx)
+	if err != nil {
+		return fmt.Errorf("recover interrupted ingests: %w", err)
+	}
+	if len(recovered) > 0 {
+		slog.Warn(
+			"recovered interrupted ingests",
+			"count", len(recovered),
+			"scan_ids", recovered,
+		)
+	}
+	return nil
+}
+
+func runInterruptedIngestRecovery(
+	ctx context.Context,
+	pipeline *ingest.Pipeline,
+) {
+	ticker := time.NewTicker(interruptedIngestRecoveryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := recoverInterruptedIngestsOnce(ctx, pipeline); err != nil {
+				slog.Warn("interrupted ingest recovery failed", "error", err)
+			}
+		}
+	}
 }
 
 func init() {

--- a/server/internal/appdb/integration_test.go
+++ b/server/internal/appdb/integration_test.go
@@ -296,3 +296,172 @@ func TestIntegrationScansCRUD(t *testing.T) {
 	// Cleanup
 	_, _ = pool.Exec(ctx, "DELETE FROM scans WHERE id = $1", scanID)
 }
+
+func TestIntegrationRecoverInterruptedIngests(t *testing.T) {
+	skipIfNoPG(t)
+	ctx := context.Background()
+
+	admin, err := NewPool(os.Getenv("AGENTHOUND_PG_URI"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer admin.Close()
+
+	schema := fmt.Sprintf("agenthound_recovery_test_%d", time.Now().UnixNano())
+	quotedSchema := pgx.Identifier{schema}.Sanitize()
+	if _, err := admin.Exec(ctx, "CREATE SCHEMA "+quotedSchema); err != nil {
+		t.Fatalf("create isolated schema: %v", err)
+	}
+	defer func() {
+		if _, err := admin.Exec(ctx, "DROP SCHEMA "+quotedSchema+" CASCADE"); err != nil {
+			t.Errorf("drop isolated schema: %v", err)
+		}
+	}()
+
+	config, err := pgxpool.ParseConfig(os.Getenv("AGENTHOUND_PG_URI"))
+	if err != nil {
+		t.Fatalf("parse connection config: %v", err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("connect isolated schema: %v", err)
+	}
+	defer pool.Close()
+	if err := RunMigrations(ctx, pool); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	scans := NewScanStore(pool)
+	findings := NewFindingStore(pool)
+	started := time.Now().UTC()
+	publishedID := "published-before-interruption"
+	interruptedID := "interrupted-ingest"
+	pendingID := "intentionally-pending"
+	if err := scans.CreateScan(ctx, &model.Scan{
+		ID:                publishedID,
+		Collector:         "mcp",
+		Status:            model.ScanStatusCompleted,
+		StartedAt:         started.Add(-time.Minute),
+		CollectionStatus:  model.LifecycleComplete,
+		GraphStatus:       model.LifecycleComplete,
+		AnalysisStatus:    model.LifecycleComplete,
+		SnapshotStatus:    model.LifecycleComplete,
+		ProjectionStatus:  model.ProjectionComplete,
+		PublicationStatus: model.PublicationPublished,
+	}); err != nil {
+		t.Fatalf("create prior published scan: %v", err)
+	}
+	var revision int64
+	var publishedAt time.Time
+	if err := pool.QueryRow(ctx, `INSERT INTO posture_publications (scan_id)
+		VALUES ($1) RETURNING revision, published_at`,
+		publishedID,
+	).Scan(&revision, &publishedAt); err != nil {
+		t.Fatalf("create prior publication: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE scans SET
+	    published_revision = $1,
+	    published_at = $2
+	WHERE id = $3`,
+		revision,
+		publishedAt,
+		publishedID,
+	); err != nil {
+		t.Fatalf("attach prior publication to scan: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE posture_state SET
+	    projection_status = $1,
+	    projection_scan_id = $2,
+	    published_revision = $3,
+	    published_scan_id = $2,
+	    published_at = $4
+	WHERE singleton = TRUE`,
+		model.ProjectionComplete,
+		publishedID,
+		revision,
+		publishedAt,
+	); err != nil {
+		t.Fatalf("select prior publication: %v", err)
+	}
+
+	dirtyCoverage := []string{"mcp:target:sha256:interrupted"}
+	if _, err := scans.BeginScan(ctx, &model.Scan{
+		ID:                interruptedID,
+		Collector:         "mcp",
+		Status:            model.ScanStatusRunning,
+		StartedAt:         started,
+		CollectionStatus:  model.LifecycleComplete,
+		GraphStatus:       model.LifecyclePending,
+		AnalysisStatus:    model.LifecyclePending,
+		SnapshotStatus:    model.LifecyclePending,
+		ProjectionStatus:  model.ProjectionUpdating,
+		PublicationStatus: model.PublicationUnpublished,
+	}, dirtyCoverage, nil); err != nil {
+		t.Fatalf("begin interrupted scan: %v", err)
+	}
+	if err := scans.CreateScan(ctx, &model.Scan{
+		ID:                pendingID,
+		Collector:         "a2a",
+		Status:            model.ScanStatusPending,
+		StartedAt:         started,
+		CollectionStatus:  model.LifecyclePending,
+		GraphStatus:       model.LifecyclePending,
+		AnalysisStatus:    model.LifecyclePending,
+		SnapshotStatus:    model.LifecyclePending,
+		ProjectionStatus:  model.ProjectionUnknown,
+		PublicationStatus: model.PublicationUnpublished,
+	}); err != nil {
+		t.Fatalf("create pending scan: %v", err)
+	}
+
+	recovered, err := scans.RecoverInterruptedIngests(ctx)
+	if err != nil {
+		t.Fatalf("recover interrupted ingests: %v", err)
+	}
+	if !reflect.DeepEqual(recovered, []string{interruptedID}) {
+		t.Fatalf("recovered scans = %v", recovered)
+	}
+	interrupted, err := scans.GetScan(ctx, interruptedID)
+	if err != nil {
+		t.Fatalf("get interrupted scan: %v", err)
+	}
+	if interrupted.Status != model.ScanStatusFailed ||
+		interrupted.CompletedAt == nil ||
+		interrupted.CollectionStatus != model.LifecycleComplete ||
+		interrupted.GraphStatus != model.LifecycleFailed ||
+		interrupted.AnalysisStatus != model.LifecycleFailed ||
+		interrupted.SnapshotStatus != model.LifecycleFailed ||
+		interrupted.ProjectionStatus != model.ProjectionIncomplete ||
+		interrupted.Error != interruptedIngestError {
+		t.Fatalf("recovered interrupted scan = %+v", interrupted)
+	}
+	pending, err := scans.GetScan(ctx, pendingID)
+	if err != nil {
+		t.Fatalf("get pending scan: %v", err)
+	}
+	if pending.Status != model.ScanStatusPending || pending.CompletedAt != nil {
+		t.Fatalf("pending scan changed during recovery: %+v", pending)
+	}
+	state, err := findings.GetProjectionState(ctx)
+	if err != nil {
+		t.Fatalf("get recovered projection state: %v", err)
+	}
+	if state.Status != model.ProjectionIncomplete ||
+		state.ScanID != interruptedID ||
+		state.Error != interruptedIngestError ||
+		state.PublishedScanID != publishedID ||
+		state.PublishedRevision == nil ||
+		*state.PublishedRevision != revision ||
+		!reflect.DeepEqual(state.DirtyCoverage, dirtyCoverage) {
+		t.Fatalf("recovered projection state = %+v", state)
+	}
+
+	recovered, err = scans.RecoverInterruptedIngests(ctx)
+	if err != nil {
+		t.Fatalf("repeat recovery: %v", err)
+	}
+	if len(recovered) != 0 {
+		t.Fatalf("repeat recovery changed scans: %v", recovered)
+	}
+}

--- a/server/internal/appdb/scans.go
+++ b/server/internal/appdb/scans.go
@@ -42,6 +42,8 @@ type ScanFailure struct {
 	Metadata         map[string]any
 }
 
+const interruptedIngestError = "ingest interrupted before lifecycle finalization"
+
 // CampaignRejectionAudit is the complete sanitized payload persisted for a
 // campaign artifact rejected before BeginScan. It intentionally has no raw
 // artifact, artifact digest, endpoint, witness, credential material, or
@@ -506,6 +508,92 @@ func (s *ScanStore) RecordFailure(ctx context.Context, failure ScanFailure) erro
 		return fmt.Errorf("commit failure lifecycle: %w", err)
 	}
 	return nil
+}
+
+// RecoverInterruptedIngests marks orphaned running scans terminal after the
+// process that owned them has stopped. It deliberately leaves the prior
+// publication and dirty coverage untouched: Neo4j may contain partial mutable
+// writes, so only a later authoritative ingest can make the projection readable.
+func (s *ScanStore) RecoverInterruptedIngests(ctx context.Context) ([]string, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin interrupted ingest recovery: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var projectionStatus string
+	if err := tx.QueryRow(ctx, `SELECT projection_status
+		FROM posture_state WHERE singleton = TRUE
+		FOR UPDATE`).Scan(&projectionStatus); err != nil {
+		return nil, fmt.Errorf("lock projection state for interrupted ingest recovery: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, `UPDATE scans SET
+	    status = $1,
+	    completed_at = NOW(),
+	    error = CASE
+	        WHEN coalesce(error, '') = '' THEN $2
+	        ELSE error || '; ' || $2
+	    END,
+	    graph_status = CASE
+	        WHEN graph_status IN ('complete', 'partial', 'failed', 'not_applicable')
+	            THEN graph_status
+	        ELSE $3
+	    END,
+	    analysis_status = CASE
+	        WHEN analysis_status IN ('complete', 'partial', 'failed', 'not_applicable')
+	            THEN analysis_status
+	        ELSE $3
+	    END,
+	    snapshot_status = CASE
+	        WHEN snapshot_status IN ('complete', 'partial', 'failed', 'not_applicable')
+	            THEN snapshot_status
+	        ELSE $3
+	    END,
+	    projection_status = $4,
+	    lifecycle_updated_at = NOW()
+	WHERE status = $5
+	RETURNING id`,
+		model.ScanStatusFailed,
+		interruptedIngestError,
+		model.LifecycleFailed,
+		model.ProjectionIncomplete,
+		model.ScanStatusRunning,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("recover interrupted scan rows: %w", err)
+	}
+	var recovered []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan recovered interrupted scan id: %w", err)
+		}
+		recovered = append(recovered, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("recover interrupted scan rows: %w", err)
+	}
+	sort.Strings(recovered)
+
+	if projectionStatus == model.ProjectionUpdating {
+		if _, err := tx.Exec(ctx, `UPDATE posture_state SET
+		    projection_status = $1,
+		    projection_error = $2,
+		    projection_updated_at = NOW()
+		WHERE singleton = TRUE`,
+			model.ProjectionIncomplete,
+			interruptedIngestError,
+		); err != nil {
+			return nil, fmt.Errorf("recover interrupted projection state: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit interrupted ingest recovery: %w", err)
+	}
+	return recovered, nil
 }
 
 func (s *ScanStore) GetScan(ctx context.Context, id string) (*model.Scan, error) {

--- a/server/internal/ingest/pipeline.go
+++ b/server/internal/ingest/pipeline.go
@@ -53,6 +53,7 @@ type scanLifecycleRecorder interface {
 		roots []sdkingest.CoverageRoot,
 	) ([]string, error)
 	RecordFailure(ctx context.Context, failure appdb.ScanFailure) error
+	RecoverInterruptedIngests(ctx context.Context) ([]string, error)
 }
 
 // postProcessFunc runs the analysis post-processors. Defaulted to
@@ -116,6 +117,20 @@ func NewPipeline(
 		p.findingStore = findingStore
 	}
 	return p
+}
+
+// RecoverInterruptedIngests reconciles orphaned lifecycle rows only while this
+// pipeline is idle. Ingest already holds the same mutex for every graph
+// mutation, so a live request cannot be mistaken for an interrupted attempt.
+func (p *Pipeline) RecoverInterruptedIngests(ctx context.Context) ([]string, error) {
+	if !p.mu.TryLock() {
+		return nil, nil
+	}
+	defer p.mu.Unlock()
+	if p.scanStore == nil {
+		return nil, fmt.Errorf("recover interrupted ingests: lifecycle store unavailable")
+	}
+	return p.scanStore.RecoverInterruptedIngests(ctx)
 }
 
 func (p *Pipeline) Ingest(ctx context.Context, data *sdkingest.IngestData) (*sdkingest.IngestResult, error) {

--- a/server/internal/ingest/pipeline_test.go
+++ b/server/internal/ingest/pipeline_test.go
@@ -283,9 +283,12 @@ type fakeScanStore struct {
 	dirtyCoverage []string
 	retired       []string
 	resolvedRoots []sdkingest.CoverageRoot
+	recovered     []string
+	recoveryCalls int
 
 	createErr    error
 	resolveErr   error
+	recoveryErr  error
 	updateErr    error
 	recognized   bool
 	recognizeErr error
@@ -438,6 +441,15 @@ func (s *fakeScanStore) RecordFailure(
 		Error:     failure.Error,
 	})
 	return s.updateErr
+}
+
+func (s *fakeScanStore) RecoverInterruptedIngests(
+	_ context.Context,
+) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recoveryCalls++
+	return append([]string(nil), s.recovered...), s.recoveryErr
 }
 
 type scanUpdate struct {
@@ -3286,6 +3298,35 @@ func TestNewPipeline_PassesConcreteThrough(t *testing.T) {
 	p := NewPipeline(w, nil, nil, nil, allowStorageVerifier{})
 	if p.writer == nil {
 		t.Error("non-nil *graph.Writer should be stored as interface")
+	}
+}
+
+func TestPipeline_RecoverInterruptedIngestsOnlyWhileIdle(t *testing.T) {
+	ss := &fakeScanStore{recovered: []string{"scan-interrupted"}}
+	p := newTestPipeline(nil, nil, ss, noOpRunPP)
+
+	recovered, err := p.RecoverInterruptedIngests(context.Background())
+	if err != nil {
+		t.Fatalf("idle recovery: %v", err)
+	}
+	if !slices.Equal(recovered, []string{"scan-interrupted"}) {
+		t.Fatalf("idle recovery = %v", recovered)
+	}
+	if ss.recoveryCalls != 1 {
+		t.Fatalf("idle recovery calls = %d, want 1", ss.recoveryCalls)
+	}
+
+	p.mu.Lock()
+	recovered, err = p.RecoverInterruptedIngests(context.Background())
+	p.mu.Unlock()
+	if err != nil {
+		t.Fatalf("active-ingest recovery: %v", err)
+	}
+	if recovered != nil {
+		t.Fatalf("active-ingest recovery = %v, want nil", recovered)
+	}
+	if ss.recoveryCalls != 1 {
+		t.Fatalf("active-ingest recovery called store %d times", ss.recoveryCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- bind A2A bearer credentials to the original HTTP origin and reject HTTPS-to-HTTP redirects before contacting the destination
- use slash-based `embed.FS` paths for built-in text and fingerprint rules, with a native Windows CI regression job
- recognize native Winsock connection refusals so the full rules package executes correctly on Windows
- reconcile interrupted ingests to truthful terminal lifecycle state while preserving the previous publication, dirty coverage, and fail-closed graph behavior

This addresses the validated P1 findings F-010, F-011, and F-013.

## Root causes and behavior

### A2A redirects

The Agent Card client previously relied on Go's default sensitive-header redirect behavior, which treats same-host port changes and HTTPS-to-HTTP redirects as eligible for `Authorization` forwarding. Credentialed redirects now require the original scheme, hostname, and effective port. HTTPS downgrades are rejected even without credentials.

### Windows embedded rules

The embedded loaders used `filepath.Join`, producing backslash-separated paths on Windows even though `embed.FS` requires slash-separated paths. Embedded paths now use `path.Join`; real filesystem paths continue using `filepath.Join`.

The native Windows gate exposed a second platform defect: Go's `syscall.ECONNREFUSED` is a synthesized compatibility value on Windows, while Winsock returns `WSAECONNREFUSED` (`10061`). The shared refusal classifier now recognizes the native Winsock error through wrapped HTTP/network errors. The gate retains full `sdk/rules` coverage and also runs the Windows-only classifier regression.

### Interrupted ingest recovery

`BeginScan` durably recorded `running`/`updating` before Neo4j mutation, but no recovery path terminalized that state after PostgreSQL interruption or process death. The server now performs idempotent recovery at startup and periodically while the serialized pipeline is idle. Recovery marks orphaned scans failed and posture incomplete without clearing dirty coverage, changing the prior published revision, or exposing a potentially partial graph.

## Safety and compatibility

- no schema migration, new dependency, flag, environment variable, or API shape change
- pending scans are not reaped
- live ingests are excluded through the pipeline's existing serialization mutex
- prior publication metadata, coverage state, and persisted exports remain unchanged
- graph APIs remain 409 conflict-blocked until a later authoritative ingest repairs the mutable projection

## Validation

- `make prerelease` — all 13 gates passed on the original P1 change, including golangci-lint, govulncheck, license checks, race tests, dependency/size boundaries, UI build, and cross-compilation
- `make docs-check` — strict MkDocs build passed
- `go test ./... -race` — passed after the Winsock fix
- `golangci-lint run ./...` — passed after the Winsock fix
- `govulncheck ./...` — passed after the Winsock fix
- `scripts/deps-check.sh` and `scripts/size-check.sh` — passed after the Winsock fix
- PostgreSQL integration test for interrupted-ingest recovery — passed against PostgreSQL 16
- Windows amd64 `sdk/common` and `sdk/rules` test binaries cross-compile successfully
- native Windows execution remains a required PR CI job