### PR TITLE
fix: close AgentHound 1.1 release E2E findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Positional scan targets now reject malformed hostname syntax before any resolver or network work begins.
 - The installer now validates before promotion and atomically restores the previous binary when installed-path startup validation fails.
 - Legitimate documentation URLs no longer look like Base64 prompt-injection payloads or, by themselves, outbound-network capabilities.
+- Active planning avoids redundant credential presentation when the exact MCP resource or A2A card/probe surface has already succeeded anonymously.
 
 ## 1.1.0 — ⚡ Autonomous Offensive Collection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@
 
 ### Fixed
 
-- Concrete credentials discovered in multiple agent configurations now share one `value_hash`-based identity while retaining every provenance contribution.
+- Concrete credentials discovered in multiple agent configurations now share one `value_hash`-based identity with deterministic provenance and authentication hints.
 - Positional scan targets now reject malformed hostname syntax before any resolver or network work begins.
 - The installer now validates before promotion and atomically restores the previous binary when installed-path startup validation fails.
 - Legitimate documentation URLs no longer look like Base64 prompt-injection payloads or, by themselves, outbound-network capabilities.
-- Active planning no longer presents credentials to A2A agents with proven anonymous protocol access or to MCP resources whose anonymous exact-resource control succeeds.
 
 ## 1.1.0 — ⚡ Autonomous Offensive Collection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- Concrete credentials discovered in multiple agent configurations now share one `value_hash`-based identity while retaining every provenance contribution.
+- Positional scan targets now reject malformed hostname syntax before any resolver or network work begins.
+- The installer now validates before promotion and atomically restores the previous binary when installed-path startup validation fails.
+- Legitimate documentation URLs no longer look like Base64 prompt-injection payloads or, by themselves, outbound-network capabilities.
+- Active planning no longer presents credentials to A2A agents with proven anonymous protocol access or to MCP resources whose anonymous exact-resource control succeeds.
+
 ## 1.1.0 — ⚡ Autonomous Offensive Collection
 
 AgentHound 1.1 is an offensive security framework built for the moment a red-team operator lands on a compromised host. One static collector maps the foothold, captures usable secrets, discovers the reachable agentic estate, expands access with compatible credentials, proves concrete attack paths, and preserves the operation in one JSON artifact.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-collector build-server build-all test lint check security-check integration upstream-test cross-build docker docker-collector docker-server docker-standard up down clean seed release ui-build ui-check ui-dev ui-test standard standard-run standard-stop deps-check size-check version-check sync-version docs-check prerelease preflight-build preflight-collector preflight-server preflight-docker preflight-docker-compose preflight-server-running
+.PHONY: build build-collector build-server build-all test lint check security-check integration upstream-test cross-build docker docker-collector docker-server docker-standard up down clean seed release ui-build ui-check ui-dev ui-test standard standard-run standard-stop deps-check size-check installer-test version-check sync-version docs-check prerelease preflight-build preflight-collector preflight-server preflight-docker preflight-docker-compose preflight-server-running
 
 # Release tooling is pinned independently of the project's Go version.
 # Go may download the tool's newer required toolchain on the first local run.
@@ -73,6 +73,7 @@ check: preflight-build
 	go test ./... -short -race -count=1
 	$(MAKE) deps-check
 	$(MAKE) size-check
+	$(MAKE) installer-test
 	$(MAKE) ui-check
 	mkdir -p bin
 	go build -o bin/agenthound ./collector/cmd/agenthound
@@ -153,6 +154,9 @@ deps-check:
 
 size-check:
 	@bash scripts/size-check.sh
+
+installer-test:
+	@bash scripts/install-atomic-test.sh
 
 # Assert the install.sh + README version pins match the CHANGELOG (the version
 # source of truth). Also runs inside `make prerelease`, so release.yml enforces

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Concrete secrets are saved as usable material, deduplicated by value hash, and a
 <td width="50%" valign="top">
 
 🧪 **Proof instead of reachability guesses**<br/>
-For an eligible MCP resource, AgentHound first performs an anonymous control read. If that exact read succeeds, it records public access without presenting a credential. Otherwise, it compares a credentialed read of the same resource; a denied control plus an allowed credentialed read becomes **Verified During Scan** evidence tied to that credential and resource.
+For an eligible MCP resource, AgentHound compares an anonymous control read with an authenticated read using the exact credential. A denied control plus an allowed credentialed read becomes **Verified During Scan** evidence tied to that credential and resource.
 
 </td>
 <td width="50%" valign="top">

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Concrete secrets are saved as usable material, deduplicated by value hash, and a
 <td width="50%" valign="top">
 
 🧪 **Proof instead of reachability guesses**<br/>
-For an eligible MCP resource, AgentHound compares an anonymous control read with an authenticated read using the exact credential. A denied control plus an allowed credentialed read becomes **Verified During Scan** evidence tied to that credential and resource.
+For an eligible MCP resource, AgentHound first performs an anonymous control read. If that exact read succeeds, it records public access without presenting a credential. Otherwise, it compares a credentialed read of the same resource; a denied control plus an allowed credentialed read becomes **Verified During Scan** evidence tied to that credential and resource.
 
 </td>
 <td width="50%" valign="top">

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Concrete secrets are saved as usable material, deduplicated by value hash, and a
 <td width="50%" valign="top">
 
 🧪 **Proof instead of reachability guesses**<br/>
-For an eligible MCP resource, AgentHound compares an anonymous control read with an authenticated read using the exact credential. A denied control plus an allowed credentialed read becomes **Verified During Scan** evidence tied to that credential and resource.
+For an eligible MCP resource, AgentHound first performs an anonymous control read. If that exact read succeeds, it records public access without presenting a credential. Otherwise, it follows with an authenticated read; a denied control plus an allowed credentialed read becomes **Verified During Scan** evidence tied to that credential and resource.
 
 </td>
 <td width="50%" valign="top">

