### PR TITLE
Fail closed on invalid custom rule inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Fail-closed custom rule inputs.** Directory rule validation now reports
+  malformed or unreadable YAML as a failure while continuing to validate valid
+  siblings. Fingerprint tar bundles reject entries larger than 1 MiB instead
+  of parsing and executing a truncated prefix.
 - **First-class scan upload.** `agenthound scan --ingest <server-url>` saves the
   normal local JSON artifact before uploading those exact bytes,
   rejects redirects, and prints a correlated ingest receipt with finding

--- a/collector/cli/rules.go
+++ b/collector/cli/rules.go
@@ -156,13 +156,17 @@ func runRulesList(cmd *cobra.Command, _ []string) error {
 func runRulesValidate(cmd *cobra.Command, args []string) error {
 	strict, _ := cmd.Flags().GetBool("strict")
 
-	loaded, err := loadRulesForCommand(args)
+	loaded, loadFailures, err := loadRulesForCommand(args)
 	if err != nil {
 		return err
 	}
 
 	passed := 0
-	failed := 0
+	failed := len(loadFailures)
+
+	for _, loadErr := range loadFailures {
+		fmt.Printf("[FAIL] %v\n", loadErr)
+	}
 
 	for _, r := range loaded {
 		valErrs := rules.ValidateRule(r)
@@ -210,9 +214,12 @@ func runRulesTest(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid format %q: must be table or json", format)
 	}
 
-	loaded, err := loadRulesForCommand(args)
+	loaded, loadFailures, err := loadRulesForCommand(args)
 	if err != nil {
 		return err
+	}
+	for _, loadErr := range loadFailures {
+		_, _ = fmt.Fprintf(os.Stderr, "[FAIL] %v\n", loadErr)
 	}
 
 	totalCases := 0
@@ -303,25 +310,25 @@ func runRulesTest(cmd *cobra.Command, args []string) error {
 
 	_, _ = fmt.Fprintf(os.Stderr, "%d test cases: %d passed, %d failed\n", totalPassed+totalFailed, totalPassed, totalFailed)
 
-	if totalFailed > 0 {
+	if totalFailed > 0 || len(loadFailures) > 0 {
 		os.Exit(1)
 	}
 	return nil
 }
 
-func loadRulesForCommand(args []string) ([]rules.Rule, error) {
+func loadRulesForCommand(args []string) ([]rules.Rule, []error, error) {
 	if len(args) == 0 {
 		engine, err := buildRulesEngine()
 		if err != nil {
-			return nil, fmt.Errorf("loading rules: %w", err)
+			return nil, nil, fmt.Errorf("loading rules: %w", err)
 		}
-		return engine.Rules(), nil
+		return engine.Rules(), nil, nil
 	}
 
 	path := args[0]
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, fmt.Errorf("stat %s: %w", path, err)
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
 	}
 
 	if info.IsDir() {
@@ -329,9 +336,9 @@ func loadRulesForCommand(args []string) ([]rules.Rule, error) {
 	}
 	r, err := loadRuleFromFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return []rules.Rule{*r}, nil
+	return []rules.Rule{*r}, nil, nil
 }
 
 func loadRuleFromFile(path string) (*rules.Rule, error) {
@@ -353,12 +360,13 @@ func loadRuleFromFile(path string) (*rules.Rule, error) {
 	return &r, nil
 }
 
-func loadRulesFromDir(dir string) ([]rules.Rule, error) {
+func loadRulesFromDir(dir string) ([]rules.Rule, []error, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("reading directory %s: %w", dir, err)
+		return nil, nil, fmt.Errorf("reading directory %s: %w", dir, err)
 	}
 	var loaded []rules.Rule
+	var failures []error
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -369,12 +377,12 @@ func loadRulesFromDir(dir string) ([]rules.Rule, error) {
 		}
 		r, err := loadRuleFromFile(filepath.Join(dir, name))
 		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+			failures = append(failures, err)
 			continue
 		}
 		loaded = append(loaded, *r)
 	}
-	return loaded, nil
+	return loaded, failures, nil
 }
 
 func yamlHasField(data []byte, field string) bool {

--- a/collector/cli/rules.go
+++ b/collector/cli/rules.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -322,7 +323,12 @@ func loadRulesForCommand(args []string) ([]rules.Rule, []error, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("loading rules: %w", err)
 		}
-		return engine.Rules(), nil, nil
+		failureMessages := engine.LoadFailures()
+		loadFailures := make([]error, len(failureMessages))
+		for i, failure := range failureMessages {
+			loadFailures[i] = errors.New(failure)
+		}
+		return engine.Rules(), loadFailures, nil
 	}
 
 	path := args[0]

--- a/collector/cli/rules_test.go
+++ b/collector/cli/rules_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const validRuleYAML = `
+id: valid-rule
+name: Valid rule
+severity: medium
+scope:
+  collector: config
+  targets:
+    - instruction.content
+matcher:
+  type: keyword
+  keywords:
+    - ignore previous instructions
+tests:
+  - input: ignore previous instructions
+    should_match: true
+`
+
+func TestLoadRulesFromDirReturnsValidRulesAndParseFailures(t *testing.T) {
+	dir := writeMixedRuleDirectory(t)
+
+	loaded, failures, err := loadRulesFromDir(dir)
+	if err != nil {
+		t.Fatalf("loadRulesFromDir: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].ID != "valid-rule" {
+		t.Fatalf("loaded rules = %+v, want valid-rule only", loaded)
+	}
+	if len(failures) != 1 ||
+		!strings.Contains(failures[0].Error(), "broken.yaml") {
+		t.Fatalf("load failures = %v, want broken.yaml parse failure", failures)
+	}
+}
+
+func TestRulesValidateDirectoryParseFailureExitsNonZero(t *testing.T) {
+	if os.Getenv("AGENTHOUND_RULES_VALIDATE_HELPER") == "1" {
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("strict", false, "")
+		if err := runRulesValidate(
+			cmd,
+			[]string{os.Getenv("AGENTHOUND_RULES_VALIDATE_DIR")},
+		); err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		return
+	}
+
+	dir := writeMixedRuleDirectory(t)
+	cmd := exec.Command(
+		os.Args[0],
+		"-test.run=^TestRulesValidateDirectoryParseFailureExitsNonZero$",
+	)
+	cmd.Env = append(
+		os.Environ(),
+		"AGENTHOUND_RULES_VALIDATE_HELPER=1",
+		"AGENTHOUND_RULES_VALIDATE_DIR="+dir,
+	)
+	output, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("rules validate error = %v, output:\n%s", err, output)
+	}
+
+	got := string(output)
+	for _, want := range []string{
+		"[FAIL] parsing " + filepath.Join(dir, "broken.yaml"),
+		"[PASS] valid-rule (1 tests)",
+		"1 passed, 1 failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rules validate output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func writeMixedRuleDirectory(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "valid.yaml"),
+		[]byte(validRuleYAML),
+		0o600,
+	); err != nil {
+		t.Fatalf("write valid rule: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "broken.yaml"),
+		[]byte("matcher: ["),
+		0o600,
+	); err != nil {
+		t.Fatalf("write broken rule: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, "README.md"),
+		[]byte("ignored"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write ignored file: %v", err)
+	}
+	return dir
+}

--- a/collector/cli/rules_test.go
+++ b/collector/cli/rules_test.go
@@ -87,6 +87,90 @@ func TestRulesValidateDirectoryParseFailureExitsNonZero(t *testing.T) {
 	}
 }
 
+func TestRulesCommandsNoPathLoadFailureExitsNonZero(t *testing.T) {
+	if mode := os.Getenv("AGENTHOUND_RULES_NO_PATH_HELPER"); mode != "" {
+		cmd := &cobra.Command{}
+		var err error
+		switch mode {
+		case "validate":
+			cmd.Flags().Bool("strict", false, "")
+			err = runRulesValidate(cmd, nil)
+		case "test":
+			cmd.Flags().String("format", "table", "")
+			cmd.Flags().Bool("verbose", false, "")
+			err = runRulesTest(cmd, nil)
+		default:
+			_, _ = fmt.Fprintf(os.Stderr, "unknown helper mode %q\n", mode)
+			os.Exit(2)
+		}
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		return
+	}
+
+	dir := writeMixedRuleDirectory(t)
+	for _, tt := range []struct {
+		mode  string
+		wants []string
+	}{
+		{
+			mode: "validate",
+			wants: []string{
+				"[PASS] valid-rule (1 tests)",
+				"1 failed",
+			},
+		},
+		{
+			mode: "test",
+			wants: []string{
+				"Testing ",
+				"1 test cases: 1 passed, 0 failed",
+			},
+		},
+	} {
+		t.Run(tt.mode, func(t *testing.T) {
+			cmd := exec.Command(
+				os.Args[0],
+				"-test.run=^TestRulesCommandsNoPathLoadFailureExitsNonZero$",
+			)
+			cmd.Env = append(
+				os.Environ(),
+				"AGENTHOUND_RULES_NO_PATH_HELPER="+tt.mode,
+				"AGENTHOUND_RULES_DIR="+dir,
+			)
+			output, err := cmd.CombinedOutput()
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+				t.Fatalf("rules %s error = %v, output:\n%s", tt.mode, err, output)
+			}
+
+			got := string(output)
+			loadFailure := "[FAIL] parse custom rule " +
+				filepath.Join(dir, "broken.yaml")
+			if !strings.Contains(got, loadFailure) {
+				t.Errorf(
+					"rules %s output missing %q:\n%s",
+					tt.mode,
+					loadFailure,
+					got,
+				)
+			}
+			for _, want := range tt.wants {
+				if !strings.Contains(got, want) {
+					t.Errorf(
+						"rules %s output missing %q:\n%s",
+						tt.mode,
+						want,
+						got,
+					)
+				}
+			}
+		})
+	}
+}
+
 func writeMixedRuleDirectory(t *testing.T) string {
 	t.Helper()
 

--- a/sdk/rules/bundle.go
+++ b/sdk/rules/bundle.go
@@ -66,7 +66,8 @@ func getBundleOverridePath() string {
 // path replaces it with the absolute path of the bundle the rule came
 // from so operators have a clear provenance trail.
 const (
-	BundleSourceBuiltin = "builtin"
+	BundleSourceBuiltin            = "builtin"
+	maxFingerprintBundleEntryBytes = int64(1 << 20)
 )
 
 // LoadFingerprintBundle reads fingerprint rules from a directory or
@@ -183,11 +184,34 @@ func loadBundleFromTarballWithFailures(
 		}
 		// Cap per-file size at 1 MiB. Fingerprint YAMLs are tiny;
 		// anything larger is suspicious.
-		data, err := io.ReadAll(io.LimitReader(tr, 1<<20))
+		if hdr.Size > maxFingerprintBundleEntryBytes {
+			failures = append(
+				failures,
+				fmt.Sprintf(
+					"reject fingerprint rule %s: entry size %d exceeds 1 MiB limit",
+					hdr.Name,
+					hdr.Size,
+				),
+			)
+			continue
+		}
+		data, err := io.ReadAll(
+			io.LimitReader(tr, maxFingerprintBundleEntryBytes+1),
+		)
 		if err != nil {
 			failures = append(
 				failures,
 				fmt.Sprintf("read fingerprint rule %s: %v", hdr.Name, err),
+			)
+			continue
+		}
+		if int64(len(data)) > maxFingerprintBundleEntryBytes {
+			failures = append(
+				failures,
+				fmt.Sprintf(
+					"reject fingerprint rule %s: entry exceeds 1 MiB limit",
+					hdr.Name,
+				),
 			)
 			continue
 		}

--- a/sdk/rules/bundle_test.go
+++ b/sdk/rules/bundle_test.go
@@ -120,6 +120,43 @@ func TestLoadFingerprintBundle_Tarball(t *testing.T) {
 	}
 }
 
+func TestLoadFingerprintBundle_TarballEntrySizeBoundary(t *testing.T) {
+	exact := make([]byte, int(maxFingerprintBundleEntryBytes))
+	copy(exact, newRuleYAML)
+	for i := len(newRuleYAML); i < len(exact); i++ {
+		exact[i] = ' '
+	}
+
+	exactPath := writeBundleTarball(t, []bundleTarEntry{
+		{name: "exact.yaml", content: exact},
+	})
+	loaded, err := LoadFingerprintBundle(exactPath)
+	if err != nil {
+		t.Fatalf("load exact-boundary bundle: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].ID != "bundle-only-rule" {
+		t.Fatalf("exact-boundary rules = %+v, want bundle-only-rule", loaded)
+	}
+
+	oversized := append(append([]byte(nil), exact...), 'x')
+	oversizedPath := writeBundleTarball(t, []bundleTarEntry{
+		{name: "oversized.yaml", content: oversized},
+		{name: "valid.yaml", content: []byte(sampleRuleYAML)},
+	})
+	loaded, failures, err := loadFingerprintBundleWithFailures(oversizedPath)
+	if err != nil {
+		t.Fatalf("load oversized bundle: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].ID != "ollama" {
+		t.Fatalf("oversized bundle rules = %+v, want valid ollama sibling only", loaded)
+	}
+	if len(failures) != 1 ||
+		!strings.Contains(failures[0], "oversized.yaml") ||
+		!strings.Contains(failures[0], "exceeds 1 MiB limit") {
+		t.Fatalf("oversized bundle failures = %v", failures)
+	}
+}
+
 func TestLoadFingerprintBundle_MissingPath(t *testing.T) {
 	_, err := LoadFingerprintBundle("/nonexistent/path/to/bundle.tar.gz")
 	if err == nil {
@@ -216,4 +253,42 @@ func TestMergeFingerprintRules_EmptyOverride(t *testing.T) {
 	if len(merged) != 1 {
 		t.Errorf("got %d rules, want 1", len(merged))
 	}
+}
+
+type bundleTarEntry struct {
+	name    string
+	content []byte
+}
+
+func writeBundleTarball(t *testing.T, entries []bundleTarEntry) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, entry := range entries {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     entry.name,
+			Mode:     0o644,
+			Size:     int64(len(entry.content)),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header: %v", err)
+		}
+		if _, err := tw.Write(entry.content); err != nil {
+			t.Fatalf("tar write: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "rules.tar.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+	return path
 }


### PR DESCRIPTION
## Summary

- make explicit-directory and configured no-path `rules validate` / `rules test` report per-file YAML load failures and exit nonzero while still processing valid siblings
- propagate parse, validation, and compilation failures retained by `Engine.LoadFailures()` through the command result
- reject fingerprint tar entries larger than 1 MiB instead of parsing a truncated prefix
- preserve intentional partial-bundle behavior so valid sibling entries still load
- add regression coverage for both command forms and exact/oversized archive boundaries

## Root cause

The explicit-directory loader printed parse errors but discarded their failure state, allowing the command to exit successfully. The initial fix preserved those failures for explicit directory arguments, but the documented no-path branch built the configured engine and discarded its retained `LoadFailures()`. Both command forms now feed load failures into the same reporting and exit-status path.

The tar loader used `io.LimitReader` at exactly 1 MiB and parsed whatever prefix it read, so a larger entry with a valid 1 MiB prefix could be accepted and executed.

## Impact

Rule validation and testing now produce truthful nonzero results for every candidate YAML that cannot be loaded, including rules discovered through `AGENTHOUND_RULES_DIR` or the default custom-rule directory. Oversized fingerprint entries are recorded through the existing partial-load failure channel and cannot enter the effective rule set.

## Validation

- retained mixed valid/malformed fixture: no-path `rules validate` and `rules test` both report `[FAIL]` and exit 1
- `go test ./collector/cli ./sdk/rules -race`
- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./... -race`
- `golangci-lint run ./...`
- `govulncheck ./...`
- `scripts/deps-check.sh`
- `scripts/size-check.sh`

Local `go-licenses` could not evaluate dependencies because the installed tool rejects Go 1.25 standard-library packages as lacking module metadata; this change adds no dependencies.