### PR TITLE
release: prepare supported 1.0.0 reset (corrected candidate auth)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,99 +2,87 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
-  # A manual run executes only the publishing preflight: release metadata,
-  # GoReleaser snapshot, and non-mutating Homebrew tap access checks.
+    tags: ['[0-9]*.[0-9]*.[0-9]*']
   workflow_dispatch:
+    inputs:
+      operation:
+        description: Manual release-control operation
+        required: true
+        default: gate-test
+        type: choice
+        options:
+          - gate-test
+          - bootstrap-staging
 
 concurrency:
   group: agenthound-release
-  queue: max
+  cancel-in-progress: false
 
 permissions:
   contents: write
   packages: write
-  id-token: write  # required for cosign keyless OIDC signing
+  id-token: write
+
+env:
+  STAGING_COLLECTOR: ghcr.io/adithyan-ak/agenthound-release-staging
+  STAGING_SERVER: ghcr.io/adithyan-ak/agenthound-server-release-staging
+  PRODUCTION_COLLECTOR: ghcr.io/adithyan-ak/agenthound
+  PRODUCTION_SERVER: ghcr.io/adithyan-ak/agenthound-server
 
 jobs:
-  publishing-preflight:
+  gate-test:
+    if: github.event_name == 'workflow_dispatch' && inputs.operation == 'gate-test'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: release-production
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          fetch-depth: 0
-          # The probe below supplies the separate tap token. Persisting the
-          # repository token here would send two Authorization headers.
-          persist-credentials: false
+      - name: Confirm the production approval gate resumed
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" != "branch" ]]; then
+            echo "Gate test must be dispatched from a branch" >&2
+            exit 1
+          fi
+          echo "release-production approval resumed a read-only, secret-free gate test for ${GITHUB_REF_NAME}"
 
+  bootstrap-staging:
+    if: github.event_name == 'workflow_dispatch' && inputs.operation == 'bootstrap-staging'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version: "1.25.12"
 
-      - name: Verify release tag and Homebrew tap access
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create repository-linked staging packages
         shell: bash
         run: |
           set -euo pipefail
