### PR TITLE
ci: fix immutable release publication gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,7 +370,6 @@ jobs:
             [[ "${draft}" == false && "${immutable}" == true ]]
           fi
           [[ "$(jq -r '.body' <<<"${release_json}")" == "$(cat "${records}/release-notes.md")" ]]
-          [[ "$(gh api "repos/${GITHUB_REPOSITORY}/immutable-releases" --jq '.enabled')" == true ]]
 
           for package in agenthound-release-staging agenthound-server-release-staging; do
             [[ "$(gh api "users/adithyan-ak/packages/container/${package}" --jq '.visibility')" == private ]]


### PR DESCRIPTION
## Summary

- remove the pre-publication query to the admin-only immutable-release settings endpoint
- retain the authoritative post-publication requirement that the release object is immutable
- unblock the protected 1.1.0 publication job without weakening release verification

## Validation

- `make version-check`
- `./scripts/release-process-test.sh`
- `git diff --check`

The 1.1.0 candidate remains unpublished and all public distribution surfaces remain on 1.0.0.