### PR TITLE
Refresh release installation and version references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
         run: |
           set -euo pipefail
           go install github.com/google/go-containerregistry/cmd/crane@v0.20.6
-          crane copy ghcr.io/adithyan-ak/agenthound:1.0.1 \
+          crane copy ghcr.io/adithyan-ak/agenthound:latest \
             "${STAGING_COLLECTOR}:bootstrap"
-          crane copy ghcr.io/adithyan-ak/agenthound-server:1.0.1 \
+          crane copy ghcr.io/adithyan-ak/agenthound-server:latest \
             "${STAGING_SERVER}:bootstrap"
 
   candidate:

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@
 [Safety](#-safety--authorization)
 
 [![CI](https://github.com/adithyan-ak/agenthound/actions/workflows/ci.yml/badge.svg)](https://github.com/adithyan-ak/agenthound/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/adithyan-ak/agenthound?logo=github)](https://github.com/adithyan-ak/agenthound/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/adithyan-ak/agenthound)](https://goreportcard.com/report/github.com/adithyan-ak/agenthound)
+[![Release](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fadithyan-ak%2FAgentHound%2Freleases%2Flatest&query=%24.tag_name&label=release&logo=github)](https://github.com/adithyan-ak/agenthound/releases/latest)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![cosign](https://img.shields.io/badge/checksums-cosign%20signed-0b7285)](https://docs.agenthound.io/getting-started/install/)
 
 </div>
 
@@ -135,7 +133,8 @@ A new attack against a new AI service is one module away - implement an action i
 
 ## 🚀 Quick start
 
-Prerequisites: Docker + Compose v2. No Go, no Node, no `git clone`.
+Default path prerequisites: Docker + Compose v2. No Go, no Node, no
+`git clone`.
 
 **1. Start the analysis server** - Neo4j + Postgres + UI, binds
 `127.0.0.1:8080`:
@@ -150,6 +149,19 @@ curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/main/docker/
 curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/main/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
 ```
+
+Or choose one of these package-manager alternatives:
+
+```bash
+# Homebrew (macOS or Linux; adds the tap automatically)
+brew install adithyan-ak/agenthound/agenthound
+
+# Go 1.25.12+
+go install github.com/adithyan-ak/agenthound/collector/cmd/agenthound@1.0.0
+```
+
+Go installs into `GOBIN` or, by default, `$(go env GOPATH)/bin`; ensure that
+directory is on `PATH`.
 
 **3. Scan local configs** - offline, read-only, raw credential values omitted.
 Choose one coverage level and ingest the saved artifact.
@@ -181,19 +193,13 @@ ingest receipt. Use `--json` for the full receipt.
   <img src="docs/readme-assets/agenthound-dashboard.png" alt="AgentHound dashboard" width="900">
 </p>
 
-Prefer Homebrew for both binaries?
-
-```bash
-brew tap adithyan-ak/agenthound
-brew install adithyan-ak/agenthound/agenthound \
-  adithyan-ak/agenthound/agenthound-server
-```
-
 <!-- Release automation updates this hidden compatibility pin:
 https://raw.githubusercontent.com/adithyan-ak/agenthound/1.0.0/install.sh
 -->
 
-Also available from release archives, or from Go at the explicit
+The standalone server binary is also available as
+`adithyan-ak/agenthound/agenthound-server` through Homebrew. Both binaries are
+available from release archives, or from Go at the explicit
 `@1.0.0` revision. Release archives include a Cosign-signed checksum manifest
 and per-archive SPDX SBOMs - see the
 [installation guide](https://docs.agenthound.io/getting-started/install/).

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -4,7 +4,7 @@
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| Go | 1.25+ | Build from source only |
+| Go | 1.25.12+ | Build from source or install with `go install` |
 | Docker + Compose | v2+ | Required for the analysis server (Neo4j + Postgres) |
 | Node.js | 20+ | UI build only (skippable if using Docker or collector-only) |
 
@@ -15,14 +15,13 @@ The **collector** (`agenthound`) has zero runtime dependencies -- single static 
 ## Homebrew (macOS / Linux)
 
 ```bash
-brew tap adithyan-ak/agenthound
 brew install adithyan-ak/agenthound/agenthound            # collector only
 brew install adithyan-ak/agenthound/agenthound-server     # analysis server
 ```
 
 Both formulas are published from the verified release candidate. The
-fully-qualified names are required because Homebrew does not automatically
-trust third-party taps. Multi-arch (amd64 + arm64).
+fully-qualified command automatically adds the tap and trusts only the selected
+formula. Multi-arch (amd64 + arm64).
 
 ## Docker
 
@@ -78,14 +77,15 @@ go install github.com/adithyan-ak/agenthound/server/cmd/agenthound-server@1.0.0
 
 The numeric Git tag is an explicit revision for Go rather than a canonical
 `v1.0.0` module version, so Go reports a pseudo-version for this installation.
-Always use the explicit `@1.0.0` revision; `@latest` can resolve the unsupported
-historical `v1.0.1` module from public proxy caches.
+Always use the explicit `@1.0.0` revision. Do not use `@latest`: historical
+canonical `v*` versions remain in module proxies, so resolver and cache state can
+produce a different version label or source revision.
 
 ## Verify
 
 ```bash
-agenthound version
-agenthound-server version
+agenthound --version
+agenthound-server --version
 ```
 
 GoReleaser archives and containers print the release version and source commit.

--- a/docs/operator/discover.md
+++ b/docs/operator/discover.md
@@ -57,7 +57,7 @@ ingest that output.
     "version": 1,
     "type": "agenthound-ingest",
     "collector": "scan",
-    "collector_version": "1.0.1",
+    "collector_version": "1.0.0",
     "timestamp": "2026-07-11T20:00:00Z",
     "scan_id": "...",
     "identity": {

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -287,7 +287,7 @@ credential material.
     "version": 1,
     "type": "agenthound-ingest",
     "collector": "mcp",
-    "collector_version": "1.0.1",
+    "collector_version": "1.0.0",
     "timestamp": "2026-07-11T00:00:00Z",
     "scan_id": "scan-abc123",
     "identity": {

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -622,7 +622,7 @@ New modules emit nodes and edges via the `sdk/ingest` wire format:
     "version": 1,
     "type": "agenthound-ingest",
     "collector": "mcp|a2a|config|scan",
-    "collector_version": "1.0.1",
+    "collector_version": "1.0.0",
     "timestamp": "2025-01-15T10:30:00Z",
     "scan_id": "scan-abc123",
     "identity": {


### PR DESCRIPTION
## Summary

- make the README release badge display the exact numeric `1.0.0` tag
- document the verified Homebrew and explicit Go installation paths in Quick Start
- update the installation guide for Homebrew's current direct-install behavior and Go 1.25.12
- replace stale `collector_version: 1.0.1` documentation examples with `1.0.0`
- bootstrap future private staging packages from the current production `latest` images instead of the deleted `1.0.1` tags

## Why

The release reset left a few user-facing version references and one staging-bootstrap source pointing at the retired release line. The standard Shields release badge also normalized the numeric tag to `v1.0.0`, which did not match the repository's exact supported tag.

## Impact

New users get accurate installer alternatives and version guidance. The release badge now reports the exact GitHub release tag, documentation examples agree with the supported release, and staging bootstrap no longer depends on deleted GHCR tags.

## Validation

- `make version-check`
- `make docs-check` (strict MkDocs build)
- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./... -race`
- live verification of GitHub latest release, Homebrew formulas, GHCR tags, and explicit `go install ...@1.0.0` resolution