+          go install github.com/google/go-containerregistry/cmd/crane@v0.20.6
+          crane copy ghcr.io/adithyan-ak/agenthound:1.0.1 \
+            "${STAGING_COLLECTOR}:bootstrap"
+          crane copy ghcr.io/adithyan-ak/agenthound-server:1.0.1 \
+            "${STAGING_SERVER}:bootstrap"
 
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            ./scripts/version-check.sh
-            git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
-            tag_commit="$(git rev-parse --verify "${GITHUB_REF_NAME}^{commit}")"
-            if ! git merge-base --is-ancestor "${tag_commit}" refs/remotes/origin/main; then
-              echo "Release tag ${GITHUB_REF_NAME} does not point to an ancestor of origin/main" >&2
-              exit 1
-            fi
-
-            latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"
-            highest_tag="$(printf '%s\n' "${latest_tag}" "${GITHUB_REF_NAME}" | sort -V | tail -n 1)"
-            if [[ "${latest_tag}" == "${GITHUB_REF_NAME}" || "${highest_tag}" != "${GITHUB_REF_NAME}" ]]; then
-              echo "Release tag ${GITHUB_REF_NAME} must be newer than current latest ${latest_tag}" >&2
-              exit 1
-            fi
-          fi
-
-          if [[ -z "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
-            echo "HOMEBREW_TAP_GITHUB_TOKEN is not configured" >&2
-            exit 1
-          fi
-
-          tap_url="https://github.com/adithyan-ak/homebrew-agenthound.git"
-          auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_TAP_GITHUB_TOKEN}" | base64 | tr -d '\n')"
-          tap_sha="$(git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
-            ls-remote "${tap_url}" refs/heads/main | awk '{print $1}')"
-
-          if [[ ! "${tap_sha}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Could not resolve the Homebrew tap's main branch with the configured token" >&2
-            exit 1
-          fi
-
-          git fetch --quiet "${tap_url}" "${tap_sha}"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
-            push --dry-run "${tap_url}" "${tap_sha}:refs/heads/main"
-
-      - name: Check GoReleaser configuration
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
-        with:
-          version: 'v2.15.4'
-          args: check
-
-      - name: Run GoReleaser snapshot preflight
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
-        with:
-          version: 'v2.15.4'
-          args: release --clean --snapshot --skip=docker,sign,sbom
-
-  release:
-    needs: publishing-preflight
-    if: startsWith(github.ref, 'refs/tags/v')
+  candidate:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
@@ -106,17 +94,76 @@ jobs:
           cache: npm
           cache-dependency-path: server/ui/package-lock.json
 
-      - name: Build frontend
-        run: cd server/ui && npm ci --ignore-scripts && npm run build
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.x"
+
+      - name: Verify one-time migration invariants
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Release ref is not strict numeric SemVer: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          ./scripts/version-check.sh
+          git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          latest_release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"
+          mode="$(./scripts/release-tag-check.sh candidate \
+            "${GITHUB_REF_NAME}" "${latest_release}" refs/remotes/origin/main)"
+          printf '%s\n' "${mode}" > "${RUNNER_TEMP}/release-mode"
+          printf 'Validated %s release transition.\n' "${mode}"
+
+      - name: Verify Homebrew tap write access
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
+            echo "HOMEBREW_TAP_GITHUB_TOKEN is not configured" >&2
+            exit 1
+          fi
+          tap_url="https://github.com/adithyan-ak/homebrew-agenthound.git"
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_TAP_GITHUB_TOKEN}" | base64 | tr -d '\n')"
+          tap_sha="$(git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            ls-remote "${tap_url}" refs/heads/main | awk '{print $1}')"
+          [[ "${tap_sha}" =~ ^[0-9a-f]{40}$ ]]
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            push --dry-run "${tap_url}" "${tap_sha}:refs/heads/main"
+
+      - name: Install release gate dependencies
+        run: |
+          pip install -r docs/requirements.txt
+          cd server/ui
+          npm ci --ignore-scripts
 
       - name: Install release gate tools
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0
+          go install github.com/google/go-containerregistry/cmd/crane@v0.20.6
 
-      - name: Run prerelease gate
-        run: make prerelease
+      - name: Run mandatory release gates
+        run: |
+          make prerelease
+          make docs-check
 
-      - name: Copy frontend dist for embedding
-        run: mkdir -p server/internal/api/ui/dist && cp -r server/ui/dist/* server/internal/api/ui/dist/
+      - name: Copy frontend for release embedding
+        run: |
+          mkdir -p server/internal/api/ui/dist
+          cp -r server/ui/dist/. server/internal/api/ui/dist/
+
+      - name: Check GoReleaser configuration
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
+        with:
+          version: 'v2.15.4'
+          args: check
+        env:
+          AGENTHOUND_IMAGE_REPOSITORY: ${{ env.STAGING_COLLECTOR }}
+          AGENTHOUND_SERVER_IMAGE_REPOSITORY: ${{ env.STAGING_SERVER }}
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
@@ -132,11 +179,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare curated release notes
+      - name: Reconfirm private staging packages
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_GITHUB_TOKEN }}
         shell: bash
+        run: |
+          set -euo pipefail
+          for package in agenthound-release-staging agenthound-server-release-staging; do
+            visibility="$(gh api "users/adithyan-ak/packages/container/${package}" --jq '.visibility')"
+            if [[ "${visibility}" != "private" ]]; then
+              echo "Staging package ${package} is ${visibility}, expected private" >&2
+              exit 1
+            fi
+          done
+
+      - name: Prepare curated release notes
         run: ./scripts/release-notes.sh CHANGELOG.md "${GITHUB_REF_NAME}" > "${RUNNER_TEMP}/agenthound-release-notes.md"
 
-      - name: Run GoReleaser
+      - name: Build the private candidate once
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
           version: 'v2.15.4'
@@ -144,155 +204,507 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          AGENTHOUND_IMAGE_REPOSITORY: ${{ env.STAGING_COLLECTOR }}
+          AGENTHOUND_SERVER_IMAGE_REPOSITORY: ${{ env.STAGING_SERVER }}
 
-      - name: Verify published release surfaces
+      - name: Verify candidate assets, formulas, images, and Go origin
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ADMIN_GITHUB_TOKEN: ${{ secrets.RELEASE_ADMIN_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag}"
+          tag_commit="$(git rev-parse "${tag}^{commit}")"
+          candidate_dir="${RUNNER_TEMP}/release-candidate"
+          mkdir -p "${candidate_dir}/formulas"
+
+          expected_assets="${candidate_dir}/expected-assets.txt"
+          : > "${expected_assets}"
+          for product in agenthound agenthound-server; do
+            for os in darwin linux windows; do
+              for arch in amd64 arm64; do
+                extension=tar.gz
+                [[ "${os}" == windows ]] && extension=zip
+                asset="${product}_${version}_${os}_${arch}.${extension}"
+                printf '%s\n%s.sbom.json\n' "${asset}" "${asset}" >> "${expected_assets}"
+              done
+            done
+          done
+          printf '%s\n' checksums.txt checksums.txt.sigstore.json >> "${expected_assets}"
+          sort -o "${expected_assets}" "${expected_assets}"
+          [[ "$(wc -l < "${expected_assets}" | tr -d ' ')" == 26 ]]
+
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq ".[] | select(.tag_name == \"${tag}\" and .draft == true) | .id" | head -n1)"
+          [[ -n "${release_id}" ]]
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > "${candidate_dir}/draft.json"
+          jq -e --arg tag "${tag}" '.draft == true and .tag_name == $tag' "${candidate_dir}/draft.json" >/dev/null
+          jq -r '.assets[].name' "${candidate_dir}/draft.json" | sort > "${candidate_dir}/draft-assets.txt"
+          diff -u "${expected_assets}" "${candidate_dir}/draft-assets.txt"
+
+          expected_notes="$(cat "${RUNNER_TEMP}/agenthound-release-notes.md")"
+          published_notes="$(jq -r '.body' "${candidate_dir}/draft.json")"
+          [[ "${published_notes}" == "${expected_notes}" ]]
+
+          : > "${candidate_dir}/assets.tsv"
+          while IFS= read -r asset; do
+            local_file="$(find dist -type f -name "${asset}" -print -quit)"
+            [[ -n "${local_file}" ]]
+            digest="$(sha256sum "${local_file}" | awk '{print $1}')"
+            api_digest="$(jq -r --arg name "${asset}" '.assets[] | select(.name == $name) | .digest' \
+              "${candidate_dir}/draft.json")"
+            [[ "${api_digest}" == "sha256:${digest}" ]]
+            printf '%s\t%s\n' "${asset}" "${digest}" >> "${candidate_dir}/assets.tsv"
+          done < "${expected_assets}"
+
+          checksums_file="$(find dist -type f -name checksums.txt -print -quit)"
+          bundle_file="$(find dist -type f -name checksums.txt.sigstore.json -print -quit)"
+          cosign verify-blob \
+            --bundle "${bundle_file}" \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${tag}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${checksums_file}"
+
+          while read -r expected_sum asset; do
+            local_file="$(find dist -type f -name "${asset}" -print -quit)"
+            [[ -n "${local_file}" ]]
+            actual_sum="$(sha256sum "${local_file}" | awk '{print $1}')"
+            [[ "${actual_sum}" == "${expected_sum}" ]]
+          done < "${checksums_file}"
+
+          for product in agenthound agenthound-server; do
+            formula_file="$(find dist -type f -name "${product}.rb" -print -quit)"
+            [[ -n "${formula_file}" ]]
+            cp "${formula_file}" "${candidate_dir}/formulas/${product}.rb"
+            ./scripts/verify-homebrew-formula.sh \
+              "${product}" "${version}" "${tag}" "${formula_file}" "${checksums_file}"
+
+            for arch in amd64 arm64; do
+              image_var=STAGING_COLLECTOR
+              [[ "${product}" == agenthound-server ]] && image_var=STAGING_SERVER
+              image_repo="${!image_var}"
+              image="${image_repo}:${version}-${arch}"
+              output="$(docker run --rm --platform "linux/${arch}" "${image}" --version)"
+              [[ "${output}" == "${product} version ${version} (commit: ${tag_commit})" ]]
+            done
+          done
+
+          : > "${candidate_dir}/images.tsv"
+          for image_repo in "${STAGING_COLLECTOR}" "${STAGING_SERVER}"; do
+            for suffix in "${version}-amd64" "${version}-arm64" "${version}"; do
+              digest="$(crane digest "${image_repo}:${suffix}")"
+              printf '%s\t%s\n' "${image_repo}:${suffix}" "${digest}" >> "${candidate_dir}/images.tsv"
+            done
+            manifest="$(docker buildx imagetools inspect "${image_repo}:${version}")"
+            grep -Fq 'linux/amd64' <<<"${manifest}"
+            grep -Fq 'linux/arm64' <<<"${manifest}"
+          done
+
+          direct_json="$(GOWORK=off GOPROXY=direct GOSUMDB=off \
+            go list -m -json "github.com/adithyan-ak/agenthound@${tag}")"
+          [[ "$(jq -r '.Origin.Ref' <<<"${direct_json}")" == "refs/tags/${tag}" ]]
+          [[ "$(jq -r '.Origin.Hash' <<<"${direct_json}")" == "${tag_commit}" ]]
+
+          git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          [[ -n "${RELEASE_ADMIN_GITHUB_TOKEN:-}" ]]
+          admin_auth_header="$(printf 'x-access-token:%s' "${RELEASE_ADMIN_GITHUB_TOKEN}" | base64 | tr -d '\n')"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${admin_auth_header}" \
+            push --dry-run origin "${tag_commit}:refs/heads/main"
+
+          printf '%s\n' "${tag_commit}" > "${candidate_dir}/release-commit"
+          printf '%s\n' "$(git rev-parse "${tag_commit}^")" > "${candidate_dir}/release-parent"
+          cp "${RUNNER_TEMP}/release-mode" "${candidate_dir}/release-mode"
+          (
+            cd "${candidate_dir}/formulas"
+            sha256sum *.rb | sort > "${candidate_dir}/formula-digests.txt"
+          )
+          cp "${RUNNER_TEMP}/agenthound-release-notes.md" "${candidate_dir}/release-notes.md"
+
+      - name: Preserve verified candidate records
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: release-candidate-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-candidate
+          if-no-files-found: error
+          retention-days: 3
+
+  publish:
+    needs: candidate
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: release-production
+    permissions:
+      actions: write
+      contents: write
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version: "1.25.12"
+
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Install registry promotion tool
+        run: go install github.com/google/go-containerregistry/cmd/crane@v0.20.6
+
+      - name: Restore verified candidate records
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: release-candidate-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-candidate
+
+      - name: Revalidate the irreversible publication checkpoint
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          records="${RUNNER_TEMP}/release-candidate"
+          tag_commit="$(git rev-parse "${tag}^{commit}")"
+          recorded_commit="$(cat "${records}/release-commit")"
+          recorded_parent="$(cat "${records}/release-parent")"
+          release_mode="$(cat "${records}/release-mode")"
+          [[ "${tag_commit}" == "${recorded_commit}" ]]
+          git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          live_main="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "${release_mode}" == migration ]]; then
+            [[ "$(git rev-list --parents -n1 "${tag_commit}" | awk '{print NF}')" == 2 ]]
+            [[ "$(git rev-parse "${tag_commit}^")" == "${recorded_parent}" ]]
+            [[ "${live_main}" == "${recorded_parent}" ]]
+          else
+            [[ "${release_mode}" == normal ]]
+            [[ "${live_main}" == "${recorded_commit}" ]]
+          fi
+
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq ".[] | select(.tag_name == \"${tag}\")" | head -n1)"
+          [[ -n "${release_json}" ]]
+          [[ "$(jq -r '.draft' <<<"${release_json}")" == true ]]
+          [[ "$(jq -r '.immutable' <<<"${release_json}")" == false ]]
+          [[ "$(jq -r '.body' <<<"${release_json}")" == "$(cat "${records}/release-notes.md")" ]]
+          [[ "$(gh api "repos/${GITHUB_REPOSITORY}/immutable-releases" --jq '.enabled')" == true ]]
+
+          ruleset_id="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" --paginate \
+            --jq '.[] | select(.name == "Protect numeric release tags") | .id')"
+          [[ -n "${ruleset_id}" ]]
+          bypass_count="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets/${ruleset_id}" \
+            --jq '[.bypass_actors[] | select(.actor_type == "User" and .actor_id == 34126904 and .bypass_mode == "always")] | length')"
+          [[ "${bypass_count}" == 1 ]]
+
+          for package in agenthound-release-staging agenthound-server-release-staging; do
+            [[ "$(gh api "users/adithyan-ak/packages/container/${package}" --jq '.visibility')" == private ]]
+          done
+
+          release_id="$(jq -r '.id' <<<"${release_json}")"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > "${RUNNER_TEMP}/live-draft.json"
+          jq -r '.assets[] | [.name, (.digest | sub("^sha256:"; ""))] | @tsv' \
+            "${RUNNER_TEMP}/live-draft.json" | sort > "${RUNNER_TEMP}/live-assets.tsv"
+          diff -u "${records}/assets.tsv" "${RUNNER_TEMP}/live-assets.tsv"
+          (
+            cd "${records}/formulas"
+            sha256sum --check "${records}/formula-digests.txt"
+          )
+          while IFS=$'\t' read -r image digest; do
+            [[ "$(crane digest "${image}")" == "${digest}" ]]
+          done < "${records}/images.tsv"
+
+      - name: Publish and prove the immutable GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          records="${RUNNER_TEMP}/release-candidate"
+          tag_commit="$(cat "${records}/release-commit")"
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq ".[] | select(.tag_name == \"${tag}\")" | head -n1)"
+          release_id="$(jq -r '.id' <<<"${release_json}")"
+          if [[ "$(jq -r '.draft' <<<"${release_json}")" == true ]]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              -F draft=false -F make_latest=true >/dev/null
+          fi
+
+          published="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}")"
+          jq -e --arg tag "${tag}" \
+            '.draft == false and .immutable == true and .tag_name == $tag and (.assets | length) == 26' \
+            <<<"${published}" >/dev/null
+          [[ "$(git rev-parse "${tag}^{commit}")" == "${tag_commit}" ]]
+          jq -r '.assets[] | [.name, (.digest | sub("^sha256:"; ""))] | @tsv' \
+            <<<"${published}" | sort > "${RUNNER_TEMP}/published-assets.tsv"
+          diff -u "${records}/assets.tsv" "${RUNNER_TEMP}/published-assets.tsv"
+          [[ "$(jq -r '.body' <<<"${published}")" == "$(cat "${records}/release-notes.md")" ]]
+          [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')" == "${tag}" ]]
+
+      - name: Fast-forward main to the immutable release commit
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          records="${RUNNER_TEMP}/release-candidate"
+          tag_commit="$(cat "${records}/release-commit")"
+          release_parent="$(cat "${records}/release-parent")"
+          git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          live_main="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "${live_main}" == "${release_parent}" ]]; then
+            auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+              push origin "${tag_commit}:refs/heads/main"
+          elif [[ "${live_main}" != "${tag_commit}" ]]; then
+            echo "main moved unexpectedly to ${live_main}" >&2
+            exit 1
+          fi
+          git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          ./scripts/release-tag-check.sh published "${GITHUB_REF_NAME}" refs/remotes/origin/main >/dev/null
+
+      - name: Promote verified image digests and sign production identities
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          records="${RUNNER_TEMP}/release-candidate"
+          for pair in \
+            "${STAGING_COLLECTOR} ${PRODUCTION_COLLECTOR}" \
+            "${STAGING_SERVER} ${PRODUCTION_SERVER}"; do
+            read -r staging production <<<"${pair}"
+            for arch in amd64 arm64; do
+              crane copy "${staging}:${tag}-${arch}" "${production}:${tag}-${arch}"
+              crane copy "${staging}:${tag}-${arch}" "${production}:latest-${arch}"
+              expected="$(crane digest "${staging}:${tag}-${arch}")"
+              [[ "$(crane digest "${production}:${tag}-${arch}")" == "${expected}" ]]
+              [[ "$(crane digest "${production}:latest-${arch}")" == "${expected}" ]]
+            done
+            crane copy "${staging}:${tag}" "${production}:${tag}"
+            crane copy "${staging}:${tag}" "${production}:latest"
+            expected="$(crane digest "${staging}:${tag}")"
+            [[ "$(crane digest "${production}:${tag}")" == "${expected}" ]]
+            [[ "$(crane digest "${production}:latest")" == "${expected}" ]]
+            cosign sign --yes "${production}@${expected}"
+            cosign verify \
+              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${tag}" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${production}@${expected}" >/dev/null
+          done
+
+          while IFS=$'\t' read -r staging_ref expected; do
+            staging_repo="${staging_ref%%:*}"
+            suffix="${staging_ref##*:}"
+            production="${PRODUCTION_COLLECTOR}"
+            [[ "${staging_repo}" == "${STAGING_SERVER}" ]] && production="${PRODUCTION_SERVER}"
+            [[ "$(crane digest "${production}:${suffix}")" == "${expected}" ]]
+          done < "${records}/images.tsv"
+
+      - name: Publish the exact verified Homebrew formulas
+        env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
+          records="${RUNNER_TEMP}/release-candidate"
+          tap="${RUNNER_TEMP}/homebrew-agenthound"
+          auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_TAP_GITHUB_TOKEN}" | base64 | tr -d '\n')"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            clone --quiet https://github.com/adithyan-ak/homebrew-agenthound.git "${tap}"
+          cp "${records}/formulas/agenthound.rb" "${tap}/Formula/agenthound.rb"
+          cp "${records}/formulas/agenthound-server.rb" "${tap}/Formula/agenthound-server.rb"
+          (
+            cd "${tap}"
+            git config user.name github-actions[bot]
+            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+            if ! git diff --quiet -- Formula/agenthound.rb Formula/agenthound-server.rb; then
+              git add Formula/agenthound.rb Formula/agenthound-server.rb
+              git commit -m "brew: AgentHound ${GITHUB_REF_NAME}"
+              git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+                push origin HEAD:main
+            fi
+          )
+          (
+            cd "${records}/formulas"
+            sha256sum --check "${records}/formula-digests.txt"
+          )
 
+      - name: Remove the temporary numeric-tag rollback bypass
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruleset_id="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" --paginate \
+            --jq '.[] | select(.name == "Protect numeric release tags") | .id')"
+          live="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets/${ruleset_id}")"
+          jq '{name, target, enforcement, bypass_actors: [], conditions, rules}' <<<"${live}" \
+            > "${RUNNER_TEMP}/numeric-ruleset.json"
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/rulesets/${ruleset_id}" \
+            --input "${RUNNER_TEMP}/numeric-ruleset.json" >/dev/null
+          [[ "$(gh api "repos/${GITHUB_REPOSITORY}/rulesets/${ruleset_id}" --jq '.bypass_actors | length')" == 0 ]]
+
+      - name: Verify public GitHub, installer, GHCR, Homebrew, and Go surfaces
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          version="${tag#v}"
-          repo="${GITHUB_REPOSITORY}"
-          tag_commit="$(git rev-parse --verify "${tag}^{commit}")"
-          module="github.com/adithyan-ak/agenthound"
+          commit="$(cat "${RUNNER_TEMP}/release-candidate/release-commit")"
+          module=github.com/adithyan-ak/agenthound
+          [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')" == "${tag}" ]]
+          [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq '.immutable')" == true ]]
+          git fetch --quiet --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          ./scripts/release-tag-check.sh published "${tag}" refs/remotes/origin/main >/dev/null
 
-          latest_tag="$(gh api "repos/${repo}/releases/latest" --jq '.tag_name')"
-          if [[ "${latest_tag}" != "${tag}" ]]; then
-            echo "Latest GitHub release is ${latest_tag}, expected ${tag}" >&2
-            exit 1
-          fi
-
-          asset_count="$(gh release view --repo "${repo}" "${tag}" --json assets --jq '.assets | length')"
-          if [[ "${asset_count}" != "26" ]]; then
-            echo "Expected 26 release assets, found ${asset_count}" >&2
-            exit 1
-          fi
-
-          expected_notes="$(cat "${RUNNER_TEMP}/agenthound-release-notes.md")"
-          published_notes="$(gh release view --repo "${repo}" "${tag}" --json body --jq '.body')"
-          if [[ "${published_notes}" != "${expected_notes}" ]]; then
-            echo "Published release notes do not match the curated changelog section" >&2
-            exit 1
-          fi
-
-          verify_dir="$(mktemp -d)"
-          gh release download --repo "${repo}" "${tag}" --pattern checksums.txt --dir "${verify_dir}"
-
-          for formula in agenthound agenthound-server; do
-            formula_file="${verify_dir}/${formula}.rb"
-            GH_TOKEN="${HOMEBREW_TAP_GITHUB_TOKEN}" gh api \
-              -H 'Accept: application/vnd.github.raw+json' \
-              "repos/adithyan-ak/homebrew-agenthound/contents/Formula/${formula}.rb" > "${formula_file}"
-            ./scripts/verify-homebrew-formula.sh \
-              "${formula}" "${version}" "${tag}" "${formula_file}" "${verify_dir}/checksums.txt"
-          done
-
-          for image in agenthound agenthound-server; do
-            version_image="ghcr.io/adithyan-ak/${image}:${version}"
-            latest_image="ghcr.io/adithyan-ak/${image}:latest"
-            manifest="$(docker buildx imagetools inspect "${version_image}")"
-            grep -Fq 'linux/amd64' <<<"${manifest}"
-            grep -Fq 'linux/arm64' <<<"${manifest}"
-
-            version_digest="$(docker buildx imagetools inspect --raw "${version_image}" | sha256sum | awk '{print $1}')"
-            latest_digest="$(docker buildx imagetools inspect --raw "${latest_image}" | sha256sum | awk '{print $1}')"
-            if [[ "${version_digest}" != "${latest_digest}" ]]; then
-              echo "GHCR ${image}:latest and :${version} resolve to different manifests" >&2
-              exit 1
-            fi
-
-            version_output="$(docker run --rm "${version_image}" --version)"
-            expected_output="${image} version ${version} (commit: ${tag_commit})"
-            if [[ "${version_output}" != "${expected_output}" ]]; then
-              echo "Unexpected ${image} container version: ${version_output}" >&2
-              exit 1
-            fi
-          done
-          if ! grep -Eq '^[[:space:]]*image:[[:space:]]*ghcr\.io/adithyan-ak/agenthound-server:latest[[:space:]]*$' \
-            docker/docker-compose.public.yml; then
-            echo "Public Docker Compose no longer defaults to agenthound-server:latest" >&2
-            exit 1
-          fi
-
-          installer_dir="$(mktemp -d)"
-          curl -sSfL "https://raw.githubusercontent.com/${repo}/main/install.sh" |
-            env -u AGENTHOUND_VERSION AGENTHOUND_INSTALL_DIR="${installer_dir}" sh
-          installer_output="$("${installer_dir}/agenthound" --version)"
-          expected_installer_output="agenthound version ${version} (commit: ${tag_commit})"
-          if [[ "${installer_output}" != "${expected_installer_output}" ]]; then
-            echo "Default installer resolved unexpected build: ${installer_output}" >&2
-            exit 1
-          fi
-
-          go_verify_dir="$(mktemp -d)"
-          latest_json=""
-          for attempt in $(seq 1 12); do
-            attempt_modcache="${go_verify_dir}/mod-${attempt}"
-            candidate="$(GOWORK=off GOMODCACHE="${attempt_modcache}" GOPROXY=https://proxy.golang.org \
-              GOSUMDB=sum.golang.org timeout 60s go list -m -json "${module}@latest" 2>&1 || true)"
-            candidate_version="$(jq -r '.Version // empty' <<<"${candidate}" 2>/dev/null || true)"
-            if [[ "${candidate_version}" == "${tag}" ]]; then
-              latest_json="${candidate}"
+          first_digest="$(head -n1 "${RUNNER_TEMP}/release-candidate/assets.tsv" | cut -f2)"
+          attestation=
+          for attempt in $(seq 1 30); do
+            candidate="$(gh api "users/adithyan-ak/attestations/sha256:${first_digest}?per_page=100" 2>/dev/null || true)"
+            if jq -e '.attestations | length > 0' <<<"${candidate}" >/dev/null 2>&1; then
+              attestation="${candidate}"
               break
             fi
-            echo "Go proxy latest is ${candidate_version:-unavailable}; waiting for ${tag} (${attempt}/12)"
+            echo "Release attestation is not available yet; retry ${attempt}/30"
             sleep 10
           done
-          if [[ -z "${latest_json}" ]]; then
-            echo "Go proxy did not resolve ${module}@latest to ${tag}" >&2
-            exit 1
-          fi
+          [[ -n "${attestation}" ]]
+          jq -r '.attestations[0].bundle.dsseEnvelope.payload' <<<"${attestation}" |
+            base64 --decode > "${RUNNER_TEMP}/release-attestation.json"
+          jq -e --arg tag "${tag}" --arg repo "${GITHUB_REPOSITORY}" \
+            '.predicateType == "https://in-toto.io/attestation/release/v0.2"
+             and .predicate.tag == $tag
+             and (.predicate.repository | ascii_downcase) == ($repo | ascii_downcase)
+             and (.subject | length) == 27' \
+            "${RUNNER_TEMP}/release-attestation.json" >/dev/null
+          tag_object="$(git rev-parse "${tag}")"
+          jq -e --arg uri "pkg:github/adithyan-ak/AgentHound@${tag}" --arg sha1 "${tag_object}" \
+            '.subject[] | select(.uri == $uri and .digest.sha1 == $sha1)' \
+            "${RUNNER_TEMP}/release-attestation.json" >/dev/null
+          jq -r '.subject[] | select(.name != null) | [.name, .digest.sha256] | @tsv' \
+            "${RUNNER_TEMP}/release-attestation.json" | sort > "${RUNNER_TEMP}/attested-assets.tsv"
+          diff -u "${RUNNER_TEMP}/release-candidate/assets.tsv" "${RUNNER_TEMP}/attested-assets.tsv"
 
-          origin_hash="$(jq -r '.Origin.Hash // "not reported"' <<<"${latest_json}")"
-          echo "Go latest Origin.Hash (diagnostic only): ${origin_hash}"
-
-          versions_modcache="${go_verify_dir}/versions-modcache"
-          normal_versions="$(GOWORK=off GOMODCACHE="${versions_modcache}" GOPROXY=https://proxy.golang.org \
-            GOSUMDB=sum.golang.org timeout 60s go list -m -versions -json "${module}@latest")"
-          all_versions="$(GOWORK=off GOMODCACHE="${versions_modcache}" GOPROXY=https://proxy.golang.org \
-            GOSUMDB=sum.golang.org timeout 60s go list -m -versions -retracted -json "${module}@latest")"
-          if ! jq -e --arg latest "${tag}" \
-            '.Version == $latest and (.Versions | index($latest) != null)' <<<"${normal_versions}" >/dev/null; then
-            echo "Normal Go version listing does not select and include ${tag}" >&2
-            exit 1
-          fi
-
-          retracted_versions=(v0.5.0 v0.6.0 v0.6.1 v0.7.0 v0.8.0 v0.9.0 v1.0.0)
-          for retracted in "${retracted_versions[@]}"; do
-            if jq -e --arg version "${retracted}" '.Versions | index($version) != null' \
-              <<<"${normal_versions}" >/dev/null; then
-              echo "Normal Go version listing still includes retracted ${retracted}" >&2
-              exit 1
-            fi
-            if ! jq -e --arg version "${retracted}" '.Versions | index($version) != null' \
-              <<<"${all_versions}" >/dev/null; then
-              echo "Go -retracted version listing omits published ${retracted}" >&2
-              exit 1
-            fi
+          for image in "${PRODUCTION_COLLECTOR}" "${PRODUCTION_SERVER}"; do
+            [[ "$(crane digest "${image}:${tag}")" == "$(crane digest "${image}:latest")" ]]
+            manifest="$(docker buildx imagetools inspect "${image}:${tag}")"
+            grep -Fq 'linux/amd64' <<<"${manifest}"
+            grep -Fq 'linux/arm64' <<<"${manifest}"
+          done
+          for product in agenthound agenthound-server; do
+            image="${PRODUCTION_COLLECTOR}"
+            [[ "${product}" == agenthound-server ]] && image="${PRODUCTION_SERVER}"
+            for arch in amd64 arm64; do
+              output="$(docker run --rm --platform "linux/${arch}" "${image}:${tag}-${arch}" --version)"
+              [[ "${output}" == "${product} version ${tag} (commit: ${commit})" ]]
+            done
           done
 
-          download_json="$(GOWORK=off GOMODCACHE="${go_verify_dir}/download-modcache" \
-            GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
-            timeout 60s go mod download -json "${module}@${tag}")"
-          if ! jq -e --arg version "${tag}" '.Version == $version' <<<"${download_json}" >/dev/null; then
-            echo "go mod download did not resolve ${module}@${tag}" >&2
-            exit 1
+          install_default="$(mktemp -d)"
+          curl -sSfL "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/install.sh" |
+            env -u AGENTHOUND_VERSION AGENTHOUND_INSTALL_DIR="${install_default}" sh
+          [[ "$("${install_default}/agenthound" --version)" == "agenthound version ${tag} (commit: ${commit})" ]]
+          install_pinned="$(mktemp -d)"
+          curl -sSfL "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/install.sh" |
+            env AGENTHOUND_VERSION="${tag}" AGENTHOUND_INSTALL_DIR="${install_pinned}" sh
+          [[ "$("${install_pinned}/agenthound" --version)" == "agenthound version ${tag} (commit: ${commit})" ]]
+
+          verify_dir="$(mktemp -d)"
+          gh release download "${tag}" --repo "${GITHUB_REPOSITORY}" \
+            --pattern checksums.txt --dir "${verify_dir}"
+          for formula in agenthound agenthound-server; do
+            GH_TOKEN="${HOMEBREW_TAP_GITHUB_TOKEN}" gh api \
+              -H 'Accept: application/vnd.github.raw+json' \
+              "repos/adithyan-ak/homebrew-agenthound/contents/Formula/${formula}.rb" \
+              > "${verify_dir}/${formula}.rb"
+            ./scripts/verify-homebrew-formula.sh \
+              "${formula}" "${tag}" "${tag}" "${verify_dir}/${formula}.rb" "${verify_dir}/checksums.txt"
+          done
+
+          proxy_json=
+          for attempt in $(seq 1 30); do
+            modcache="$(mktemp -d)"
+            candidate="$(GOWORK=off GOMODCACHE="${modcache}" GOPROXY=https://proxy.golang.org \
+              GOSUMDB=sum.golang.org timeout 60s go list -m -json "${module}@${tag}" 2>/dev/null || true)"
+            if jq -e '.Version != null' <<<"${candidate}" >/dev/null 2>&1; then
+              proxy_json="${candidate}"
+              break
+            fi
+            echo "Go proxy has not resolved @${tag}; retry ${attempt}/30"
+            sleep 60
+          done
+          [[ -n "${proxy_json}" ]]
+          proxy_version="$(jq -r '.Version' <<<"${proxy_json}")"
+
+          direct_json="$(GOWORK=off GOPROXY=direct GOSUMDB=off go list -m -json "${module}@${tag}")"
+          [[ "$(jq -r '.Origin.Ref' <<<"${direct_json}")" == "refs/tags/${tag}" ]]
+          [[ "$(jq -r '.Origin.Hash' <<<"${direct_json}")" == "${commit}" ]]
+          proxy_download="$(GOWORK=off GOMODCACHE="$(mktemp -d)" GOPROXY=https://proxy.golang.org \
+            GOSUMDB=sum.golang.org go mod download -json "${module}@${tag}")"
+          direct_download="$(GOWORK=off GOMODCACHE="$(mktemp -d)" GOPROXY=direct \
+            GOSUMDB=off go mod download -json "${module}@${tag}")"
+          if [[ "$(jq -r '.Version' <<<"${proxy_download}")" == "$(jq -r '.Version' <<<"${direct_download}")" ]]; then
+            [[ "$(jq -r '.Sum' <<<"${proxy_download}")" == "$(jq -r '.Sum' <<<"${direct_download}")" ]]
+            [[ "$(jq -r '.GoModSum' <<<"${proxy_download}")" == "$(jq -r '.GoModSum' <<<"${direct_download}")" ]]
           fi
 
-          mkdir -p "${go_verify_dir}/bin" "${go_verify_dir}/install-modcache" "${go_verify_dir}/build-cache"
+          go_root="$(mktemp -d)"
+          mkdir -p "${go_root}/bin"
           for command_path in collector/cmd/agenthound server/cmd/agenthound-server; do
-            GOWORK=off GOBIN="${go_verify_dir}/bin" GOMODCACHE="${go_verify_dir}/install-modcache" \
-              GOCACHE="${go_verify_dir}/build-cache" GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
-              timeout 10m go install "${module}/${command_path}@latest"
+            GOWORK=off GOBIN="${go_root}/bin" GOMODCACHE="${go_root}/mod" GOCACHE="${go_root}/cache" \
+              GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org \
+              timeout 10m go install "${module}/${command_path}@${tag}"
           done
-          for binary in agenthound agenthound-server; do
-            source_output="$("${go_verify_dir}/bin/${binary}" --version)"
-            expected_source_output="${binary} version ${version} (commit: none)"
-            if [[ "${source_output}" != "${expected_source_output}" ]]; then
-              echo "Unexpected go install provenance for ${binary}: ${source_output}" >&2
-              exit 1
-            fi
-          done
+          [[ "$("${go_root}/bin/agenthound" --version)" == "agenthound version ${proxy_version} (commit: none)" ]]
+          [[ "$("${go_root}/bin/agenthound-server" --version)" == "agenthound-server version ${proxy_version} (commit: none)" ]]
+
+      - name: Remove the temporary candidate artifact
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "release-candidate-'"${GITHUB_RUN_ID}"'") | .id')"
+          [[ -z "${artifact_id}" ]] || gh api --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
+
+  homebrew-acceptance:
+    needs: publish
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Clean install and test both formulas
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew uninstall --force agenthound agenthound-server 2>/dev/null || true
+          brew untap adithyan-ak/agenthound 2>/dev/null || true
+          brew tap adithyan-ak/agenthound
+          brew install adithyan-ak/agenthound/agenthound \
+            adithyan-ak/agenthound/agenthound-server
+          brew test adithyan-ak/agenthound/agenthound
+          brew test adithyan-ak/agenthound/agenthound-server
+          commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+          [[ "$(agenthound --version)" == "agenthound version ${GITHUB_REF_NAME} (commit: ${commit})" ]]
+          [[ "$(agenthound-server --version)" == "agenthound-server version ${GITHUB_REF_NAME} (commit: ${commit})" ]]

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -18,6 +18,7 @@ on:
       - "Makefile"
       - "scripts/release-notes.sh"
       - "scripts/release-process-test.sh"
+      - "scripts/release-tag-check.sh"
       - "scripts/sync-version.sh"
       - "scripts/verify-homebrew-formula.sh"
       - "scripts/version-check.sh"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,7 @@ brews:
       owner: adithyan-ak
       name: homebrew-agenthound
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    skip_upload: true
     ids: [agenthound]
     name: agenthound
     directory: Formula
@@ -75,6 +76,7 @@ brews:
       owner: adithyan-ak
       name: homebrew-agenthound
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    skip_upload: true
     ids: [agenthound-server]
     name: agenthound-server
     directory: Formula
@@ -88,8 +90,7 @@ brews:
 dockers:
   - id: agenthound
     image_templates:
-      - "ghcr.io/adithyan-ak/agenthound:{{ .Version }}-amd64"
-      - "ghcr.io/adithyan-ak/agenthound:latest-amd64"
+      - "{{ .Env.AGENTHOUND_IMAGE_REPOSITORY }}:{{ .Version }}-amd64"
     dockerfile: docker/Dockerfile.agenthound
     use: buildx
     build_flag_templates:
@@ -104,8 +105,7 @@ dockers:
     goarch: amd64
   - id: agenthound-arm64
     image_templates:
-      - "ghcr.io/adithyan-ak/agenthound:{{ .Version }}-arm64"
-      - "ghcr.io/adithyan-ak/agenthound:latest-arm64"
+      - "{{ .Env.AGENTHOUND_IMAGE_REPOSITORY }}:{{ .Version }}-arm64"
     dockerfile: docker/Dockerfile.agenthound
     use: buildx
     build_flag_templates:
@@ -116,8 +116,7 @@ dockers:
     goarch: arm64
   - id: agenthound-server
     image_templates:
-      - "ghcr.io/adithyan-ak/agenthound-server:{{ .Version }}-amd64"
-      - "ghcr.io/adithyan-ak/agenthound-server:latest-amd64"
+      - "{{ .Env.AGENTHOUND_SERVER_IMAGE_REPOSITORY }}:{{ .Version }}-amd64"
     dockerfile: docker/Dockerfile.agenthound-server
     use: buildx
     build_flag_templates:
@@ -128,8 +127,7 @@ dockers:
     goarch: amd64
   - id: agenthound-server-arm64
     image_templates:
-      - "ghcr.io/adithyan-ak/agenthound-server:{{ .Version }}-arm64"
-      - "ghcr.io/adithyan-ak/agenthound-server:latest-arm64"
+      - "{{ .Env.AGENTHOUND_SERVER_IMAGE_REPOSITORY }}:{{ .Version }}-arm64"
     dockerfile: docker/Dockerfile.agenthound-server
     use: buildx
     build_flag_templates:
@@ -140,27 +138,17 @@ dockers:
     goarch: arm64
 
 docker_manifests:
-  - name_template: ghcr.io/adithyan-ak/agenthound:{{ .Version }}
+  - name_template: "{{ .Env.AGENTHOUND_IMAGE_REPOSITORY }}:{{ .Version }}"
     image_templates:
-      - ghcr.io/adithyan-ak/agenthound:{{ .Version }}-amd64
-      - ghcr.io/adithyan-ak/agenthound:{{ .Version }}-arm64
-  - name_template: ghcr.io/adithyan-ak/agenthound:latest
+      - "{{ .Env.AGENTHOUND_IMAGE_REPOSITORY }}:{{ .Version }}-amd64"
+      - "{{ .Env.AGENTHOUND_IMAGE_REPOSITORY }}:{{ .Version }}-arm64"
+  - name_template: "{{ .Env.AGENTHOUND_SERVER_IMAGE_REPOSITORY }}:{{ .Version }}"
     image_templates:
-      - ghcr.io/adithyan-ak/agenthound:latest-amd64
-      - ghcr.io/adithyan-ak/agenthound:latest-arm64
-  - name_template: ghcr.io/adithyan-ak/agenthound-server:{{ .Version }}
-    image_templates:
-      - ghcr.io/adithyan-ak/agenthound-server:{{ .Version }}-amd64
-      - ghcr.io/adithyan-ak/agenthound-server:{{ .Version }}-arm64
-  - name_template: ghcr.io/adithyan-ak/agenthound-server:latest
-    image_templates:
-      - ghcr.io/adithyan-ak/agenthound-server:latest-amd64
-      - ghcr.io/adithyan-ak/agenthound-server:latest-arm64
+      - "{{ .Env.AGENTHOUND_SERVER_IMAGE_REPOSITORY }}:{{ .Version }}-amd64"
+      - "{{ .Env.AGENTHOUND_SERVER_IMAGE_REPOSITORY }}:{{ .Version }}-arm64"
 
-docker_signs:
-  - cmd: cosign
-    artifacts: manifests
-    args: ["sign", "--yes", "${artifact}@${digest}"]
+release:
+  draft: true
 
 changelog:
   sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,90 +2,46 @@
 
 ## Unreleased
 
-- **Fail-closed custom rule inputs.** Directory rule validation now reports
-  malformed or unreadable YAML as a failure while continuing to validate valid
-  siblings. Fingerprint tar bundles reject entries larger than 1 MiB instead
-  of parsing and executing a truncated prefix.
+## 1.0.0 — 🚀 First Supported Release (2026-07-27)
+
+AgentHound 1.0.0 is the first supported release of the offensive security
+framework built for AI agent infrastructure. It maps MCP, A2A, agent
+configuration, model infrastructure, credentials, tools, resources, notebooks,
+vector stores, and instruction supply chains into one attack graph—then helps
+operators validate the paths that matter against real systems.
+
+> **From observation to proof.** Discover the agentic estate, reveal the paths
+> that matter, and validate them against real infrastructure.
+
+| 🗺️ Discover | 🧠 Correlate | 🎯 Validate | 🔎 Investigate | 📦 Ship |
+|---|---|---|---|---|
+| MCP, A2A, configs, AI services | Temporal attack graph | Reversible campaigns | Evidence-backed UI | Signed multi-platform artifacts |
+
+### 🗺️ Map the agentic attack surface
+
+- **One graph across the agentic stack.** Model agents, MCP servers, tools,
+  prompts, resources, A2A agents, AI services, credentials, instruction files,
+  hosts, and models share one relationship-driven view.
+- **Broad agent configuration coverage.** Discover MCP and agent configuration
+  across Claude Desktop, Claude Code, VS Code, Windsurf, Continue, Zed, Cline,
+  JetBrains, Kiro, Amazon Q, Augment, Cursor, and GitHub Copilot.
+- **Bounded instruction discovery.** Normal scans inspect registered
+  instruction sources at canonical user and project roots. Deep scans add
+  bounded nested-project discovery while excluding dependency, cache, trash,
+  and symlinked descendant trees.
+- **Protocol-aware MCP and A2A collection.** Enumerate live MCP capabilities
+  through the official SDK and ingest A2A v0.3 and v1.0.1 Agent Cards with
+  schema-aware parsing, preserved interfaces, authentication requirements, and
+  bounded JWS verification.
+- **Port-neutral service discovery.** Fingerprint Ollama, Open WebUI, LiteLLM,
+  vLLM, LangServe, MLflow, Qdrant, and Jupyter from observed protocol behavior
+  instead of assuming a service from its port number.
+- **Evidence-backed inventory.** Read-only looters cover LiteLLM, Ollama,
+  Open WebUI, MLflow, Qdrant, and Jupyter while distinguishing verified
+  anonymous access, authenticated access, partial inventory, and unknown state.
 - **First-class scan upload.** `agenthound scan --ingest <server-url>` saves the
-  normal local JSON artifact before uploading those exact bytes,
-  rejects redirects, and prints a correlated ingest receipt with finding
-  counts. Normal and `--deep` config scans use the same explicit workflow.
-- **Fast fully observed empty ingests.** A complete empty collection against an
-  empty projection skips no-op reconciliation, analysis, duplicate graph
-  statistics, and finding queries. Limited or incomplete collections retain
-  the full V1 lifecycle path and cannot enter this optimization.
-- **Bounded instruction discovery by default.** Config scans now check the
-  registered Claude, Cursor, GitHub Copilot, `AGENTS.md`, and `CLAUDE.md`
-  sources at the canonical user and project roots. `--deep` adds a bounded
-  nested-project search under the user home and an independently partitioned
-  selected project; explicit project selection overrides home pruning without
-  scanning sibling dependency or cache trees. Unrelated files do not consume
-  its directory or matched-source budgets, and trash, dependency, cache, and
-  symlinked descendant trees are excluded.
-- **Truthful independent instruction lifecycle.** Exact-user, exact-project,
-  and deep observations have stable owner identities independent of registry
-  evolution. Complete roots retire absent evidence; truncated deep scans
-  publish usable exact posture, retain unseen prior deep evidence, and surface
-  an explicit limitation. Failed deep attempts leave prior deep ownership
-  untouched.
-- **Strict ingest-v1 boundary.** Wire version and registered-source contract
-  mismatches are rejected before storage access. Storage binding v1 requires a
-  clean paired PostgreSQL/Neo4j initialization.
-- **Origin-bound A2A bearer redirects.** Authenticated Agent Card requests now
-  reject host, port, or scheme changes, and all HTTPS-to-HTTP redirects fail
-  before the destination receives a request.
-- **Native Windows embedded rules.** Built-in detection and fingerprint rules
-  use slash-based embedded filesystem paths and are exercised on a native
-  Windows CI runner. Native fingerprint probes also recognize Winsock
-  connection refusals.
-- **Truthful interrupted-ingest recovery.** Server startup and an idle recovery
-  loop terminalize orphaned running scans, retain the previous publication and
-  dirty coverage, and leave the mutable projection safely incomplete until a
-  later authoritative ingest repairs it.
-- **No false clean instruction score.** Agent poisoning risk uses observed
-  `LOADS_INSTRUCTIONS` relationships only; missing load relationships remain
-  an assessment limitation. Published truncated posture remains visible in the
-  dashboard with persistent deep-coverage and registry-refresh warnings, while
-  ambiguous comparisons are unavailable.
-- **Typed posture export v1.** Projection state and persisted exports expose
-  typed active instruction-root coverage. Unsupported persisted export schemas
-  fail closed instead of violating the documented response contract.
-
-## v1.0.1 — 🚀 First Supported Public Release (2026-07-22)
-
-AgentHound v1.0.1 is the first supported public release of an offensive
-security framework built specifically for AI agent infrastructure. It brings
-the relationship-driven analysis of an attack graph to MCP, A2A, agent
-configuration, model infrastructure, credentials, tools, resources, and
-instruction supply chains—then lets operators validate predicted paths against
-real systems with evidence-backed, reversible workflows.
-
-> **From observation to proof.** Discover the agentic estate, reveal the paths
-> that matter, and validate them against real infrastructure.
-
-| 🗺️ Discover | 🧠 Correlate | 🎯 Validate | 🔎 Investigate | 📦 Ship |
-|---|---|---|---|---|
-| MCP, A2A, configs, AI services | Temporal attack graph | Reversible campaigns | Evidence-backed UI | Signed multi-platform artifacts |
-
-### 🗺️ Map the agentic attack surface
-
-- **One graph across the agentic stack.** Model agents, MCP servers, tools,
-  prompts, resources, A2A agents, AI services, credentials, instruction files,
-  hosts, models, and their trust relationships in one temporal attack graph.
-- **Broad local configuration coverage.** Discover MCP and agent configuration
-  across Claude Desktop, Claude Code, VS Code, Windsurf, Continue, Zed, Cline,
-  JetBrains, Kiro, Amazon Q, and Augment, including nested project rules and
-  instruction files.
-- **Protocol-aware MCP and A2A collection.** Enumerate live MCP capabilities
-  through the official SDK and ingest A2A v0.3 and v1.0.1 Agent Cards with
-  schema-aware parsing, interface preservation, authentication requirements,
-  and bounded JWS verification.
-- **Port-neutral AI service discovery.** Fingerprint Ollama, Open WebUI,
-  LiteLLM, vLLM, LangServe, MLflow, Qdrant, and Jupyter from observed protocol
-  behavior rather than assuming a service from its port number.
-- **Evidence-backed inventory.** Read-only looters cover LiteLLM, Ollama,
-  Open WebUI, MLflow, Qdrant, and Jupyter while distinguishing verified
-  anonymous access, authenticated access, partial inventory, and unknown state.
+  local artifact before uploading those exact bytes and returns a correlated
+  ingest receipt with finding counts.
 
 ### 🧠 Turn observations into defensible attack paths
 
@@ -93,66 +49,64 @@ real systems with evidence-backed, reversible workflows.
   the same infrastructure across collectors, while stable credential hashes
   correlate a secret observed in configuration with the service that accepts
   or exposes it—without persisting the raw value by default.
-- **Vantage-aware temporal ingestion.** Ingest V1 derives collection-point and
-  network-context provenance automatically. Ambiguous identities, lifecycle
-  ownership, and cross-observation processing remain scoped per vantage, while
-  weak identity stays analyzable under artifact-local additive-only scope.
-- **Coverage-aware temporal ingestion.** Collection domains declare what they
-  observed completely, partially, or not at all. Complete epochs retire stale
-  truth and rebuild derived relationships; incomplete scans cannot silently
-  present an authoritative clean posture.
+- **Vantage-aware temporal ingestion.** Collection-point and network-context
+  provenance keep identity, lifecycle, and cross-observation analysis scoped to
+  what a scanner could actually observe.
+- **Coverage-aware truth.** Collection domains declare what they observed
+  completely, partially, or not at all. Complete epochs retire stale facts;
+  incomplete scans cannot silently present an authoritative clean posture.
+- **Resilient publication lifecycle.** Interrupted ingests preserve the last
+  trustworthy publication, expose incomplete coverage, and recover cleanly
+  when a later authoritative scan arrives.
 - **Ordered graph reasoning.** Post-processors derive access, execution,
   shadowing, poisoned content, reachability, credential chains, exfiltration,
-  impersonation, cross-protocol paths, and risk scores from the retained raw
-  evidence.
-- **Canonical risk semantics.** `EdgeRiskWeight` and the V1 risk table agree
-  for Basic, OIDC, and unknown or custom authentication.
+  impersonation, cross-protocol paths, and risk scores from retained evidence.
 - **Evidence-first findings.** Prebuilt attack paths, finding detail,
   remediation guidance, graph evidence, and stable witness export keep each
   security conclusion tied to the nodes, edges, provenance, and publication
   revision that produced it.
 - **Rules with provenance.** Built-in detection and fingerprint rules cover
   agent capabilities, credentials, prompt and instruction injection, exposed
-  services, and supply-chain risk. Each collection records the effective rule
-  manifest so reviewers can identify the semantics behind an observation.
+  services, and supply-chain risk, with the effective rule set recorded for
+  each collection.
 
 ### 🎯 Validate the graph against real infrastructure
 
-- **Predicted-to-verified campaigns.** `agenthound campaign` converts a graph
+- **Predicted-to-verified campaigns.** `agenthound campaign` turns a graph
   hypothesis into observed evidence. Credential-reach campaigns compare an
   anonymous control with a hash-matched authenticated probe and upgrade the
-  existing predicted finding when gated access is proven.
-- **ContextForge MCP round trips.** Provider-aware MCP tool-description
-  campaigns bind a live MCP tool to its exact ContextForge row, apply a benign
-  run-specific marker, verify it through management and MCP surfaces, restore
-  the original value, and independently report mutation and cleanup outcomes.
+  predicted finding only when gated access is proven.
+- **ContextForge MCP round trips.** Provider-aware campaigns bind a live MCP
+  tool to its exact ContextForge row, apply a benign run-specific marker,
+  verify it through management and MCP surfaces, and restore the original
+  value.
 - **Reversible offensive primitives.** Authorized extraction, poisoning,
   implantation, campaign, and recovery workflows are dry-run-first. Mutating
-  operations persist typed recovery receipts before the write, use bounded
-  verification, and retain the receipt whenever cleanup is incomplete.
+  operations persist recovery receipts before the write and retain them when
+  cleanup is incomplete.
 - **Truthful runtime evidence.** A2A authentication probes, MCP observations,
-  Jupyter access checks, looter authentication results, and campaign outcomes
-  record only states proven by protocol-correct responses; ambiguity remains
-  visible instead of being promoted into a security claim.
+  Jupyter access checks, looter results, and campaign outcomes record only
+  states proven by protocol-correct responses.
 
 ### 🛡️ Built for trustworthy field use
 
 - **Lean collector boundary.** `agenthound` is a static field binary with no
-  Neo4j, PostgreSQL, web-server, or `server/internal` dependency. Dependency
-  and stripped-size gates enforce that boundary on every release.
+  Neo4j, PostgreSQL, web-server, or server implementation dependency.
+  Dependency and stripped-size gates protect that boundary on every release.
 - **Local-first analysis.** `agenthound-server` combines PostgreSQL, Neo4j,
   post-processing, the REST API, and an embedded React UI while binding to
   `127.0.0.1:8080` by default.
-- **Automatic storage pairing.** The server generates and validates the
-  PostgreSQL/Neo4j storage pairing internally, accepts artifacts from multiple
-  recognized vantages, and reports identity recognition in ingest results.
-- **Strict ingest-v1 boundary.** V1 artifacts use automatic vantage-aware
-  ownership and require freshly initialized paired storage.
+- **Automatic storage pairing.** The server generates and validates its
+  PostgreSQL/Neo4j pairing, accepts artifacts from recognized vantages, and
+  reports identity recognition in ingest results.
 - **Strict transport defaults.** MCP and A2A TLS verification is on by default;
-  insecure transport requires an explicit operator choice. Active operations
-  require an `AUTHORIZED` acknowledgement and record engagement provenance.
-- **Dependency remediation.** `golang.org/x/text` 0.39.0 closes the reachable
-  `GO-2026-5970` invalid-input infinite loop reported by `govulncheck`.
+  insecure transport requires an explicit operator choice. Authenticated A2A
+  redirects cannot cross origin or downgrade from HTTPS to HTTP.
+- **Fail-closed inputs.** Invalid custom detection rules, oversized fingerprint
+  bundles, incompatible wire contracts, and unsupported persisted export
+  schemas are rejected instead of being partially trusted.
+- **Explicit authorization.** Active operations require an `AUTHORIZED`
+  acknowledgement and record engagement provenance.
 
 ### 🔎 Investigation-ready frontend
 
@@ -171,159 +125,15 @@ real systems with evidence-backed, reversible workflows.
 
 ### 📦 Verifiable multi-platform release
 
-- ✅ Collector and server archives for macOS, Linux, and Windows on amd64 and
+- Collector and server archives for macOS, Linux, and Windows on amd64 and
   arm64.
-- ✅ Multi-architecture `agenthound` and `agenthound-server` images on GHCR.
-- ✅ SHA-256 checksums, keyless Sigstore verification bundles, and per-archive
+- Multi-architecture `agenthound` and `agenthound-server` images on GHCR.
+- SHA-256 checksums, a keyless Sigstore verification bundle, and per-archive
   software bills of materials.
-- ✅ Homebrew formulas for the collector and analysis server.
-- ✅ Public Docker Compose deployment with health-checked PostgreSQL, Neo4j, and
+- Homebrew formulas for the collector and analysis server.
+- Public Docker Compose deployment with health-checked PostgreSQL, Neo4j, and
   the loopback-bound AgentHound server.
-- ✅ Tagged archives and containers carry the GoReleaser-injected source commit;
-  `go install ...@latest` derives its module version from Go build metadata and
-  truthfully reports `commit: none` when no linker commit was injected.
-- ✅ Release gates reject drift across every installer pin and require an empty
-  Unreleased section on tag builds. Publication verification covers the latest
-  GitHub release, GHCR tag digests, Homebrew URLs and checksums, the default
-  installer, Go module retractions, and fresh source installs.
-
-### ✅ Release confidence
-
-This release was validated end to end against the project’s real disposable
-infrastructure: collection, ingest lifecycle, database binding, derived graph,
-API responses, browser representation, recovery paths, upgrades, release
-gates, and distribution configuration. Documentation and source comments were
-also reconciled against the shipped v1 implementation and release process.
-
-## v1.0.0 — 🚀 First Supported Public Release (2026-07-20)
-
-> **Retracted historical publication.** This section preserves the original
-> v1.0.0 notes. That publication is unsupported because GitHub and the Go
-> module proxy resolved it to different source commits. v1.0.1 is the first
-> supported public release.
-
-AgentHound v1.0.0 is the first supported public release of an offensive
-security framework built specifically for AI agent infrastructure. It brings
-the relationship-driven analysis of an attack graph to MCP, A2A, agent
-configuration, model infrastructure, credentials, tools, resources, and
-instruction supply chains—then lets operators validate predicted paths against
-real systems with evidence-backed, reversible workflows.
-
-> **From observation to proof.** Discover the agentic estate, reveal the paths
-> that matter, and validate them against real infrastructure.
-
-| 🗺️ Discover | 🧠 Correlate | 🎯 Validate | 🔎 Investigate | 📦 Ship |
-|---|---|---|---|---|
-| MCP, A2A, configs, AI services | Temporal attack graph | Reversible campaigns | Evidence-backed UI | Signed multi-platform artifacts |
-
-### 🗺️ Map the agentic attack surface
-
-- **One graph across the agentic stack.** Model agents, MCP servers, tools,
-  prompts, resources, A2A agents, AI services, credentials, instruction files,
-  hosts, models, and their trust relationships in one temporal attack graph.
-- **Broad local configuration coverage.** Discover MCP and agent configuration
-  across Claude Desktop, Claude Code, VS Code, Windsurf, Continue, Zed, Cline,
-  JetBrains, Kiro, Amazon Q, and Augment, including nested project rules and
-  instruction files.
-- **Protocol-aware MCP and A2A collection.** Enumerate live MCP capabilities
-  through the official SDK and ingest A2A v0.3 and v1.0.1 Agent Cards with
-  schema-aware parsing, interface preservation, authentication requirements,
-  and bounded JWS verification.
-- **Port-neutral AI service discovery.** Fingerprint Ollama, Open WebUI,
-  LiteLLM, vLLM, LangServe, MLflow, Qdrant, and Jupyter from observed protocol
-  behavior rather than assuming a service from its port number.
-- **Evidence-backed inventory.** Read-only looters cover LiteLLM, Ollama,
-  Open WebUI, MLflow, Qdrant, and Jupyter while distinguishing verified
-  anonymous access, authenticated access, partial inventory, and unknown state.
-
-### 🧠 Turn observations into defensible attack paths
-
-- **Deterministic cross-collector identity.** Content-addressed node IDs merge
-  the same infrastructure across collectors, while stable credential hashes
-  correlate a secret observed in configuration with the service that accepts
-  or exposes it—without persisting the raw value by default.
-- **Coverage-aware temporal ingestion.** Collection domains declare what they
-  observed completely, partially, or not at all. Complete epochs retire stale
-  truth and rebuild derived relationships; incomplete scans cannot silently
-  present an authoritative clean posture.
-- **Ordered graph reasoning.** Post-processors derive access, execution,
-  shadowing, poisoned content, reachability, credential chains, exfiltration,
-  impersonation, cross-protocol paths, and risk scores from the retained raw
-  evidence.
-- **Evidence-first findings.** Prebuilt attack paths, finding detail,
-  remediation guidance, graph evidence, and stable witness export keep each
-  security conclusion tied to the nodes, edges, provenance, and publication
-  revision that produced it.
-- **Rules with provenance.** Built-in detection and fingerprint rules cover
-  agent capabilities, credentials, prompt and instruction injection, exposed
-  services, and supply-chain risk. Each collection records the effective rule
-  manifest so reviewers can identify the semantics behind an observation.
-
-### 🎯 Validate the graph against real infrastructure
-
-- **Predicted-to-verified campaigns.** `agenthound campaign` converts a graph
-  hypothesis into observed evidence. Credential-reach campaigns compare an
-  anonymous control with a hash-matched authenticated probe and upgrade the
-  existing predicted finding when gated access is proven.
-- **ContextForge MCP round trips.** Provider-aware MCP tool-description
-  campaigns bind a live MCP tool to its exact ContextForge row, apply a benign
-  run-specific marker, verify it through management and MCP surfaces, restore
-  the original value, and independently report mutation and cleanup outcomes.
-- **Reversible offensive primitives.** Authorized extraction, poisoning,
-  implantation, campaign, and recovery workflows are dry-run-first. Mutating
-  operations persist typed recovery receipts before the write, use bounded
-  verification, and retain the receipt whenever cleanup is incomplete.
-- **Truthful runtime evidence.** A2A authentication probes, MCP observations,
-  Jupyter access checks, looter authentication results, and campaign outcomes
-  record only states proven by protocol-correct responses; ambiguity remains
-  visible instead of being promoted into a security claim.
-
-### 🛡️ Built for trustworthy field use
-
-- **Lean collector boundary.** `agenthound` is a static field binary with no
-  Neo4j, PostgreSQL, web-server, or `server/internal` dependency. Dependency
-  and stripped-size gates enforce that boundary on every release.
-- **Local-first analysis.** `agenthound-server` combines PostgreSQL, Neo4j,
-  post-processing, the REST API, and an embedded React UI while binding to
-  `127.0.0.1:8080` by default.
-- **Realm-safe graph ownership.** The v1.0.0 wire contract used a canonical
-  host/private-network realm and admitted one collection realm per database.
-- **Fail-closed storage pairing.** The v1.0.0 server required a configured
-  versioned storage-pair binding in both databases and rechecked it before
-  ingest mutation.
-- **Strict transport defaults.** MCP and A2A TLS verification is on by default;
-  insecure transport requires an explicit operator choice. Active operations
-  require an `AUTHORIZED` acknowledgement and record engagement provenance.
-
-### 🔎 Investigation-ready frontend
-
-- **Dashboard and triage.** Review exposure, risk distribution, credential
-  posture, chokepoints, cross-protocol reach, high-risk entities, and current
-  findings from the same published graph revision.
-- **Interactive graph explorer.** Navigate the React Flow + ELK graph through
-  security lenses, search, evidence drawers, relationship semantics, attack
-  paths, and exportable investigation context.
-- **Reviewer-friendly findings.** Finding pages expose the supporting path,
-  verification status, remediation, property evidence, and copy-ready reports
-  without flattening predicted and observed claims into the same state.
-- **Operator-guided collection.** Scan Manager generates origin-correct,
-  copyable commands for configuration, MCP, A2A, discovery, and service
-  collection workflows.
-
-### 📦 Verifiable multi-platform release
-
-- ✅ Collector and server archives for macOS, Linux, and Windows on amd64 and
-  arm64.
-- ✅ Multi-architecture `agenthound` and `agenthound-server` images on GHCR.
-- ✅ SHA-256 checksums, keyless Sigstore verification bundles, and per-archive
-  software bills of materials.
-- ✅ Homebrew formulas for the collector and analysis server.
-- ✅ Public Docker Compose deployment with health-checked PostgreSQL, Neo4j, and
-  the loopback-bound AgentHound server.
-
-### ✅ Release confidence
-
-This release was validated end to end against the project’s real disposable
-infrastructure: collection, ingest lifecycle, database binding, derived graph,
-API responses, browser representation, recovery paths, upgrades, release
-gates, and distribution configuration.
+- Release archives and containers identify the exact source commit.
+- Release gates protect installer pins, release notes, dependency boundaries,
+  binary size, tests, documentation, cross-compilation, and distribution
+  metadata before publication.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ IMPORTANT: Before any release tag, run `make prerelease` — it gates on all rel
 
 ### Release versioning (single source of truth)
 
-The first `## vX.Y.Z` header in `CHANGELOG.md` is the SSOT for the human-maintained version. The binary / Docker / Homebrew versions are injected by GoReleaser from the git tag, so the only strings to bump are the install pins in `install.sh` and `README.md`.
+The first `## X.Y.Z` header in `CHANGELOG.md` is the SSOT for the human-maintained version. Release tags use strict numeric SemVer without a `v` prefix. The binary / Docker / Homebrew versions are injected by GoReleaser from the git tag, so the only strings to bump are the install pins in `install.sh` and `README.md`.
 
 Release prep: write the new `CHANGELOG.md` section, run `make sync-version` (rewrites both pins from the CHANGELOG), then `make prerelease`. `scripts/version-check.sh` runs as a `prerelease` step (and as a path-filtered CI job on `install.sh` / `README.md` / `CHANGELOG.md` changes); it fails if the pins or the pushed tag disagree with the CHANGELOG, so a mismatched version can never ship.
 

--- a/README.md
+++ b/README.md
@@ -190,11 +190,12 @@ brew install adithyan-ak/agenthound/agenthound \
 ```
 
 <!-- Release automation updates this hidden compatibility pin:
-https://raw.githubusercontent.com/adithyan-ak/agenthound/v1.0.1/install.sh
+https://raw.githubusercontent.com/adithyan-ak/agenthound/1.0.0/install.sh
 -->
 
-Also available via `go install` and release archives with a Cosign-signed checksum
-manifest and per-archive SPDX SBOMs - see the
+Also available from release archives, or from Go at the explicit
+`@1.0.0` revision. Release archives include a Cosign-signed checksum manifest
+and per-archive SPDX SBOMs - see the
 [installation guide](https://docs.agenthound.io/getting-started/install/).
 
 ## 🔪 The offensive lifecycle

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -20,7 +20,7 @@ brew install adithyan-ak/agenthound/agenthound            # collector only
 brew install adithyan-ak/agenthound/agenthound-server     # analysis server
 ```
 
-Both formulas are published by GoReleaser on every tagged release. The
+Both formulas are published from the verified release candidate. The
 fully-qualified names are required because Homebrew does not automatically
 trust third-party taps. Multi-arch (amd64 + arm64).
 
@@ -72,9 +72,14 @@ go build -o bin/agenthound ./collector/cmd/agenthound
 ## Via `go install`
 
 ```bash
-go install github.com/adithyan-ak/agenthound/collector/cmd/agenthound@latest
-go install github.com/adithyan-ak/agenthound/server/cmd/agenthound-server@latest
+go install github.com/adithyan-ak/agenthound/collector/cmd/agenthound@1.0.0
+go install github.com/adithyan-ak/agenthound/server/cmd/agenthound-server@1.0.0
 ```
+
+The numeric Git tag is an explicit revision for Go rather than a canonical
+`v1.0.0` module version, so Go reports a pseudo-version for this installation.
+Always use the explicit `@1.0.0` revision; `@latest` can resolve the unsupported
+historical `v1.0.1` module from public proxy caches.
 
 ## Verify
 
@@ -83,9 +88,10 @@ agenthound version
 agenthound-server version
 ```
 
-Both print `version (commit: commit)`. On a release build GoReleaser injects the
-git-tag version and commit hash. A local build without linker overrides prints
-the compiled development defaults.
+GoReleaser archives and containers print the release version and source commit.
+A `go install` build reports Go's pseudo-version and may not include a linker
+commit. A local build without linker overrides prints the compiled development
+defaults.
 
 ## Release signatures
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/adithyan-ak/agenthound
 
 go 1.25.12
 
-// v0.5.0 through v1.0.0 are superseded unsupported publications; v1.0.0 is
-// inconsistent across GitHub and the Go module proxy. Use v1.0.1 or later.
+// v0.5.0 through v1.0.0 are superseded unsupported publications. The historical
+// v1.0.1 is also unsupported, but a numeric Git tag cannot make that canonical
+// module version technically retracted. Use the explicit revision @1.0.0.
 retract [v0.5.0, v1.0.0]
 
 require (

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # AgentHound collector installer.
 #
 # Pin to a release tag for integrity:
-#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/v1.0.1/install.sh | sh
+#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/1.0.0/install.sh | sh
 #
 # Verifies the downloaded archive against checksums.txt before extracting,
 # and against cosign signatures if cosign is available on $PATH.
@@ -41,7 +41,7 @@ if [ -z "$AGENTHOUND_VERSION" ]; then
   VERSION=${resolved##*/tag/}
   if [ -z "$VERSION" ] || [ "$VERSION" = "$resolved" ]; then
     echo "Error: could not determine latest release"