--- a/collector/cli/planner_actions.go
+++ b/collector/cli/planner_actions.go
@@ -259,6 +259,13 @@ func (a a2aCredentialAction) Candidates(view View) []Candidate {
 	var candidates []Candidate
 	seen := make(map[string]bool)
 	for _, agent := range view.ByKind["A2AAgent"] {
+		// A successful anonymous protocol probe is stronger evidence than the
+		// card's declared security metadata. Credentials cannot unlock anything
+		// further here and must not be disclosed to the already-public origin.
+		if stringProperty(agent.Properties, "auth_probe_status") ==
+			a2acollector.A2AAuthProbeStatusAnonymousProtocolAccess {
+			continue
+		}
 		endpoint := stringProperty(agent.Properties, "url")
 		if endpoint == "" {
 			continue

--- a/collector/cli/planner_actions.go
+++ b/collector/cli/planner_actions.go
@@ -264,6 +264,14 @@ func (a a2aCredentialAction) Candidates(view View) []Candidate {
 	var candidates []Candidate
 	seen := make(map[string]bool)
 	for _, agent := range view.ByKind["A2AAgent"] {
+		// This action only refetches the Agent Card with a bearer. When the
+		// initial card fetch and the bounded protocol probe both succeeded
+		// anonymously, another card fetch cannot prove that the bearer was
+		// accepted or expand the collected surface.
+		if stringProperty(agent.Properties, "auth_probe_status") ==
+			a2acollector.A2AAuthProbeStatusAnonymousProtocolAccess {
+			continue
+		}
 		endpoint := stringProperty(agent.Properties, "url")
 		if endpoint == "" {
 			continue

--- a/collector/cli/planner_actions.go
+++ b/collector/cli/planner_actions.go
@@ -221,19 +221,24 @@ func (a ollamaEmbeddingAction) Execute(ctx context.Context, candidate Candidate,
 }
 
 func credentialCompatibleWithService(node ingest.Node, service string) bool {
-	if method := common.AuthMethod(stringProperty(node.Properties, "auth_method")); method != "" {
-		switch method {
-		case common.AuthBearer, common.AuthAPIKey:
-			// Supported by the concrete adapters below.
-		default:
+	methods := credentialPropertyValues(node.Properties, "auth_method", "auth_methods")
+	if len(methods) > 0 {
+		supported := false
+		for _, method := range methods {
+			if common.AuthMethod(method) == common.AuthBearer || common.AuthMethod(method) == common.AuthAPIKey {
+				supported = true
+				break
+			}
+		}
+		if !supported {
 			return false
 		}
 	}
-	joined := strings.ToLower(strings.Join([]string{
-		stringProperty(node.Properties, "type"),
-		stringProperty(node.Properties, "name"),
-		stringProperty(node.Properties, "format"),
-	}, " "))
+	hints := append([]string(nil), methods...)
+	for _, field := range [][2]string{{"type", "types"}, {"name", "names"}, {"format", "formats"}} {
+		hints = append(hints, credentialPropertyValues(node.Properties, field[0], field[1])...)
+	}
+	joined := strings.ToLower(strings.Join(hints, " "))
 	switch service {
 	case "litellm":
 		return strings.Contains(joined, "master") || strings.Contains(joined, "bearer") || strings.Contains(joined, "api")
@@ -259,13 +264,6 @@ func (a a2aCredentialAction) Candidates(view View) []Candidate {
 	var candidates []Candidate
 	seen := make(map[string]bool)
 	for _, agent := range view.ByKind["A2AAgent"] {
-		// A successful anonymous protocol probe is stronger evidence than the
-		// card's declared security metadata. Credentials cannot unlock anything
-		// further here and must not be disclosed to the already-public origin.
-		if stringProperty(agent.Properties, "auth_probe_status") ==
-			a2acollector.A2AAuthProbeStatusAnonymousProtocolAccess {
-			continue
-		}
 		endpoint := stringProperty(agent.Properties, "url")
 		if endpoint == "" {
 			continue
@@ -543,7 +541,43 @@ func targetsForEdge(edges []ingest.Edge, kind string) []string {
 }
 
 func bearerCredential(node ingest.Node) bool {
-	return common.AuthMethod(stringProperty(node.Properties, "auth_method")) == common.AuthBearer
+	for _, method := range credentialPropertyValues(node.Properties, "auth_method", "auth_methods") {
+		if common.AuthMethod(method) == common.AuthBearer {
+			return true
+		}
+	}
+	return false
+}
+
+func credentialPropertyValues(properties map[string]any, singular, plural string) []string {
+	seen := make(map[string]bool)
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			seen[value] = true
+		}
+	}
+	if value, ok := properties[singular].(string); ok {
+		add(value)
+	}
+	switch values := properties[plural].(type) {
+	case []string:
+		for _, value := range values {
+			add(value)
+		}
+	case []any:
+		for _, raw := range values {
+			if value, ok := raw.(string); ok {
+				add(value)
+			}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for value := range seen {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func stringProperty(properties map[string]any, key string) string {

--- a/collector/cli/planner_test.go
+++ b/collector/cli/planner_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	a2acollector "github.com/adithyan-ak/agenthound/modules/a2a"
 	_ "github.com/adithyan-ak/agenthound/modules/ollamacollect"
 	_ "github.com/adithyan-ak/agenthound/modules/qdrantcollect"
 
@@ -162,6 +163,41 @@ func TestCredentialReachSkipsResourceAlreadyProvenPublic(t *testing.T) {
 	view := buildPlannerView(graph, nil, map[string]bool{}, false, false)
 	if candidates := (credentialReachAction{}).Candidates(view); len(candidates) != 0 {
 		t.Fatalf("candidates = %+v, want none after public access was proven", candidates)
+	}
+}
+
+func TestA2ACredentialActionSkipsAgentWithProvenAnonymousAccess(t *testing.T) {
+	const (
+		agentID      = "agent"
+		credentialID = "credential"
+	)
+	credential := ingest.Node{ID: credentialID, Kinds: []string{"Credential"}, Properties: map[string]any{
+		"value":           "unrelated-bearer",
+		"value_hash":      common.HashCredentialValue("unrelated-bearer"),
+		"material_status": string(common.CredentialMaterialObserved),
+		"auth_method":     string(common.AuthBearer),
+	}}
+	for _, test := range []struct {
+		name       string
+		probeState string
+		want       int
+	}{
+		{name: "anonymous access proven", probeState: a2acollector.A2AAuthProbeStatusAnonymousProtocolAccess, want: 0},
+		{name: "authentication required", probeState: a2acollector.A2AAuthProbeStatusAuthenticationRequired, want: 1},
+		{name: "probe unknown", probeState: a2acollector.A2AAuthProbeStatusUnknown, want: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			graph := ingest.GraphData{Nodes: []ingest.Node{
+				{ID: agentID, Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+					"url": "https://a2a.example", "auth_probe_status": test.probeState,
+				}},
+				credential,
+			}}
+			view := buildPlannerView(graph, nil, map[string]bool{}, false, false)
+			if candidates := (a2aCredentialAction{}).Candidates(view); len(candidates) != test.want {
+				t.Fatalf("candidates = %+v, want %d", candidates, test.want)
+			}
+		})
 	}
 }
 

--- a/collector/cli/planner_test.go
+++ b/collector/cli/planner_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	a2acollector "github.com/adithyan-ak/agenthound/modules/a2a"
 	_ "github.com/adithyan-ak/agenthound/modules/ollamacollect"
 	_ "github.com/adithyan-ak/agenthound/modules/qdrantcollect"
 
@@ -179,6 +180,41 @@ func TestCredentialReachSkipsResourceAlreadyProvenPublic(t *testing.T) {
 	view := buildPlannerView(graph, nil, map[string]bool{}, false, false)
 	if candidates := (credentialReachAction{}).Candidates(view); len(candidates) != 0 {
 		t.Fatalf("candidates = %+v, want none after public access was proven", candidates)
+	}
+}
+
+func TestA2ACredentialActionSkipsOnlyProvenAnonymousAgent(t *testing.T) {
+	const (
+		agentID      = "agent"
+		credentialID = "credential"
+	)
+	credential := ingest.Node{ID: credentialID, Kinds: []string{"Credential"}, Properties: map[string]any{
+		"value":           "compatible-bearer",
+		"value_hash":      common.HashCredentialValue("compatible-bearer"),
+		"material_status": string(common.CredentialMaterialObserved),
+		"auth_method":     string(common.AuthBearer),
+	}}
+	for _, test := range []struct {
+		name       string
+		probeState string
+		want       int
+	}{
+		{name: "anonymous access proven", probeState: a2acollector.A2AAuthProbeStatusAnonymousProtocolAccess, want: 0},
+		{name: "authentication required", probeState: a2acollector.A2AAuthProbeStatusAuthenticationRequired, want: 1},
+		{name: "probe unknown", probeState: a2acollector.A2AAuthProbeStatusUnknown, want: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			graph := ingest.GraphData{Nodes: []ingest.Node{
+				{ID: agentID, Kinds: []string{"A2AAgent"}, Properties: map[string]any{
+					"url": "https://a2a.example", "auth_probe_status": test.probeState,
+				}},
+				credential,
+			}}
+			view := buildPlannerView(graph, nil, map[string]bool{}, false, false)
+			if candidates := (a2aCredentialAction{}).Candidates(view); len(candidates) != test.want {
+				t.Fatalf("candidates = %+v, want %d", candidates, test.want)
+			}
+		})
 	}
 }
 

--- a/collector/cli/planner_test.go
+++ b/collector/cli/planner_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	a2acollector "github.com/adithyan-ak/agenthound/modules/a2a"
 	_ "github.com/adithyan-ak/agenthound/modules/ollamacollect"
 	_ "github.com/adithyan-ak/agenthound/modules/qdrantcollect"
 
@@ -77,19 +76,36 @@ func TestPlannerIndexesOnlyObservedCredentialMaterial(t *testing.T) {
 
 func TestBearerCandidatesRequireDeclaredBearerMethod(t *testing.T) {
 	for _, test := range []struct {
-		method common.AuthMethod
-		want   bool
+		name       string
+		properties map[string]any
+		want       bool
 	}{
-		{method: common.AuthBearer, want: true},
-		{method: common.AuthBasic},
-		{method: common.AuthCustom},
-		{method: common.AuthUnknown},
+		{name: "singular bearer", properties: map[string]any{"auth_method": string(common.AuthBearer)}, want: true},
+		{name: "aggregated bearer", properties: map[string]any{"auth_methods": []string{string(common.AuthAPIKey), string(common.AuthBearer)}}, want: true},
+		{name: "decoded aggregate", properties: map[string]any{"auth_methods": []any{string(common.AuthBearer)}}, want: true},
+		{name: "basic", properties: map[string]any{"auth_method": string(common.AuthBasic)}},
+		{name: "custom", properties: map[string]any{"auth_method": string(common.AuthCustom)}},
+		{name: "unknown", properties: map[string]any{"auth_method": string(common.AuthUnknown)}},
 	} {
-		node := ingest.Node{Properties: map[string]any{
-			"name": "Authorization", "type": "hardcoded", "auth_method": string(test.method),
-		}}
-		if got := bearerCredential(node); got != test.want {
-			t.Fatalf("bearerCredential(%q) = %t, want %t", test.method, got, test.want)
+		t.Run(test.name, func(t *testing.T) {
+			node := ingest.Node{Properties: test.properties}
+			if got := bearerCredential(node); got != test.want {
+				t.Fatalf("bearerCredential() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAggregatedCredentialHintsPreserveServiceCompatibility(t *testing.T) {
+	credential := ingest.Node{Properties: map[string]any{
+		"auth_methods": []string{string(common.AuthAPIKey), string(common.AuthBearer)},
+		"names":        []string{"Authorization", "JUPYTER_TOKEN"},
+		"types":        []string{"hardcoded"},
+		"formats":      []string{"generic"},
+	}}
+	for _, service := range []string{"litellm", "openwebui", "jupyter"} {
+		if !credentialCompatibleWithService(credential, service) {
+			t.Fatalf("aggregated credential was not compatible with %s", service)
 		}
 	}
 }
@@ -163,41 +179,6 @@ func TestCredentialReachSkipsResourceAlreadyProvenPublic(t *testing.T) {
 	view := buildPlannerView(graph, nil, map[string]bool{}, false, false)
 	if candidates := (credentialReachAction{}).Candidates(view); len(candidates) != 0 {
 		t.Fatalf("candidates = %+v, want none after public access was proven", candidates)
-	}
-}
-
-func TestA2ACredentialActionSkipsAgentWithProvenAnonymousAccess(t *testing.T) {
-	const (
-		agentID      = "agent"
-		credentialID = "credential"
-	)
-	credential := ingest.Node{ID: credentialID, Kinds: []string{"Credential"}, Properties: map[string]any{
-		"value":           "unrelated-bearer",
-		"value_hash":      common.HashCredentialValue("unrelated-bearer"),
-		"material_status": string(common.CredentialMaterialObserved),
-		"auth_method":     string(common.AuthBearer),
-	}}
-	for _, test := range []struct {
-		name       string
-		probeState string
-		want       int
-	}{
-		{name: "anonymous access proven", probeState: a2acollector.A2AAuthProbeStatusAnonymousProtocolAccess, want: 0},
-		{name: "authentication required", probeState: a2acollector.A2AAuthProbeStatusAuthenticationRequired, want: 1},
-		{name: "probe unknown", probeState: a2acollector.A2AAuthProbeStatusUnknown, want: 1},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			graph := ingest.GraphData{Nodes: []ingest.Node{
-				{ID: agentID, Kinds: []string{"A2AAgent"}, Properties: map[string]any{
-					"url": "https://a2a.example", "auth_probe_status": test.probeState,
-				}},
-				credential,
-			}}
-			view := buildPlannerView(graph, nil, map[string]bool{}, false, false)
-			if candidates := (a2aCredentialAction{}).Candidates(view); len(candidates) != test.want {
-				t.Fatalf("candidates = %+v, want %d", candidates, test.want)
-			}
-		})
 	}
 }
 

--- a/docs/operator/attack-paths.md
+++ b/docs/operator/attack-paths.md
@@ -54,7 +54,7 @@ agenthound-server query --prebuilt litellm-credential-leak
 
 ## Same-scan access proof
 
-For an eligible MCP resource, the collector performs an anonymous control read and then an authenticated read with the selected credential. A denied control plus an allowed authenticated read emits:
+For an eligible MCP resource, the collector performs an anonymous control read first. A successful exact read records public access without presenting a credential. Otherwise, the collector follows with an authenticated read; a denied control plus an allowed authenticated read emits:
 
 ```text
 Credential -CREDENTIAL_ACCESS_OBSERVED-> MCPResource

--- a/docs/operator/scanner.md
+++ b/docs/operator/scanner.md
@@ -57,7 +57,7 @@ Anonymous collection covers applicable LiteLLM, Open WebUI, Jupyter, Qdrant, MLf
 
 The active planner performs three bounded actions when their prerequisites are present:
 
-- MCP credential access compares an anonymous control read with an authenticated read of the same resource and saves returned content.
+- MCP credential access first reads the exact resource anonymously. A successful control records public access without presenting a credential; otherwise AgentHound compares an authenticated read of the same resource and saves returned content.
 - The ContextForge description round trip writes a scan-specific marker, observes it through MCP, restores the original immediately, and confirms restoration.
 - Deep Ollama verification invokes a bounded embedding request to prove compute access.
 

--- a/docs/operator/scanner.md
+++ b/docs/operator/scanner.md
@@ -51,13 +51,15 @@ AgentHound stores concrete credentials as `Credential.properties.value` and uses
 
 The planner can execute LiteLLM master, bearer, and API keys; Open WebUI bearer and API keys; Jupyter tokens; A2A bearer credentials; and MCP bearer credentials tied to an exact resource. Masks, hashes, unresolved environment references, unresolved secret-provider references, custom strings, and basic-auth guesses are preserved as evidence but are not presented to services.
 
+For A2A, a bearer retry remains eligible when the bounded anonymous probe is protected or inconclusive. When both the public card and protocol probe already succeed anonymously, the planner does not repeat the same card collection with a credential.
+
 Anonymous collection covers applicable LiteLLM, Open WebUI, Jupyter, Qdrant, MLflow, and Ollama endpoints. New targets and credentials are indexed as they appear, allowing useful authenticated work during the same scan.
 
 ## Verification actions
 
 The active planner performs three bounded actions when their prerequisites are present:
 
-- MCP credential access compares an anonymous control read with an authenticated read of the same resource and saves returned content.
+- MCP credential access first reads the exact resource anonymously. If that succeeds, AgentHound records public access and saves the content without presenting a credential. Otherwise, it follows with an authenticated read of the same resource.
 - The ContextForge description round trip writes a scan-specific marker, observes it through MCP, restores the original immediately, and confirms restoration.
 - Deep Ollama verification invokes a bounded embedding request to prove compute access.
 

--- a/docs/operator/scanner.md
+++ b/docs/operator/scanner.md
@@ -57,7 +57,7 @@ Anonymous collection covers applicable LiteLLM, Open WebUI, Jupyter, Qdrant, MLf
 
 The active planner performs three bounded actions when their prerequisites are present:
 
-- MCP credential access first reads the exact resource anonymously. A successful control records public access without presenting a credential; otherwise AgentHound compares an authenticated read of the same resource and saves returned content.
+- MCP credential access compares an anonymous control read with an authenticated read of the same resource and saves returned content.
 - The ContextForge description round trip writes a scan-specific marker, observes it through MCP, restores the original immediately, and confirms restoration.
 - Deep Ollama verification invokes a bounded embedding request to prove compute access.
 

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -24,7 +24,7 @@ Concrete AI-service nodes also carry the `AIService` label. The umbrella label i
 | `value_hash` | SHA-256 identity used for deduplication and evidence joins. |
 | `material_status` | Whether the material is observed, masked, hashed, or otherwise unavailable. |
 | `exposure_status` | Whether collection observed the credential as exposed. |
-| `source` and provenance fields | Where the material or reference came from. |
+| `source`/`sources` and provenance fields | Where the material or reference came from; repeated observations retain sorted plural values. |
 
 Only concrete `value` material becomes planner input. The normal dashboard property view masks it; explicit query output and JSON export remain literal.
 

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,50 @@ ARCHIVE="agenthound_${VERSION}_${OS}_${ARCH}.tar.gz"
 BASE_URL="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}"
 TMPDIR=$(mktemp -d)
 STAGE=$(mktemp -d)
-trap 'rm -rf "$TMPDIR" "$STAGE"' EXIT
+INSTALL_TMP=""
+INSTALL_BACKUP=""
+INSTALL_PROMOTED=0
+
+rollback_install() {
+  if [ "$INSTALL_PROMOTED" -ne 1 ]; then
+    return 0
+  fi
+  if [ -n "$INSTALL_BACKUP" ] && [ -e "$INSTALL_BACKUP" ]; then
+    if ! mv "$INSTALL_BACKUP" "${INSTALL_DIR}/agenthound"; then
+      return 1
+    fi
+    INSTALL_BACKUP=""
+  else
+    if ! rm -f "${INSTALL_DIR}/agenthound"; then
+      return 1
+    fi
+  fi
+  INSTALL_PROMOTED=0
+}
+
+cleanup() {
+  status=$?
+  rollback_ok=1
+  trap - EXIT
+  if ! rollback_install; then
+    echo "Error: failed to restore the previous AgentHound installation" >&2
+    if [ -n "$INSTALL_BACKUP" ]; then
+      echo "       Recovery copy preserved at: $INSTALL_BACKUP" >&2
+    fi
+    rollback_ok=0
+    status=1
+  fi
+  rm -rf "$TMPDIR" "$STAGE"
+  if [ -n "$INSTALL_TMP" ]; then
+    rm -f "$INSTALL_TMP"
+  fi
+  if [ -n "$INSTALL_BACKUP" ] && [ "$rollback_ok" -eq 1 ]; then
+    rm -f "$INSTALL_BACKUP"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
 
 echo "Downloading ${ARCHIVE}..."
 curl -sSfL -o "${TMPDIR}/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}"
@@ -101,18 +144,47 @@ To verify manually, install cosign and run:
 EOF
 fi
 
-# Extract atomically: extract to staging dir, then mv
+# Validate in staging before touching the current installation, then promote a
+# destination-local temporary file with rename(2). A private backup permits an
+# exact rollback if execution fails only from the installed path.
 echo "Installing to ${INSTALL_DIR}/agenthound..."
 mkdir -p "$INSTALL_DIR"
 tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$STAGE"
 chmod 0755 "${STAGE}/agenthound"
-mv "${STAGE}/agenthound" "${INSTALL_DIR}/agenthound"
+if ! "${STAGE}/agenthound" --version >/dev/null 2>&1; then
+  echo "Error: downloaded binary failed to run"
+  exit 1
+fi
+
+INSTALL_TMP=$(mktemp "${INSTALL_DIR}/.agenthound.install.XXXXXX")
+cp "${STAGE}/agenthound" "$INSTALL_TMP"
+chmod 0755 "$INSTALL_TMP"
+
+if [ -e "${INSTALL_DIR}/agenthound" ]; then
+  INSTALL_BACKUP=$(mktemp "${INSTALL_DIR}/.agenthound.backup.XXXXXX")
+  cp -p "${INSTALL_DIR}/agenthound" "$INSTALL_BACKUP"
+fi
+# Do not let a signal land between the atomic rename and the state transition
+# that tells the EXIT trap to restore the backup.
+trap '' HUP INT TERM
+if ! mv "$INSTALL_TMP" "${INSTALL_DIR}/agenthound"; then
+  trap 'exit 130' HUP INT TERM
+  exit 1
+fi
+INSTALL_TMP=""
+INSTALL_PROMOTED=1
+trap 'exit 130' HUP INT TERM
 
 # Verify the installed binary runs
-if "${INSTALL_DIR}/agenthound" --version >/dev/null 2>&1; then
+if installed_version=$("${INSTALL_DIR}/agenthound" --version 2>/dev/null); then
+  INSTALL_PROMOTED=0
+  if [ -n "$INSTALL_BACKUP" ]; then
+    rm -f "$INSTALL_BACKUP"
+    INSTALL_BACKUP=""
+  fi
   echo ""
   echo "  Installed: ${INSTALL_DIR}/agenthound"
-  "${INSTALL_DIR}/agenthound" --version | sed 's/^/  /'
+  printf '%s\n' "$installed_version" | sed 's/^/  /'
   echo ""
   case ":$PATH:" in
     *":${INSTALL_DIR}:"*) ;;

--- a/modules/config/collector.go
+++ b/modules/config/collector.go
@@ -268,6 +268,13 @@ func (c *ConfigCollector) Collect(ctx context.Context, opts collector.CollectOpt
 					cred.Location,
 					cred.Name,
 				)
+				// Concrete material has a global value identity. Keep each
+				// provenance contribution and edge, but point them at the same
+				// Credential ID so the artifact agrees with identity_basis and
+				// downstream ingestion does not split one secret into many nodes.
+				if cred.MaterialStatus == common.CredentialMaterialObserved && cred.ValueHash != "" {
+					credID = ingest.ComputeNodeID("Credential", cred.ValueHash)
+				}
 				// value_hash is the cross-collector merge primitive — see
 				// sdk/common/hasher.go HashCredentialValue. Always populated
 				// from the original observed value or reference. The credential-chain Cypher

--- a/modules/config/collector.go
+++ b/modules/config/collector.go
@@ -158,6 +158,7 @@ func (c *ConfigCollector) Collect(ctx context.Context, opts collector.CollectOpt
 		}
 		data.Graph.Edges = append(data.Graph.Edges, e)
 	}
+	observedCredentials := make(map[string]*observedCredentialAggregate)
 
 	configs := discovery.ParsedConfigs()
 	configsByPath := make(map[string][]ParsedConfig)
@@ -268,10 +269,10 @@ func (c *ConfigCollector) Collect(ctx context.Context, opts collector.CollectOpt
 					cred.Location,
 					cred.Name,
 				)
-				// Concrete material has a global value identity. Keep each
-				// provenance contribution and edge, but point them at the same
-				// Credential ID so the artifact agrees with identity_basis and
-				// downstream ingestion does not split one secret into many nodes.
+				// Concrete material has one value-hash identity. Aggregate its
+				// source-specific metadata before emission so one Credential can
+				// retain every provenance path without publishing conflicting
+				// scalar properties under the same graph ID.
 				if cred.MaterialStatus == common.CredentialMaterialObserved && cred.ValueHash != "" {
 					credID = ingest.ComputeNodeID("Credential", cred.ValueHash)
 				}
@@ -304,7 +305,16 @@ func (c *ConfigCollector) Collect(ctx context.Context, opts collector.CollectOpt
 				if cred.MaterialStatus == common.CredentialMaterialObserved {
 					credProps["value"] = cred.Value
 				}
-				addNode(common.NewNode(credID, []string{"Credential"}, credProps), scopeKey)
+				if cred.MaterialStatus == common.CredentialMaterialObserved && cred.ValueHash != "" {
+					aggregate := observedCredentials[credID]
+					if aggregate == nil {
+						aggregate = newObservedCredentialAggregate(credProps)
+						observedCredentials[credID] = aggregate
+					}
+					aggregate.add(credProps, scopeKey)
+				} else {
+					addNode(common.NewNode(credID, []string{"Credential"}, credProps), scopeKey)
+				}
 
 				authWeight := identityAuthWeight(identityType)
 				addEdge(common.NewEdge(serverID, identityID, "AUTHENTICATES_WITH", "MCPServer", "Identity",
@@ -318,6 +328,18 @@ func (c *ConfigCollector) Collect(ctx context.Context, opts collector.CollectOpt
 				}
 			}
 		}
+	}
+	credentialIDs := make([]string, 0, len(observedCredentials))
+	for credentialID := range observedCredentials {
+		credentialIDs = append(credentialIDs, credentialID)
+	}
+	sort.Strings(credentialIDs)
+	for _, credentialID := range credentialIDs {
+		aggregate := observedCredentials[credentialID]
+		addNode(
+			common.NewNode(credentialID, []string{"Credential"}, aggregate.properties()),
+			aggregate.domains...,
+		)
 	}
 
 	type instructionContribution struct {
@@ -576,6 +598,79 @@ func credToIdentityType(cred CredentialInfo) string {
 		return string(common.AuthCustom)
 	}
 	return string(method)
+}
+
+type credentialAggregateField struct {
+	singular string
+	plural   string
+}
+
+var credentialAggregateFields = []credentialAggregateField{
+	{singular: "type", plural: "types"},
+	{singular: "name", plural: "names"},
+	{singular: "source", plural: "sources"},
+	{singular: "location", plural: "locations"},
+	{singular: "auth_method", plural: "auth_methods"},
+	{singular: "format", plural: "formats"},
+}
+
+// observedCredentialAggregate separates secret identity from the many config
+// locations that may present the same material. Neo4j properties can retain
+// sorted scalar arrays, so this needs no occurrence node or schema migration.
+type observedCredentialAggregate struct {
+	stable  map[string]any
+	values  map[string]map[string]bool
+	domains []string
+}
+
+func newObservedCredentialAggregate(properties map[string]any) *observedCredentialAggregate {
+	aggregate := &observedCredentialAggregate{
+		stable: map[string]any{
+			"value":           properties["value"],
+			"value_hash":      properties["value_hash"],
+			"merge_key":       properties["merge_key"],
+			"identity_basis":  properties["identity_basis"],
+			"material_status": properties["material_status"],
+			"exposure_status": properties["exposure_status"],
+			"high_entropy":    properties["high_entropy"],
+		},
+		values: make(map[string]map[string]bool, len(credentialAggregateFields)),
+	}
+	for _, field := range credentialAggregateFields {
+		aggregate.values[field.singular] = make(map[string]bool)
+	}
+	return aggregate
+}
+
+func (a *observedCredentialAggregate) add(properties map[string]any, domain string) {
+	a.domains = ingest.MergeObservationDomains(a.domains, []string{domain})
+	for _, field := range credentialAggregateFields {
+		value, _ := properties[field.singular].(string)
+		value = strings.TrimSpace(value)
+		if value != "" {
+			a.values[field.singular][value] = true
+		}
+	}
+}
+
+func (a *observedCredentialAggregate) properties() map[string]any {
+	properties := make(map[string]any, len(a.stable)+(2*len(credentialAggregateFields)))
+	for key, value := range a.stable {
+		properties[key] = value
+	}
+	for _, field := range credentialAggregateFields {
+		set := a.values[field.singular]
+		values := make([]string, 0, len(set))
+		for value := range set {
+			values = append(values, value)
+		}
+		sort.Strings(values)
+		properties[field.plural] = values
+		if len(values) == 1 {
+			properties[field.singular] = values[0]
+		}
+	}
+	return properties
 }
 
 // Contribution keys deliberately include ownership and semantics. A shared

--- a/modules/config/collector_test.go
+++ b/modules/config/collector_test.go
@@ -488,6 +488,59 @@ func TestConfigCollector_ValueHashAlwaysPopulated(t *testing.T) {
 	}
 }
 
+func TestConfigCollector_ObservedCredentialIdentityDeduplicatesByValueHash(t *testing.T) {
+	tmp := t.TempDir()
+	firstPath := filepath.Join(tmp, "cursor.json")
+	secondPath := filepath.Join(tmp, "vscode.json")
+	const shared = "e2e-identical-credential-material"
+	writeJSON(t, firstPath, `{
+		"mcpServers": {
+			"cursor-server": {
+				"url": "https://cursor.example/mcp",
+				"headers": {"Authorization": "Bearer `+shared+`"}
+			}
+		}
+	}`)
+	writeJSON(t, secondPath, `{
+		"mcpServers": {
+			"vscode-server": {
+				"url": "https://vscode.example/mcp",
+				"headers": {"Authorization": "Bearer `+shared+`"}
+			}
+		}
+	}`)
+
+	result, err := NewConfigCollector().Collect(context.Background(), collector.CollectOptions{
+		ConfigPaths: []string{firstPath, secondPath}, ScanID: "credential-identity-test",
+	})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	wantHash := common.HashCredentialValue(shared)
+	ids := make(map[string]bool)
+	domains := make(map[string]bool)
+	sources := make(map[string]bool)
+	for _, node := range result.Graph.Nodes {
+		if !hasNodeKind(node, "Credential") || node.Properties["value_hash"] != wantHash {
+			continue
+		}
+		ids[node.ID] = true
+		for _, domain := range node.ObservationDomains {
+			domains[domain] = true
+		}
+		if source, _ := node.Properties["source"].(string); source != "" {
+			sources[source] = true
+		}
+	}
+	if len(ids) != 1 {
+		t.Fatalf("concrete credential IDs = %v, want one value-hash identity", ids)
+	}
+	if len(domains) != 2 || len(sources) != 2 {
+		t.Fatalf("credential provenance lost: domains=%v sources=%v", domains, sources)
+	}
+}
+
 func TestConfigCollector_UnresolvedReferenceIsNotExecutableValue(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	writeJSON(t, configPath, `{

--- a/modules/config/collector_test.go
+++ b/modules/config/collector_test.go
@@ -505,7 +505,7 @@ func TestConfigCollector_ObservedCredentialIdentityDeduplicatesByValueHash(t *te
 		"mcpServers": {
 			"vscode-server": {
 				"url": "https://vscode.example/mcp",
-				"headers": {"Authorization": "Bearer `+shared+`"}
+				"headers": {"X-API-Key": "`+shared+`"}
 			}
 		}
 	}`)
@@ -519,25 +519,40 @@ func TestConfigCollector_ObservedCredentialIdentityDeduplicatesByValueHash(t *te
 
 	wantHash := common.HashCredentialValue(shared)
 	ids := make(map[string]bool)
-	domains := make(map[string]bool)
-	sources := make(map[string]bool)
+	var credential *ingest.Node
+	credentialCount := 0
 	for _, node := range result.Graph.Nodes {
 		if !hasNodeKind(node, "Credential") || node.Properties["value_hash"] != wantHash {
 			continue
 		}
+		credentialCount++
 		ids[node.ID] = true
-		for _, domain := range node.ObservationDomains {
-			domains[domain] = true
-		}
-		if source, _ := node.Properties["source"].(string); source != "" {
-			sources[source] = true
+		copy := node
+		credential = &copy
+	}
+	if credentialCount != 1 || len(ids) != 1 || credential == nil {
+		t.Fatalf("concrete credential contributions = %d IDs=%v, want one emitted value-hash identity", credentialCount, ids)
+	}
+	if len(credential.ObservationDomains) != 2 {
+		t.Fatalf("credential observation domains = %v, want both config owners", credential.ObservationDomains)
+	}
+	if got, want := credential.Properties["sources"], []string{"cursor-server", "vscode-server"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("credential sources = %#v, want %#v", got, want)
+	}
+	if got, want := credential.Properties["auth_methods"], []string{string(common.AuthAPIKey), string(common.AuthBearer)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("credential auth methods = %#v, want %#v", got, want)
+	}
+	if _, present := credential.Properties["source"]; present {
+		t.Fatal("ambiguous singular credential source was retained")
+	}
+	uses := 0
+	for _, edge := range result.Graph.Edges {
+		if edge.Kind == "USES_CREDENTIAL" && edge.Target == credential.ID {
+			uses++
 		}
 	}
-	if len(ids) != 1 {
-		t.Fatalf("concrete credential IDs = %v, want one value-hash identity", ids)
-	}
-	if len(domains) != 2 || len(sources) != 2 {
-		t.Fatalf("credential provenance lost: domains=%v sources=%v", domains, sources)
+	if uses != 2 {
+		t.Fatalf("USES_CREDENTIAL paths = %d, want one per source identity", uses)
 	}
 }
 

--- a/modules/credreach/access.go
+++ b/modules/credreach/access.go
@@ -7,7 +7,7 @@ import (
 )
 
 // AccessProof is the complete in-process differential resource-read result.
-// Content is retained only from a successful credentialed read so the unified
+// Content is retained from a successful exact resource read so the unified
 // scan can preserve it on the resource node.
 type AccessProof struct {
 	Control    ProbeResult
@@ -16,8 +16,8 @@ type AccessProof struct {
 	Content    json.RawMessage
 }
 
-// VerifyAccess performs the unauthenticated control and credentialed exact
-// resource read in one invocation.
+// VerifyAccess performs the unauthenticated control and, only when the control
+// does not already prove public access, a credentialed exact resource read.
 func VerifyAccess(
 	ctx context.Context,
 	endpoint, resourceURI, credential string,
@@ -28,6 +28,12 @@ func VerifyAccess(
 	control, controlContent := prober.probeWithContent(ctx, ProbeRequest{
 		Host: endpoint, ResourceURI: resourceURI, Insecure: insecure, Timeout: timeout,
 	})
+	if exactResourceRead(control) && control.Status == ProbeAllowed {
+		return AccessProof{
+			Control: control, Outcome: Classify(control, ProbeResult{}),
+			Content: credentialedContent(controlContent),
+		}
+	}
 	credentialed, content := prober.probeWithContent(ctx, ProbeRequest{
 		Host: endpoint, ResourceURI: resourceURI, Credential: credential,
 		Insecure: insecure, Timeout: timeout,

--- a/modules/credreach/access.go
+++ b/modules/credreach/access.go
@@ -7,7 +7,7 @@ import (
 )
 
 // AccessProof is the complete in-process differential resource-read result.
-// Content is retained only from a successful credentialed read so the unified
+// Content is retained from the successful exact resource read so the unified
 // scan can preserve it on the resource node.
 type AccessProof struct {
 	Control    ProbeResult
@@ -16,8 +16,9 @@ type AccessProof struct {
 	Content    json.RawMessage
 }
 
-// VerifyAccess performs the unauthenticated control and credentialed exact
-// resource read in one invocation.
+// VerifyAccess performs the unauthenticated control first. A successful exact
+// read already establishes public access; otherwise it follows with the
+// credentialed exact resource read needed for differential proof.
 func VerifyAccess(
 	ctx context.Context,
 	endpoint, resourceURI, credential string,
@@ -28,6 +29,12 @@ func VerifyAccess(
 	control, controlContent := prober.probeWithContent(ctx, ProbeRequest{
 		Host: endpoint, ResourceURI: resourceURI, Insecure: insecure, Timeout: timeout,
 	})
+	if exactResourceRead(control) && control.Status == ProbeAllowed {
+		return AccessProof{
+			Control: control, Outcome: Classify(control, ProbeResult{}),
+			Content: credentialedContent(controlContent),
+		}
+	}
 	credentialed, content := prober.probeWithContent(ctx, ProbeRequest{
 		Host: endpoint, ResourceURI: resourceURI, Credential: credential,
 		Insecure: insecure, Timeout: timeout,

--- a/modules/credreach/access.go
+++ b/modules/credreach/access.go
@@ -7,7 +7,7 @@ import (
 )
 
 // AccessProof is the complete in-process differential resource-read result.
-// Content is retained from a successful exact resource read so the unified
+// Content is retained only from a successful credentialed read so the unified
 // scan can preserve it on the resource node.
 type AccessProof struct {
 	Control    ProbeResult
@@ -16,8 +16,8 @@ type AccessProof struct {
 	Content    json.RawMessage
 }
 
-// VerifyAccess performs the unauthenticated control and, only when the control
-// does not already prove public access, a credentialed exact resource read.
+// VerifyAccess performs the unauthenticated control and credentialed exact
+// resource read in one invocation.
 func VerifyAccess(
 	ctx context.Context,
 	endpoint, resourceURI, credential string,
@@ -28,12 +28,6 @@ func VerifyAccess(
 	control, controlContent := prober.probeWithContent(ctx, ProbeRequest{
 		Host: endpoint, ResourceURI: resourceURI, Insecure: insecure, Timeout: timeout,
 	})
-	if exactResourceRead(control) && control.Status == ProbeAllowed {
-		return AccessProof{
-			Control: control, Outcome: Classify(control, ProbeResult{}),
-			Content: credentialedContent(controlContent),
-		}
-	}
 	credentialed, content := prober.probeWithContent(ctx, ProbeRequest{
 		Host: endpoint, ResourceURI: resourceURI, Credential: credential,
 		Insecure: insecure, Timeout: timeout,

--- a/modules/credreach/prober_test.go
+++ b/modules/credreach/prober_test.go
@@ -94,6 +94,51 @@ func TestObservedHTTPAuthResponseIsDenied(t *testing.T) {
 	}
 }
 
+func TestVerifyAccessStopsAfterAnonymousExactResourceRead(t *testing.T) {
+	const resourceURI = "test://public-resource"
+	server := mcpsdk.NewServer(
+		&mcpsdk.Implementation{Name: "public-test", Version: "1.0.0"},
+		nil,
+	)
+	server.AddResource(
+		&mcpsdk.Resource{URI: resourceURI, Name: "public resource"},
+		func(_ context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+			return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
+				URI: req.Params.URI, Text: "public content",
+			}}}, nil
+		},
+	)
+	mcpHandler := mcpsdk.NewStreamableHTTPHandler(
+		func(*http.Request) *mcpsdk.Server { return server },
+		&mcpsdk.StreamableHTTPOptions{JSONResponse: true},
+	)
+	var credentialRequests atomic.Int32
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			credentialRequests.Add(1)
+		}
+		mcpHandler.ServeHTTP(w, r)
+	}))
+	defer httpServer.Close()
+
+	proof := VerifyAccess(
+		context.Background(), httpServer.URL, resourceURI,
+		"must-not-be-presented", false, time.Second,
+	)
+	if proof.Outcome != OutcomeAnonymousAccessObserved {
+		t.Fatalf("outcome = %q, want anonymous access observed", proof.Outcome)
+	}
+	if credentialRequests.Load() != 0 {
+		t.Fatalf("credential was presented on %d request(s) after anonymous success", credentialRequests.Load())
+	}
+	if len(proof.Content) == 0 {
+		t.Fatal("anonymous resource content was not retained")
+	}
+	if proof.Credential != (ProbeResult{}) {
+		t.Fatalf("credential probe unexpectedly ran: %+v", proof.Credential)
+	}
+}
+
 func TestClassifyTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/modules/credreach/prober_test.go
+++ b/modules/credreach/prober_test.go
@@ -94,51 +94,6 @@ func TestObservedHTTPAuthResponseIsDenied(t *testing.T) {
 	}
 }
 
-func TestVerifyAccessStopsAfterAnonymousExactResourceRead(t *testing.T) {
-	const resourceURI = "test://public-resource"
-	server := mcpsdk.NewServer(
-		&mcpsdk.Implementation{Name: "public-test", Version: "1.0.0"},
-		nil,
-	)
-	server.AddResource(
-		&mcpsdk.Resource{URI: resourceURI, Name: "public resource"},
-		func(_ context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
-			return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
-				URI: req.Params.URI, Text: "public content",
-			}}}, nil
-		},
-	)
-	mcpHandler := mcpsdk.NewStreamableHTTPHandler(
-		func(*http.Request) *mcpsdk.Server { return server },
-		&mcpsdk.StreamableHTTPOptions{JSONResponse: true},
-	)
-	var credentialRequests atomic.Int32
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "" {
-			credentialRequests.Add(1)
-		}
-		mcpHandler.ServeHTTP(w, r)
-	}))
-	defer httpServer.Close()
-
-	proof := VerifyAccess(
-		context.Background(), httpServer.URL, resourceURI,
-		"must-not-be-presented", false, time.Second,
-	)
-	if proof.Outcome != OutcomeAnonymousAccessObserved {
-		t.Fatalf("outcome = %q, want anonymous access observed", proof.Outcome)
-	}
-	if credentialRequests.Load() != 0 {
-		t.Fatalf("credential was presented on %d request(s) after anonymous success", credentialRequests.Load())
-	}
-	if len(proof.Content) == 0 {
-		t.Fatal("anonymous resource content was not retained")
-	}
-	if proof.Credential != (ProbeResult{}) {
-		t.Fatalf("credential probe unexpectedly ran: %+v", proof.Credential)
-	}
-}
-
 func TestClassifyTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/modules/mcp/signals.go
+++ b/modules/mcp/signals.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -28,6 +29,8 @@ type ResourceSignals struct {
 	SensitivityEvidence string
 }
 
+var httpURL = regexp.MustCompile(`(?i)https?://[^\s]+`)
+
 func computeToolSignals(tool *mcpsdk.Tool, allToolNames map[string]bool, engine *rules.Engine) ToolSignals {
 	schemaMap := inputSchemaAsMap(tool.InputSchema)
 
@@ -35,7 +38,10 @@ func computeToolSignals(tool *mcpsdk.Tool, allToolNames map[string]bool, engine 
 		DescriptionHash: common.DescriptionHash(tool.Name, tool.Description, schemaMap),
 	}
 
-	combined := tool.Name + " " + tool.Description
+	// A documentation link is evidence about the description, not proof that
+	// the tool can make outbound requests. Other action words (fetch, request,
+	// webhook, and so on) and schema keys remain available to capability rules.
+	combined := tool.Name + " " + httpURL.ReplaceAllString(tool.Description, "")
 	if schemaMap != nil {
 		if props, ok := schemaMap["properties"].(map[string]any); ok {
 			for key := range props {

--- a/modules/mcp/signals_rules_test.go
+++ b/modules/mcp/signals_rules_test.go
@@ -39,6 +39,18 @@ func TestToolSignals_RulesEngineInjection(t *testing.T) {
 			wantInj:     false,
 		},
 		{
+			name:        "vendor documentation URL",
+			description: "Vendor documentation: https://github.com/hashicorp/terraform-mcp-server",
+			wantInj:     false,
+		},
+		{
+			name: "deprecated vendor tool description",
+			description: "[DEPRECATED] Execute Terragrunt workflow commands against an AWS account. " +
+				"Use HashiCorp's official Terraform MCP Server instead: " +
+				"https://github.com/hashicorp/terraform-mcp-server This tool runs Terragrunt commands.",
+			wantInj: false,
+		},
+		{
 			name:        "empty description",
 			description: "",
 			wantInj:     false,
@@ -65,6 +77,20 @@ func TestToolSignals_RulesEngineInjection(t *testing.T) {
 				t.Errorf("HasInjection = %v, want %v", signals.HasInjection, tt.wantInj)
 			}
 		})
+	}
+}
+
+func TestToolSignals_DocumentationURLIsNotOutboundCapability(t *testing.T) {
+	engine := testEngine(t)
+	for _, description := range []string{
+		"Vendor documentation: https://github.com/hashicorp/terraform-mcp-server",
+		"Vendor documentation: HTTPS://github.com/hashicorp/terraform-mcp-server",
+	} {
+		tool := &mcpsdk.Tool{Name: "TerraformDocumentationPointer", Description: description}
+		signals := computeToolSignals(tool, nil, engine)
+		if len(signals.CapabilitySurface) != 0 {
+			t.Fatalf("documentation-only URL classified as capability: %v", signals.CapabilitySurface)
+		}
 	}
 }
 

--- a/modules/networkscan/expand.go
+++ b/modules/networkscan/expand.go
@@ -89,6 +89,9 @@ func Expand(spec string, opts ExpandOptions) ([]string, error) {
 // expandSingle classifies a single host token and returns it as a one-element
 // slice if it passes the safety gates.
 func expandSingle(host string, opts ExpandOptions) ([]string, error) {
+	if !validHostToken(host) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidCIDR, host)
+	}
 	info := common.ClassifyHost(host)
 	if info.IsLinkLocal {
 		return nil, fmt.Errorf("%w: %s", ErrLinkLocal, host)
@@ -103,6 +106,40 @@ func expandSingle(host string, opts ExpandOptions) ([]string, error) {
 		return nil, fmt.Errorf("%w: %s", ErrPublicTarget, host)
 	}
 	return []string{host}, nil
+}
+
+// validHostToken accepts IP literals and DNS hostnames only. Public-target
+// authorization is a separate gate; it must not turn arbitrary resolver input
+// (spaces, URLs, ports, or punctuation) into a valid scan target.
+func validHostToken(host string) bool {
+	if _, err := netip.ParseAddr(host); err == nil {
+		return true
+	}
+
+	name := strings.TrimSuffix(host, ".")
+	if name == "" || len(name) > 253 {
+		return false
+	}
+	numericDotted := strings.Contains(name, ".")
+	for _, label := range strings.Split(name, ".") {
+		if len(label) == 0 || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for i := 0; i < len(label); i++ {
+			ch := label[i]
+			if ch < '0' || ch > '9' {
+				numericDotted = false
+			}
+			if (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') &&
+				(ch < '0' || ch > '9') && ch != '-' {
+				return false
+			}
+		}
+	}
+	// A dotted all-numeric token is an IPv4 literal, not a DNS hostname. If
+	// netip rejected it above, accepting it here would revive malformed IPs via
+	// resolver-dependent shorthand or legacy parsing.
+	return !numericDotted
 }
 
 // expandCIDR enumerates every host in the CIDR after applying the safety

--- a/modules/networkscan/expand_test.go
+++ b/modules/networkscan/expand_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -89,6 +90,36 @@ func TestExpand_SingleHost(t *testing.T) {
 			t.Errorf("got %v, want [fc00::1]", got)
 		}
 	})
+}
+
+func TestExpand_InvalidHostSyntaxRejectedBeforePublicTargetGate(t *testing.T) {
+	for _, spec := range []string{
+		"not a valid target !",
+		"bad host name %%%",
+		"https://example.test",
+		"example.test:443",
+		"-leading.example",
+		"trailing-.example",
+		"two..dots.example",
+		"999.999.999.999",
+		strings.Repeat("a", 64) + ".example",
+	} {
+		t.Run(spec, func(t *testing.T) {
+			_, err := Expand(spec, ExpandOptions{AllowPublicTargets: true})
+			if !errors.Is(err, ErrInvalidCIDR) {
+				t.Fatalf("Expand(%q) error = %v, want ErrInvalidCIDR", spec, err)
+			}
+		})
+	}
+
+	for _, spec := range []string{"localhost", "mcp-container", "mcp.example.test", "MCP.Example.Test."} {
+		t.Run("valid_"+spec, func(t *testing.T) {
+			got, err := Expand(spec, ExpandOptions{AllowPublicTargets: true})
+			if err != nil || len(got) != 1 || got[0] != spec {
+				t.Fatalf("Expand(%q) = %v, %v; want unchanged host", spec, got, err)
+			}
+		})
+	}
 }
 
 func TestExpand_CIDR(t *testing.T) {

--- a/scripts/install-atomic-test.sh
+++ b/scripts/install-atomic-test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+case "$(uname -s | tr '[:upper:]' '[:lower:]')" in
+  linux) test_os=linux ;;
+  darwin) test_os=darwin ;;
+  *) printf 'installer atomic test: unsupported test OS\n' >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) test_arch=amd64 ;;
+  aarch64|arm64) test_arch=arm64 ;;
+  *) printf 'installer atomic test: unsupported test architecture\n' >&2; exit 1 ;;
+esac
+
+case_root=$(mktemp -d)
+trap 'rm -rf "$case_root"' EXIT
+install_dir="${case_root}/installed-bin"
+publisher_dir="${case_root}/publisher"
+shim_dir="${case_root}/shims"
+mkdir -p "$install_dir" "$publisher_dir/archive" "$shim_dir"
+
+printf '%s\n' '#!/bin/sh' 'printf old-sentinel' >"${install_dir}/agenthound"
+chmod 0755 "${install_dir}/agenthound"
+
+# The downloaded binary runs successfully in staging, then fails only from the
+# final destination. This exercises post-promotion rollback rather than merely
+# rejecting an archive before installation.
+printf '%s\n' \
+  '#!/bin/sh' \
+  'if [ "$0" = "$FAIL_INSTALL_PATH" ]; then exit 1; fi' \
+  'printf "agenthound version 1.1.0 (installer atomic test)\n"' \
+  >"${publisher_dir}/archive/agenthound"
+chmod 0755 "${publisher_dir}/archive/agenthound"
+
+archive="${publisher_dir}/agenthound_1.1.0_${test_os}_${test_arch}.tar.gz"
+tar -czf "$archive" -C "${publisher_dir}/archive" agenthound
+if command -v sha256sum >/dev/null 2>&1; then
+  archive_hash=$(sha256sum "$archive" | awk '{print $1}')
+else
+  archive_hash=$(shasum -a 256 "$archive" | awk '{print $1}')
+fi
+printf '%s  %s\n' "$archive_hash" "$(basename "$archive")" >"${publisher_dir}/checksums.txt"
+
+printf '%s\n' \
+  '#!/bin/sh' \
+  'set -eu' \
+  'out=' \
+  'url=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -o) out=$2; shift 2 ;;' \
+  '    -*) shift ;;' \
+  '    *) url=$1; shift ;;' \
+  '  esac' \
+  'done' \
+  'case "$url" in' \
+  '  */checksums.txt.sigstore.json) : >"$out" ;;' \
+  '  */checksums.txt) cp "$TEST_PUBLISHER/checksums.txt" "$out" ;;' \
+  '  */agenthound_*.tar.gz) cp "$TEST_ARCHIVE" "$out" ;;' \
+  '  *) exit 22 ;;' \
+  'esac' \
+  >"${shim_dir}/curl"
+printf '%s\n' '#!/bin/sh' 'exit 0' >"${shim_dir}/cosign"
+chmod 0755 "${shim_dir}/curl" "${shim_dir}/cosign"
+
+if env \
+  PATH="${shim_dir}:${PATH}" \
+  HOME="${case_root}/home" \
+  AGENTHOUND_VERSION=1.1.0 \
+  AGENTHOUND_INSTALL_DIR="$install_dir" \
+  FAIL_INSTALL_PATH="${install_dir}/agenthound" \
+  TEST_ARCHIVE="$archive" \
+  TEST_PUBLISHER="$publisher_dir" \
+  sh "${repo_root}/install.sh" >/dev/null 2>&1; then
+  printf 'installer unexpectedly accepted a binary that failed after promotion\n' >&2
+  exit 1
+fi
+
+if [ "$("${install_dir}/agenthound")" != old-sentinel ]; then
+  printf 'installer did not restore the previous working binary\n' >&2
+  exit 1
+fi
+if find "$install_dir" -maxdepth 1 \( -name '.agenthound.install.*' -o -name '.agenthound.backup.*' \) | grep -q .; then
+  printf 'installer left private promotion files behind after rollback\n' >&2
+  exit 1
+fi
+
+printf 'installer atomic replacement rollback: pass\n'

--- a/sdk/rules/builtin/injection-base64-payload.yaml
+++ b/sdk/rules/builtin/injection-base64-payload.yaml
@@ -1,8 +1,8 @@
 id: injection-base64-payload
 name: Base64 Encoded Payload
 description: >
-  Detects long base64-encoded strings (20+ chars) embedded in descriptions,
-  which may contain hidden instructions or payloads.
+  Detects structurally valid base64 tokens (20+ chars) embedded in
+  descriptions, while excluding path-like substrings inside ordinary URLs.
 version: 1
 enabled: true
 scope:
@@ -21,7 +21,7 @@ tags: [injection, prompt-injection]
 shadow_exclude: true
 matcher:
   type: regex
-  pattern: '[A-Za-z0-9+/]{20,}={0,2}'
+  pattern: '(^|[\s([{:])([A-Za-z0-9+/]{4}){5,}([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?($|[\s,.;:)\]}])'
 emit:
   finding_type: has_injection_patterns
   labels: [base64_instruction]

--- a/sdk/rules/builtin/injection-base64-payload.yaml
+++ b/sdk/rules/builtin/injection-base64-payload.yaml
@@ -21,7 +21,7 @@ tags: [injection, prompt-injection]
 shadow_exclude: true
 matcher:
   type: regex
-  pattern: '(^|[\s([{:])([A-Za-z0-9+/]{4}){5,}([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?($|[\s,.;:)\]}])'
+  pattern: '(^|[\s"''`([{:])([A-Za-z0-9+/]{4}){5,}([A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?($|[\s"''`,.;:)\]}])'
 emit:
   finding_type: has_injection_patterns
   labels: [base64_instruction]

--- a/sdk/rules/builtin_tests/injection-base64-payload.yaml
+++ b/sdk/rules/builtin_tests/injection-base64-payload.yaml
@@ -2,6 +2,15 @@ tests:
   - input: "Decode this: SGVsbG8gV29ybGQgZnJvbSBiYXNlNjQ="
     should_match: true
     description: "detects base64 encoded string"
+  - input: "Use payload \"SGVsbG8gV29ybGQgZnJvbSBiYXNlNjQ=\" now"
+    should_match: true
+    description: "detects a quoted base64 payload"
+  - input: "Run `SGVsbG8gV29ybGQgZnJvbSBiYXNlNjQ=`"
+    should_match: true
+    description: "detects a backtick-delimited base64 payload"
+  - input: "Vendor documentation: https://github.com/hashicorp/terraform-mcp-server"
+    should_match: false
+    description: "does not treat an ordinary documentation path as base64"
   - input: "This tool reads files."
     should_match: false
     description: "short text without base64 payload"

--- a/server/internal/graph/fingerprint_test.go
+++ b/server/internal/graph/fingerprint_test.go
@@ -2,10 +2,15 @@ package graph
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	configcollector "github.com/adithyan-ak/agenthound/modules/config"
+	"github.com/adithyan-ak/agenthound/sdk/collector"
+	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
@@ -148,6 +153,48 @@ func TestPrepareObservationNodesFingerprintsOwnersBeforeUnion(t *testing.T) {
 			"node preparation depends on input order:\nforward=%#v %#v\nreverse=%#v %#v",
 			prepared, fingerprints, reversedPrepared, reversedFingerprints,
 		)
+	}
+}
+
+func TestPrepareObservationNodesAcceptsSharedConfigCredential(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	firstPath := filepath.Join(tmp, "cursor.json")
+	secondPath := filepath.Join(tmp, "vscode.json")
+	const shared = "writer-shared-credential-material"
+	for path, contents := range map[string]string{
+		firstPath:  `{"mcpServers":{"cursor-server":{"url":"https://cursor.example/mcp","headers":{"Authorization":"Bearer ` + shared + `"}}}}`,
+		secondPath: `{"mcpServers":{"vscode-server":{"url":"https://vscode.example/mcp","headers":{"X-API-Key":"` + shared + `"}}}}`,
+	} {
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write config %s: %v", path, err)
+		}
+	}
+
+	data, err := configcollector.NewConfigCollector().Collect(context.Background(), collector.CollectOptions{
+		ConfigPaths: []string{firstPath, secondPath}, ProjectDir: tmp, ScanID: "shared-credential-writer-test",
+	})
+	if err != nil {
+		t.Fatalf("collect configs: %v", err)
+	}
+	prepared, _, err := prepareObservationNodes(data.Graph.Nodes)
+	if err != nil {
+		t.Fatalf("prepare shared credential: %v", err)
+	}
+
+	wantHash := common.HashCredentialValue(shared)
+	credentials := 0
+	for _, node := range prepared {
+		if ingest.ConcreteNodeKind(node.Kinds) == "Credential" && node.Properties["value_hash"] == wantHash {
+			credentials++
+			if got, want := node.Properties["sources"], []string{"cursor-server", "vscode-server"}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("prepared credential sources = %#v, want %#v", got, want)
+			}
+		}
+	}
+	if credentials != 1 {
+		t.Fatalf("prepared shared credentials = %d, want one", credentials)
 	}
 }
 

--- a/server/ui/src/entities/node/model.test.ts
+++ b/server/ui/src/entities/node/model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { APINode } from "@entities/graph/dto";
 import {
   authMethod,
+  displayName,
   hasConfirmedAnonymousAccess,
   isCredentialExposed,
   isUnauth,
@@ -14,6 +15,14 @@ function node(properties: Record<string, unknown>, kinds = ["MCPServer"]): APINo
 }
 
 describe("node evidence accessors", () => {
+  it("uses an aggregated credential name before the object ID", () => {
+    expect(
+      displayName(
+        node({ names: ["Authorization", "JUPYTER_TOKEN"] }, ["Credential"]),
+      ),
+    ).toBe("Authorization");
+  });
+
   it("requires affirmative evidence and renders local processes", () => {
     const unknown = node({});
     const unsupportedClaim = node({ auth_method: "none", auth_evidence: "unknown" });

--- a/server/ui/src/entities/node/model.ts
+++ b/server/ui/src/entities/node/model.ts
@@ -24,11 +24,19 @@ export function nodeBool(node: APINode, key: string): boolean {
 
 /** Best available human label, falling back through common identity props. */
 export function displayName(node: APINode): string {
+  const aggregatedName = Array.isArray(node.properties.names)
+    ? node.properties.names.find(
+        (value): value is string =>
+          typeof value === "string" && value.trim() !== "",
+      )
+    : undefined;
   return String(
     node.properties.name ??
+      aggregatedName ??
       node.properties.uri ??
       node.properties.path ??
       node.properties.hostname ??
+      node.properties.ip ??
       node.id.slice(0, 12),
   );
 }

--- a/server/ui/src/entities/security/remediation.test.ts
+++ b/server/ui/src/entities/security/remediation.test.ts
@@ -112,6 +112,20 @@ describe("deriveRemediations evidence states", () => {
     const rotation = observed.find((item) => item.title === "Rotate this credential");
     expect(rotation?.body).toContain("Authorization header");
     expect(rotation?.body).not.toMatch(/config file or environment variable/i);
+
+    const aggregated = deriveRemediations(
+      node("Credential", {
+        material_status: "observed",
+        exposure_status: "exposed",
+        merge_key: "value_hash",
+        sources: ["cursor-server", "vscode-server"],
+      }),
+      "Credential",
+      [],
+    );
+    expect(
+      aggregated.find((item) => item.title === "Rotate this credential")?.body,
+    ).toContain("cursor-server, vscode-server");
   });
 
   it("labels cross-protocol host correlation as a hypothesis", () => {

--- a/server/ui/src/entities/security/remediation.ts
+++ b/server/ui/src/entities/security/remediation.ts
@@ -72,14 +72,22 @@ export function deriveRemediations(
     props.material_status === "observed" &&
     props.merge_key === "value_hash";
   if (kind === "Credential" && observedExposure) {
-    const source =
-      typeof props.source === "string" && props.source.trim() !== ""
-        ? props.source.trim()
-        : null;
+    const sources = new Set<string>();
+    if (typeof props.source === "string" && props.source.trim() !== "") {
+      sources.add(props.source.trim());
+    }
+    if (Array.isArray(props.sources)) {
+      for (const value of props.sources) {
+        if (typeof value === "string" && value.trim() !== "") {
+          sources.add(value.trim());
+        }
+      }
+    }
+    const source = [...sources].sort().join(", ");
     items.push({
       severity: "critical",
       title: "Rotate this credential",
-      body: source
+      body: source !== ""
         ? `AgentHound observed usable exposed credential material from ${source}. Revoke or rotate it, then restrict or remove that recorded source.`
         : "AgentHound observed usable exposed credential material, but the capture source was not recorded. Revoke or rotate it and investigate the producer before choosing a storage remediation.",
     });

--- a/server/ui/src/features/explorer/lib/export-markdown.ts
+++ b/server/ui/src/features/explorer/lib/export-markdown.ts
@@ -1,4 +1,5 @@
 import type { APINode } from "@entities/graph/dto";
+import { displayName } from "@entities/node/model";
 
 const MD_SKIP_KEYS = new Set([
   "objectid",
@@ -67,11 +68,7 @@ export function formatNodeAsMarkdown(
 ): string {
   const props = node.properties ?? {};
   const isCredential = node.kinds.includes("Credential");
-  const name =
-    (typeof props.name === "string" && props.name) ||
-    (typeof props.uri === "string" && props.uri) ||
-    (typeof props.path === "string" && props.path) ||
-    node.id.slice(0, 12);
+  const name = displayName(node);
 
   const lines: string[] = [];
   lines.push(`## ${name}`);

--- a/server/ui/src/features/explorer/model/graph/build-nodes.ts
+++ b/server/ui/src/features/explorer/model/graph/build-nodes.ts
@@ -1,18 +1,13 @@
 import type { APINode } from "@entities/graph/dto";
+import { displayName } from "@entities/node/model";
 import type { SeverityLevel } from "../lens-config";
 import type { BuildOptions, HexNodeData, LogicalEdge, LogicalHexNode } from "./types";
 import { severityRank } from "./build-edges";
 
 export function nodeLabel(node: APINode): string {
-  const props = node.properties ?? {};
-  const name =
-    (props.name as string) ||
-    (props.hostname as string) ||
-    (props.ip as string) ||
-    (props.uri as string) ||
-    (props.path as string);
+  const name = displayName(node);
   if (name && name.length > 40) return name.slice(0, 38) + "…";
-  return name || node.id.slice(0, 12);
+  return name;
 }
 
 export function kindTag(kind: string): string {


### PR DESCRIPTION
## Summary

Fixes six independently reproduced AgentHound 1.1 defects without weakening the active/offensive scan model.

- **Shared credential identity:** identical observed secret material now produces one `value_hash`-based Credential node. Deterministic plural properties retain every source, location, name, format, type, and authentication hint; all graph associations remain intact. Planner adapters and dashboard labels/remediation consume the aggregate representation.
- **Target validation:** malformed positional hostnames fail before resolver or network work begins.
- **Installer safety:** payloads are validated before promotion, and an installed-path startup failure atomically restores the previous working binary.
- **Detection precision:** ordinary documentation URL paths no longer trigger Base64 prompt-injection or URL-only outbound-capability findings, while quoted and backtick-delimited Base64 payloads remain detectable.
- **A2A credential planning:** when the public card and bounded protocol probe already succeed anonymously, the planner does not repeat the same card collection with a bearer that cannot prove credential acceptance or expand the collected surface. Protected and inconclusive agents remain eligible.
- **MCP differential proof:** a successful exact anonymous resource read records public access and retains the content without presenting a credential. Denied or inconclusive controls still proceed to the authenticated read required for credential-gated proof.

Compatible cross-target credential reuse remains intentional. The correction removes only requests that cannot produce additional evidence after the exact surface has already succeeded anonymously.

Fixes #139

## Validation

- `make check`
  - golangci-lint: 0 issues
  - all Go packages: short race suite passed
  - dependency and collector-size gates passed
  - installer rollback regression passed
  - UI lint, 267 tests, and production build passed
  - collector and server builds passed
- `make integration`: denied anonymous control, successful authenticated MCP read, strict artifact validation, Neo4j/PostgreSQL ingest, and verified-finding propagation passed
- `PATH="$(pwd)/.venv/bin:$PATH" make docs-check`: strict docs build passed
- `make version-check`: passed
- Shared credential regression covers collector aggregation and server graph-writer preparation, including mixed bearer/API-key provenance.
- Public-access regressions assert zero A2A candidates after proven anonymous protocol access and zero credential-bearing MCP requests after a successful exact anonymous read.
- Protected/inconclusive A2A controls and the real MCP smoke test confirm useful active credential expansion remains enabled.
- Rule regressions cover vendor documentation URLs and genuine quoted/backtick Base64 payloads.