-    echo "       Set AGENTHOUND_VERSION=vX.Y.Z to pin a specific version."
+    echo "       Set AGENTHOUND_VERSION=X.Y.Z to pin a specific version."
     exit 1
   fi
 else
@@ -52,7 +52,7 @@ echo "Version:  ${VERSION}"
 echo "Platform: ${OS}/${ARCH}"
 echo ""
 
-ARCHIVE="agenthound_${VERSION#v}_${OS}_${ARCH}.tar.gz"
+ARCHIVE="agenthound_${VERSION}_${OS}_${ARCH}.tar.gz"
 BASE_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}"
 TMPDIR=$(mktemp -d)
 STAGE=$(mktemp -d)

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -5,13 +5,12 @@ set -eu
 
 changelog=${1:-CHANGELOG.md}
 expected=${2:-}
-expected=${expected#v}
 
 if [ ! -f "$changelog" ]; then
   echo "release-notes: changelog not found: $changelog" >&2
   exit 1
 fi
-if [ -n "$expected" ] && ! printf '%s\n' "$expected" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+if [ -n "$expected" ] && ! printf '%s\n' "$expected" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
   echo "release-notes: invalid expected version: $expected" >&2
   exit 1
 fi
@@ -22,17 +21,17 @@ awk -v expected="$expected" '
     next
   }
 
-  /^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)/ {
+  /^## (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([[:space:]]|$)/ {
     sections++
     if (sections > 1) {
       exit
     }
 
     version = $0
-    sub(/^## v/, "", version)
+    sub(/^## /, "", version)
     sub(/[[:space:]].*$/, "", version)
     if (expected != "" && version != expected) {
-      print "release-notes: newest version v" version " does not match expected v" expected > "/dev/stderr"
+      print "release-notes: newest version " version " does not match expected " expected > "/dev/stderr"
       exit 2
     }
     if (title != "") {

--- a/scripts/release-process-test.sh
+++ b/scripts/release-process-test.sh
@@ -13,21 +13,18 @@ new_fixture() {
   cp "$repo_root/scripts/version-check.sh" "$root/scripts/"
   cp "$repo_root/scripts/sync-version.sh" "$root/scripts/"
   cp "$repo_root/scripts/release-notes.sh" "$root/scripts/"
+  cp "$repo_root/scripts/release-tag-check.sh" "$root/scripts/"
   cat > "$root/CHANGELOG.md" <<'EOF'
 # AgentHound Changelog
 
 ## Unreleased
 
-## v1.0.1 — Release (2026-07-22)
+## 1.0.0 — Release (2026-07-27)
 
 Release body.
-
-## v1.0.0 — Historical (2026-07-20)
-
-Historical body.
 EOF
-  printf '# curl -sSfL %s/v1.0.1/install.sh | sh\n' "$pin_base" > "$root/install.sh"
-  printf 'curl -sSfL %s/v1.0.1/install.sh | sh\n' "$pin_base" > "$root/README.md"
+  printf '# curl -sSfL %s/1.0.0/install.sh | sh\n' "$pin_base" > "$root/install.sh"
+  printf 'curl -sSfL %s/1.0.0/install.sh | sh\n' "$pin_base" > "$root/README.md"
   printf '%s\n' "$root"
 }
 
@@ -42,15 +39,15 @@ expect_failure() {
 
 happy=$(new_fixture happy)
 (cd "$happy" && bash scripts/version-check.sh >/dev/null)
-(cd "$happy" && GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.0.1 bash scripts/version-check.sh >/dev/null)
+(cd "$happy" && GITHUB_REF_TYPE=tag GITHUB_REF_NAME=1.0.0 bash scripts/version-check.sh >/dev/null)
 
 mismatch=$(new_fixture mismatch)
-sed -i.bak 's/v1\.0\.1/v1.0.0/' "$mismatch/README.md"
+sed -i.bak 's/1\.0\.0/1.0.1/' "$mismatch/README.md"
 rm "$mismatch/README.md.bak"
 expect_failure "mismatched installer pin" bash "$mismatch/scripts/version-check.sh"
 
 duplicate=$(new_fixture duplicate)
-printf '%s/v1.0.1/install.sh\n' "$pin_base" >> "$duplicate/README.md"
+printf '%s/1.0.0/install.sh\n' "$pin_base" >> "$duplicate/README.md"
 expect_failure "duplicate installer pin" bash "$duplicate/scripts/version-check.sh"
 before_sync=$(cksum "$duplicate/install.sh" "$duplicate/README.md")
 expect_failure "sync with duplicate installer pin" bash "$duplicate/scripts/sync-version.sh" 1.0.2
@@ -60,49 +57,157 @@ if [ "$before_sync" != "$after_sync" ]; then
   exit 1
 fi
 
+leading_zero=$(new_fixture leading-zero)
+sed -i.bak 's/## 1\.0\.0/## 01.0.0/' "$leading_zero/CHANGELOG.md"
+rm "$leading_zero/CHANGELOG.md.bak"
+expect_failure "leading-zero release version" bash "$leading_zero/scripts/version-check.sh"
+expect_failure "leading-zero sync argument" bash "$leading_zero/scripts/sync-version.sh" 01.0.0
+
 unreleased=$(new_fixture unreleased)
 sed -i.bak '/## Unreleased/a\
 Pending change.' "$unreleased/CHANGELOG.md"
 rm "$unreleased/CHANGELOG.md.bak"
-expect_failure "non-empty Unreleased on tag" env GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.0.1 \
+expect_failure "non-empty Unreleased on tag" env GITHUB_REF_TYPE=tag GITHUB_REF_NAME=1.0.0 \
   bash "$unreleased/scripts/version-check.sh"
 
 sync=$(new_fixture sync)
 (cd "$sync" && bash scripts/sync-version.sh 1.0.2 >/dev/null)
-if [ "$(grep -RhoE 'agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh' "$sync/install.sh" "$sync/README.md" | sort -u)" != "agenthound/v1.0.2/install.sh" ]; then
+if [ "$(grep -RhoE 'agenthound/[0-9]+\.[0-9]+\.[0-9]+/install\.sh' "$sync/install.sh" "$sync/README.md" | sort -u)" != "agenthound/1.0.2/install.sh" ]; then
   echo "release-process-test: sync did not update both pins" >&2
   exit 1
 fi
 
 notes=$(new_fixture notes)
-rendered=$(cd "$notes" && sh scripts/release-notes.sh CHANGELOG.md v1.0.1)
-printf '%s\n' "$rendered" | grep -Fq '## v1.0.1 — Release'
-if printf '%s\n' "$rendered" | grep -Fq '## v1.0.0'; then
+rendered=$(cd "$notes" && sh scripts/release-notes.sh CHANGELOG.md 1.0.0)
+printf '%s\n' "$rendered" | grep -Fq '## 1.0.0 — Release'
+if printf '%s\n' "$rendered" | grep -Fq '## Unreleased'; then
   echo "release-process-test: release notes included a historical section" >&2
   exit 1
 fi
-expect_failure "release-notes version mismatch" sh "$notes/scripts/release-notes.sh" "$notes/CHANGELOG.md" v1.0.2
+expect_failure "release-notes version mismatch" sh "$notes/scripts/release-notes.sh" "$notes/CHANGELOG.md" 1.0.2
 
 formula_fixture="$test_root/agenthound.rb"
 checksums_fixture="$test_root/checksums.txt"
-printf '  version "1.0.1"\n' > "$formula_fixture"
+printf '  version "1.0.0"\n' > "$formula_fixture"
 for platform in darwin linux; do
   for arch in amd64 arm64; do
-    asset="agenthound_1.0.1_${platform}_${arch}.tar.gz"
+    asset="agenthound_1.0.0_${platform}_${arch}.tar.gz"
     checksum=$(printf '%064d' "$(( ${#platform} + ${#arch} ))")
-    printf '  url "https://github.com/adithyan-ak/AgentHound/releases/download/v1.0.1/%s"\n' "$asset" >> "$formula_fixture"
+    printf '  url "https://github.com/adithyan-ak/AgentHound/releases/download/1.0.0/%s"\n' "$asset" >> "$formula_fixture"
     printf '  sha256 "%s"\n' "$checksum" >> "$formula_fixture"
     printf '%s  %s\n' "$checksum" "$asset" >> "$checksums_fixture"
   done
 done
 bash "$repo_root/scripts/verify-homebrew-formula.sh" \
-  agenthound 1.0.1 v1.0.1 "$formula_fixture" "$checksums_fixture"
+  agenthound 1.0.0 1.0.0 "$formula_fixture" "$checksums_fixture"
 
 bad_formula="$test_root/agenthound-bad.rb"
 cp "$formula_fixture" "$bad_formula"
 sed -i.bak 's/linux_arm64/windows_arm64/' "$bad_formula"
 rm "$bad_formula.bak"
 expect_failure "unexpected Homebrew archive" bash "$repo_root/scripts/verify-homebrew-formula.sh" \
-  agenthound 1.0.1 v1.0.1 "$bad_formula" "$checksums_fixture"
+  agenthound 1.0.0 1.0.0 "$bad_formula" "$checksums_fixture"
+
+new_git_fixture() {
+  local name=$1 root="$test_root/git-$1"
+  mkdir -p "$root"
+  (
+    cd "$root"
+    git init -q
+    git config user.name "Release Test"
+    git config user.email "release-test@example.invalid"
+    printf 'base\n' > state
+    git add state
+    git commit -qm base
+  )
+  mkdir -p "$root/scripts"
+  cp "$repo_root/scripts/release-tag-check.sh" "$root/scripts/"
+  printf '%s\n' "$root"
+}
+
+migration=$(new_git_fixture migration)
+(
+  cd "$migration"
+  migration_main=$(git rev-parse HEAD)
+  printf 'candidate\n' >> state
+  git commit -qam candidate
+  git tag 1.0.0
+  [ "$(bash scripts/release-tag-check.sh candidate 1.0.0 v1.0.1 "$migration_main")" = migration ]
+  expect_failure "published main has not advanced" \
+    bash scripts/release-tag-check.sh published 1.0.0 "$migration_main"
+  bash scripts/release-tag-check.sh published 1.0.0 HEAD >/dev/null
+)
+
+wrong_parent=$(new_git_fixture wrong-parent)
+(
+  cd "$wrong_parent"
+  old_main=$(git rev-parse HEAD)
+  printf 'intermediate\n' >> state
+  git commit -qam intermediate
+  printf 'candidate\n' >> state
+  git commit -qam candidate
+  git tag 1.0.0
+  expect_failure "migration parent is not current main" \
+    bash scripts/release-tag-check.sh candidate 1.0.0 v1.0.1 "$old_main"
+)
+
+merge_candidate=$(new_git_fixture merge)
+(
+  cd "$merge_candidate"
+  base=$(git rev-parse HEAD)
+  primary=$(git branch --show-current)
+  git switch -qc side
+  printf 'side\n' > side
+  git add side
+  git commit -qm side
+  git switch -q "$primary"
+  printf 'main\n' > main
+  git add main
+  git commit -qm main
+  git merge -q --no-ff side -m merge
+  git tag 1.0.0
+  expect_failure "migration candidate is a merge commit" \
+    bash scripts/release-tag-check.sh candidate 1.0.0 v1.0.1 "$base"
+)
+
+invalid_migration=$(new_git_fixture invalid-migration)
+(
+  cd "$invalid_migration"
+  main=$(git rev-parse HEAD)
+  printf 'candidate\n' >> state
+  git commit -qam candidate
+  git tag 1.0.1
+  expect_failure "migration tag other than 1.0.0" \
+    bash scripts/release-tag-check.sh candidate 1.0.1 v1.0.1 "$main"
+  git tag 1.0.0
+  expect_failure "migration exception with a different latest release" \
+    bash scripts/release-tag-check.sh candidate 1.0.0 v1.0.0 "$main"
+)
+
+normal=$(new_git_fixture normal)
+(
+  cd "$normal"
+  printf 'candidate\n' >> state
+  git commit -qam candidate
+  git tag 1.0.1
+  [ "$(bash scripts/release-tag-check.sh candidate 1.0.1 1.0.0 HEAD)" = normal ]
+  expect_failure "duplicate normal version" \
+    bash scripts/release-tag-check.sh candidate 1.0.1 1.0.1 HEAD
+  git tag 0.9.0
+  expect_failure "lower normal version" \
+    bash scripts/release-tag-check.sh candidate 0.9.0 1.0.0 HEAD
+)
+
+normal_off_main=$(new_git_fixture normal-off-main)
+(
+  cd "$normal_off_main"
+  main=$(git rev-parse HEAD)
+  git switch -qc release
+  printf 'candidate\n' >> state
+  git commit -qam candidate
+  git tag 1.0.1
+  expect_failure "normal release tag is not contained in main" \
+    bash scripts/release-tag-check.sh candidate 1.0.1 1.0.0 "$main"
+)
 
 echo "release-process-test: all checks passed"

--- a/scripts/release-tag-check.sh
+++ b/scripts/release-tag-check.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Enforce the one-time no-v migration and the normal numeric release policy.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 candidate TAG LATEST_RELEASE MAIN_REF" >&2
+  echo "       $0 published TAG MAIN_REF" >&2
+  exit 2
+}
+
+is_numeric_semver() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+}
+
+semver_is_greater() {
+  local candidate=$1 current=$2
+  local candidate_major candidate_minor candidate_patch
+  local current_major current_minor current_patch
+  IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate"
+  IFS=. read -r current_major current_minor current_patch <<<"$current"
+
+  (( candidate_major > current_major )) ||
+    (( candidate_major == current_major && candidate_minor > current_minor )) ||
+    (( candidate_major == current_major && candidate_minor == current_minor && candidate_patch > current_patch ))
+}
+
+mode=${1:-}
+case "$mode" in
+  candidate)
+    [ "$#" -eq 4 ] || usage
+    tag=$2
+    latest=$3
+    main_ref=$4
+    is_numeric_semver "$tag" || {
+      echo "release-tag-check: tag must be strict numeric SemVer: $tag" >&2
+      exit 1
+    }
+    git rev-parse --verify "${tag}^{commit}" >/dev/null
+    git rev-parse --verify "${main_ref}^{commit}" >/dev/null
+    tag_commit=$(git rev-parse "${tag}^{commit}")
+    main_commit=$(git rev-parse "${main_ref}^{commit}")
+
+    if [ "$tag" = "1.0.0" ] && [ "$latest" = "v1.0.1" ]; then
+      parent_line=$(git rev-list --parents -n 1 "$tag_commit")
+      # A non-merge commit produces exactly two words: commit and one parent.
+      if [ "$(printf '%s\n' "$parent_line" | awk '{print NF}')" -ne 2 ]; then
+        echo "release-tag-check: migration candidate must have exactly one parent" >&2
+        exit 1
+      fi
+      parent_commit=$(printf '%s\n' "$parent_line" | awk '{print $2}')
+      if [ "$parent_commit" != "$main_commit" ]; then
+        echo "release-tag-check: migration parent $parent_commit is not current main $main_commit" >&2
+        exit 1
+      fi
+      echo migration
+      exit 0
+    fi
+
+    is_numeric_semver "$latest" || {
+      echo "release-tag-check: latest release $latest is not numeric; migration exception is unavailable" >&2
+      exit 1
+    }
+    semver_is_greater "$tag" "$latest" || {
+      echo "release-tag-check: $tag must be newer than $latest" >&2
+      exit 1
+    }
+    git merge-base --is-ancestor "$tag_commit" "$main_commit" || {
+      echo "release-tag-check: normal release tag must already be contained in main" >&2
+      exit 1
+    }
+    echo normal
+    ;;
+  published)
+    [ "$#" -eq 3 ] || usage
+    tag=$2
+    main_ref=$3
+    is_numeric_semver "$tag" || {
+      echo "release-tag-check: tag must be strict numeric SemVer: $tag" >&2
+      exit 1
+    }
+    tag_commit=$(git rev-parse --verify "${tag}^{commit}")
+    main_commit=$(git rev-parse --verify "${main_ref}^{commit}")
+    if [ "$tag_commit" != "$main_commit" ]; then
+      echo "release-tag-check: main $main_commit does not equal peeled tag commit $tag_commit" >&2
+      exit 1
+    fi
+    echo "$tag_commit"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -6,17 +6,16 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 ver="${1:-}"
-ver="${ver#v}"
 if [ -z "$ver" ]; then
-  ver=$(grep -m1 -E '^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' CHANGELOG.md \
-    | sed -nE 's/^## v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' || true)
+  ver=$(grep -m1 -E '^## (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([[:space:]]|$)' CHANGELOG.md \
+    | sed -nE 's/^## ((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)).*/\1/p' || true)
 fi
-if ! printf '%s\n' "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+if ! printf '%s\n' "$ver" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
   echo "sync-version: '${ver:-<empty>}' is not a valid X.Y.Z version"
   exit 1
 fi
 
-pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh'
+pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/(v)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)/install\.sh'
 files=(install.sh README.md)
 
 # Validate both files before mutating either one. This prevents a duplicate or
@@ -33,9 +32,9 @@ sedi() {
   if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi
 }
 
-replacement="https://raw.githubusercontent.com/adithyan-ak/agenthound/v${ver}/install.sh"
+replacement="https://raw.githubusercontent.com/adithyan-ak/agenthound/${ver}/install.sh"
 for file in "${files[@]}"; do
   sedi -E "s#${pin_pattern}#${replacement}#g" "$file"
-  echo "sync-version: set v${ver} pin in $file"
+  echo "sync-version: set ${ver} pin in $file"
 done
 echo "sync-version: updated exactly 2 tagged installer URLs. Run 'make version-check' to confirm."

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -6,23 +6,23 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 fail=0
-release_header=$(grep -m1 -E '^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' CHANGELOG.md || true)
-ver=$(printf '%s\n' "$release_header" | sed -nE 's/^## v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+release_header=$(grep -m1 -E '^## (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([[:space:]]|$)' CHANGELOG.md || true)
+ver=$(printf '%s\n' "$release_header" | sed -nE 's/^## ((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)).*/\1/p')
 if [ -z "$ver" ]; then
-  echo "version-check: FAIL — no '## vX.Y.Z' release header found in CHANGELOG.md"
+  echo "version-check: FAIL — no '## X.Y.Z' release header found in CHANGELOG.md"
   exit 1
 fi
-echo "version-check: CHANGELOG source of truth = v$ver"
+echo "version-check: CHANGELOG source of truth = $ver"
 
 unreleased_count=$(grep -cE '^## Unreleased[[:space:]]*$' CHANGELOG.md || true)
 unreleased_line=$(grep -n -m1 -E '^## Unreleased[[:space:]]*$' CHANGELOG.md | cut -d: -f1 || true)
-release_line=$(grep -n -m1 -E '^## v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' CHANGELOG.md | cut -d: -f1 || true)
+release_line=$(grep -n -m1 -E '^## (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([[:space:]]|$)' CHANGELOG.md | cut -d: -f1 || true)
 if [ "$unreleased_count" -ne 1 ] || [ -z "$unreleased_line" ] || [ "$unreleased_line" -ge "$release_line" ]; then
   echo "  FAIL: CHANGELOG.md must contain exactly one '## Unreleased' before the newest release"
   fail=1
 fi
 
-pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh'
+pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)/install\.sh'
 for file in install.sh README.md; do
   matches=$(grep -oE "$pin_pattern" "$file" || true)
   count=$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d '[:space:]')
@@ -32,9 +32,9 @@ for file in install.sh README.md; do
     continue
   fi
 
-  found=$(printf '%s\n' "$matches" | sed -nE 's#^.*/(v[0-9]+\.[0-9]+\.[0-9]+)/install\.sh$#\1#p')
-  if [ "$found" != "v$ver" ]; then
-    echo "  FAIL: $file pins $found, expected v$ver"
+  found=$(printf '%s\n' "$matches" | sed -nE 's#^.*/((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))/install\.sh$#\1#p')
+  if [ "$found" != "$ver" ]; then
+    echo "  FAIL: $file pins $found, expected $ver"
     fail=1
   else
     echo "  ok: $file -> $found"
@@ -45,8 +45,8 @@ done
 # must name the CHANGELOG version, and Unreleased must already be empty so the
 # published notes cannot omit last-minute changes.
 if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
-  if [ "${GITHUB_REF_NAME:-}" != "v$ver" ]; then
-    echo "  FAIL: tag ${GITHUB_REF_NAME:-<none>} != CHANGELOG v$ver"
+  if [ "${GITHUB_REF_NAME:-}" != "$ver" ]; then
+    echo "  FAIL: tag ${GITHUB_REF_NAME:-<none>} != CHANGELOG $ver"
     fail=1
   else
     echo "  ok: tag ${GITHUB_REF_NAME} matches CHANGELOG"
@@ -69,4 +69,4 @@ if [ "$fail" -ne 0 ]; then
   echo "version-check: FAILED — prepare CHANGELOG.md, then run 'make sync-version' (or fix the tag)."
   exit 1
 fi
-echo "version-check: all release metadata is consistent (v$ver)."
+echo "version-check: all release metadata is consistent ($ver)."


### PR DESCRIPTION
CI-only release preparation validation. Do not merge: the approved immutable release workflow will advance main after publication.