### PR TITLE
fix: preserve service credential identities across retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - The installer now validates before promotion and atomically restores the previous binary when installed-path startup validation fails.
 - Legitimate documentation URLs no longer look like Base64 prompt-injection payloads or, by themselves, outbound-network capabilities.
 - Active planning avoids redundant credential presentation when the exact MCP resource or A2A card/probe surface has already succeeded anonymously.
+- Repeated service collection now keeps protected Open WebUI posture stable across credential attempts and gives each distinct LiteLLM master key a contextual `value_hash` identity.
 
 ## 1.1.0 — ⚡ Autonomous Offensive Collection
 

--- a/collector/cli/planner_test.go
+++ b/collector/cli/planner_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	a2acollector "github.com/adithyan-ak/agenthound/modules/a2a"
+	_ "github.com/adithyan-ak/agenthound/modules/litellmcollect"
 	_ "github.com/adithyan-ak/agenthound/modules/ollamacollect"
 	_ "github.com/adithyan-ak/agenthound/modules/qdrantcollect"
 
@@ -107,6 +108,45 @@ func TestAggregatedCredentialHintsPreserveServiceCompatibility(t *testing.T) {
 	for _, service := range []string{"litellm", "openwebui", "jupyter"} {
 		if !credentialCompatibleWithService(credential, service) {
 			t.Fatalf("aggregated credential was not compatible with %s", service)
+		}
+	}
+}
+
+func TestServiceCollectCandidatesDeduplicateCredentialValuesPerEndpoint(t *testing.T) {
+	const endpoint = "https://litellm.example"
+	credential := func(id, value string) ingest.Node {
+		return ingest.Node{ID: id, Kinds: []string{"Credential"}, Properties: map[string]any{
+			"value": value, "value_hash": common.HashCredentialValue(value),
+			"material_status": string(common.CredentialMaterialObserved),
+			"auth_method":     string(common.AuthAPIKey),
+			"type":            "master_key",
+		}}
+	}
+	graph := ingest.GraphData{Nodes: []ingest.Node{
+		{ID: "gateway", Kinds: []string{"LiteLLMGateway", "AIService"}, Properties: map[string]any{
+			"endpoint": endpoint,
+		}},
+		credential("shared-a", "sk-shared-master-key"),
+		credential("shared-b", "sk-shared-master-key"),
+		credential("distinct", "sk-distinct-master-key"),
+	}}
+
+	candidates := (serviceCollectAction{}).Candidates(
+		buildPlannerView(graph, nil, map[string]bool{}, false, false),
+	)
+	if len(candidates) != 2 {
+		t.Fatalf("candidates = %+v, want two distinct credential values", candidates)
+	}
+	values := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ModuleID != "litellm.collect" || candidate.Target.Address != endpoint {
+			t.Fatalf("candidate = %+v, want LiteLLM endpoint", candidate)
+		}
+		values[candidate.Inputs["credential"]] = true
+	}
+	for _, want := range []string{"sk-shared-master-key", "sk-distinct-master-key"} {
+		if !values[want] {
+			t.Errorf("candidate for %q missing: %+v", want, candidates)
 		}
 	}
 }

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -28,6 +28,17 @@ Concrete AI-service nodes also carry the `AIService` label. The umbrella label i
 
 Only concrete `value` material becomes planner input. The normal dashboard property view masks it; explicit query output and JSON export remain literal.
 
+Credential identity is role- and scope-aware:
+
+| Observation | Identity rule | Result |
+|---|---|---|
+| Concrete material repeated across agent configurations | `value_hash` within the collection point | One Credential retains sorted plural provenance and every graph association. |
+| Concrete material accepted for a service credential role | Service endpoint, role, and `value_hash` | Repeating the same secret is idempotent; different secrets remain different nodes. |
+| Masked, hashed, or unresolved material | Source-specific identity with `merge_key=identity` | Reference evidence never merges with observed executable material. |
+| The same material observed in different evidence roles | Distinct role-owned nodes correlated by `value_hash` | Topology and provenance remain intact without presenting the same value twice to one endpoint. |
+
+Planner candidate identity includes the endpoint and `value_hash`, so duplicate observations of one concrete secret do not produce duplicate credential-bearing requests to the same surface.
+
 ### Instruction evidence
 
 `InstructionFile` records the canonical `path`, source `type`, content `hash`, captured `size_bytes`, and `modified_at`. Its classification fields are:

--- a/modules/litellmcollect/collector.go
+++ b/modules/litellmcollect/collector.go
@@ -91,7 +91,10 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 	//    cross_service_credential_chain post-processor joins
 	//    on this property. Without this node the demo fails silently.
 	masterValueHash := common.HashCredentialValue(masterKey)
-	masterID := ingest.ComputeNodeID("Credential", baseURL, "litellm-master")
+	// A gateway can accept more than one concrete master key during an
+	// autonomous scan. Preserve the service role in the identity while using
+	// the value hash to keep repeated presentation of the same key idempotent.
+	masterID := ingest.ComputeNodeID("Credential", baseURL, "litellm-master", masterValueHash)
 	masterProps := map[string]any{
 		"objectid":     masterID,
 		"type":         "master_key",

--- a/modules/litellmcollect/collector_test.go
+++ b/modules/litellmcollect/collector_test.go
@@ -193,6 +193,59 @@ func TestCollect_HappyPath(t *testing.T) {
 	}
 }
 
+func TestCollect_MasterCredentialIdentityIncludesValueHash(t *testing.T) {
+	s := newStub(t)
+	s.modelInfoBody = `{"data":[]}`
+	s.keyListBody = `{"keys":[],"total_count":0,"total_pages":0}`
+	srv := httptest.NewServer(s.handler())
+	defer srv.Close()
+
+	target := action.Target{Kind: "host", Address: strings.TrimPrefix(srv.URL, "http://")}
+	collectMaster := func(key string) ingest.Node {
+		t.Helper()
+		res, err := (&Collector{}).Collect(context.Background(), target, action.CollectOptions{
+			Credentials: map[string]string{"master_key": key},
+		})
+		if err != nil {
+			t.Fatalf("collect master key: %v", err)
+		}
+		for _, node := range res.IngestData.Graph.Nodes {
+			if node.Properties["type"] == "master_key" {
+				return node
+			}
+		}
+		t.Fatal("master Credential node not emitted")
+		return ingest.Node{}
+	}
+
+	firstKey := "sk-test-first-litellm-master-key"
+	secondKey := "sk-test-second-litellm-master-key"
+	first := collectMaster(firstKey)
+	repeated := collectMaster(firstKey)
+	second := collectMaster(secondKey)
+
+	if first.ID != repeated.ID {
+		t.Fatalf("same master key IDs differ: %q != %q", first.ID, repeated.ID)
+	}
+	if first.ID == second.ID {
+		t.Fatalf("different master keys share ID %q", first.ID)
+	}
+	for _, test := range []struct {
+		node ingest.Node
+		key  string
+	}{
+		{node: first, key: firstKey},
+		{node: second, key: secondKey},
+	} {
+		want := ingest.ComputeNodeID(
+			"Credential", srv.URL, "litellm-master", common.HashCredentialValue(test.key),
+		)
+		if test.node.ID != want {
+			t.Errorf("master ID = %q, want contextual value-hash ID %q", test.node.ID, want)
+		}
+	}
+}
+
 func TestCollect_GatewayMatchesFingerprintWithoutOwningPosture(t *testing.T) {
 	s := newStub(t)
 	s.modelInfoBody = `{"data":[]}`

--- a/modules/openwebuicollect/collector.go
+++ b/modules/openwebuicollect/collector.go
@@ -10,7 +10,7 @@
 // POSTURE properties onto the existing :OpenWebUIInstance node:
 // signup_enabled and auth_required.
 //
-// AUTHENTICATED (planner supplies compatible key material): four admin-gated probes
+// CREDENTIAL-BEARING (planner supplies compatible key material): four admin-gated probes
 // enumerate configured upstream provider API keys and emit one
 // :Credential per key, each linked via an EXPOSES_CREDENTIAL edge:
 //
@@ -152,11 +152,11 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 			props["auth_method"] = string(common.AuthNone)
 			props["auth_assurance"] = string(common.AuthAssuranceUnauthenticated)
 			props["auth_evidence"] = common.AuthEvidenceAnonymousProbeSucceeded
-		} else if apiKey != "" {
-			props["auth_method"] = string(common.AuthCustom)
-			props["auth_assurance"] = string(common.AuthAssuranceUnknown)
-			props["auth_evidence"] = common.AuthEvidenceConfiguredCredential
 		} else {
+			// /api/config proves that a gate exists, but it does not identify the
+			// method or validate any credential supplied to later admin probes.
+			// Keep this endpoint posture invariant across planner attempts so every
+			// contribution to the shared service node reports the same public fact.
 			props["auth_method"] = string(common.AuthUnknown)
 			props["auth_assurance"] = string(common.AuthAssuranceUnknown)
 			props["auth_evidence"] = common.AuthEvidenceUnknown
@@ -172,7 +172,7 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 		return res, nil
 	}
 
-	// 2. AUTHENTICATED probes — four admin-gated endpoints. Each is
+	// 2. CREDENTIAL-BEARING probes — four admin-gated endpoints. Each is
 	//    independent; a failure records a partial and the next probe
 	//    still runs.
 	remaining := maxItems
@@ -185,7 +185,7 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 
 	slog.Info("openwebui collection complete",
 		"endpoint", baseURL,
-		"authenticated", true,
+		"credential_supplied", true,
 		"credentials_found", res.Summary.CredentialsFound,
 		"partial_failures", res.Summary.PartialFailures)
 

--- a/modules/openwebuicollect/collector_test.go
+++ b/modules/openwebuicollect/collector_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/adithyan-ak/agenthound/modules/openwebuifp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/common"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
 // configBody matches Open WebUI's real /api/config shape (verified
@@ -179,6 +180,52 @@ func TestProtectedFingerprintLeavesAuthOwnershipToLooter(t *testing.T) {
 		lootProps["auth_method"] != string(common.AuthUnknown) ||
 		lootProps["auth_evidence"] != common.AuthEvidenceUnknown {
 		t.Errorf("protected looter evidence = %+v", lootProps)
+	}
+}
+
+func TestProtectedPostureIsStableAcrossCredentialAttempts(t *testing.T) {
+	const acceptedKey = "sk-accepted-openwebui-admin-key"
+	srv := openwebuiStub(t, openwebuiStubOptions{
+		apiKey:       acceptedKey,
+		config:       `{"status":true,"name":"Open WebUI","version":"0.6.32","features":{"auth":true,"enable_signup":false}}`,
+		openaiConfig: `{}`,
+	})
+	defer srv.Close()
+
+	target := action.Target{Kind: "host", Address: addrOf(srv)}
+	collect := func(key string) ingest.Node {
+		t.Helper()
+		opts := action.CollectOptions{}
+		if key != "" {
+			opts.Extras = map[string]any{"api-key": key}
+		}
+		result, err := (&Collector{}).Collect(context.Background(), target, opts)
+		if err != nil {
+			t.Fatalf("collect with credential %q: %v", key, err)
+		}
+		return result.IngestData.Graph.Nodes[0]
+	}
+
+	nodes := []ingest.Node{
+		collect(""),
+		collect(acceptedKey),
+		collect("sk-rejected-openwebui-admin-key"),
+	}
+	want := map[string]any{
+		"auth_required":  true,
+		"auth_method":    string(common.AuthUnknown),
+		"auth_assurance": string(common.AuthAssuranceUnknown),
+		"auth_evidence":  common.AuthEvidenceUnknown,
+	}
+	for index, node := range nodes {
+		if node.ID != nodes[0].ID {
+			t.Fatalf("attempt %d service ID = %q, want shared endpoint ID %q", index, node.ID, nodes[0].ID)
+		}
+		for key, value := range want {
+			if node.Properties[key] != value {
+				t.Errorf("attempt %d %s = %v, want %v", index, key, node.Properties[key], value)
+			}
+		}
 	}
 }
 

--- a/server/internal/graph/fingerprint_test.go
+++ b/server/internal/graph/fingerprint_test.go
@@ -2,6 +2,8 @@ package graph
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -9,6 +11,9 @@ import (
 	"testing"
 
 	configcollector "github.com/adithyan-ak/agenthound/modules/config"
+	"github.com/adithyan-ak/agenthound/modules/litellmcollect"
+	"github.com/adithyan-ak/agenthound/modules/openwebuicollect"
+	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/collector"
 	"github.com/adithyan-ak/agenthound/sdk/common"
 	"github.com/adithyan-ak/agenthound/sdk/ingest"
@@ -195,6 +200,114 @@ func TestPrepareObservationNodesAcceptsSharedConfigCredential(t *testing.T) {
 	}
 	if credentials != 1 {
 		t.Fatalf("prepared shared credentials = %d, want one", credentials)
+	}
+}
+
+func TestPrepareObservationNodesAcceptsDistinctLiteLLMMasterCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/model/info":
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case "/key/list":
+			_, _ = w.Write([]byte(`{"keys":[],"total_count":0,"total_pages":0}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	target := action.Target{
+		Kind: "host", Address: strings.TrimPrefix(server.URL, "http://"),
+	}
+	const domain = "scan:loot:sha256:litellm-multi-credential"
+	var nodes []ingest.Node
+	for _, key := range []string{
+		"sk-first-litellm-master-key",
+		"sk-second-litellm-master-key",
+		"sk-third-litellm-master-key",
+	} {
+		result, err := (&litellmcollect.Collector{}).Collect(
+			context.Background(), target, action.CollectOptions{
+				Credentials: map[string]string{"master_key": key},
+			},
+		)
+		if err != nil {
+			t.Fatalf("collect with key %q: %v", key, err)
+		}
+		graph := result.IngestData.Graph
+		ingest.TagObservationDomain(&graph, domain)
+		nodes = append(nodes, graph.Nodes...)
+	}
+
+	prepared, _, err := prepareObservationNodes(nodes)
+	if err != nil {
+		t.Fatalf("writer preparation rejected distinct LiteLLM credentials: %v", err)
+	}
+	credentialIDs := make(map[string]bool)
+	for _, node := range prepared {
+		if ingest.ConcreteNodeKind(node.Kinds) == "Credential" && node.Properties["type"] == "master_key" {
+			credentialIDs[node.ID] = true
+		}
+	}
+	if len(credentialIDs) != 3 {
+		t.Fatalf("prepared LiteLLM master credential IDs = %v, want three", credentialIDs)
+	}
+}
+
+func TestPrepareObservationNodesAcceptsRepeatedOpenWebUIPosture(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == "/api/config" {
+			_, _ = w.Write([]byte(
+				`{"status":true,"features":{"auth":true,"enable_signup":false}}`,
+			))
+			return
+		}
+		if request.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	target := action.Target{
+		Kind: "host", Address: strings.TrimPrefix(server.URL, "http://"),
+	}
+	const domain = "scan:loot:sha256:openwebui-multi-credential"
+	var nodes []ingest.Node
+	for _, key := range []string{"", "sk-first-openwebui-key", "sk-second-openwebui-key"} {
+		opts := action.CollectOptions{}
+		if key != "" {
+			opts.Credentials = map[string]string{"api_key": key}
+		}
+		result, err := (&openwebuicollect.Collector{}).Collect(context.Background(), target, opts)
+		if err != nil {
+			t.Fatalf("collect with key %q: %v", key, err)
+		}
+		graph := result.IngestData.Graph
+		ingest.TagObservationDomain(&graph, domain)
+		nodes = append(nodes, graph.Nodes...)
+	}
+
+	prepared, _, err := prepareObservationNodes(nodes)
+	if err != nil {
+		t.Fatalf("writer preparation rejected repeated OpenWebUI posture: %v", err)
+	}
+	instances := 0
+	for _, node := range prepared {
+		if ingest.ConcreteNodeKind(node.Kinds) != "OpenWebUIInstance" {
+			continue
+		}
+		instances++
+		if node.Properties["auth_method"] != string(common.AuthUnknown) ||
+			node.Properties["auth_evidence"] != common.AuthEvidenceUnknown {
+			t.Fatalf("prepared OpenWebUI posture = %+v, want stable protected unknown", node.Properties)
+		}
+	}
+	if instances != 1 {
+		t.Fatalf("prepared OpenWebUI instances = %d, want one", instances)
 	}
 }
 


### PR DESCRIPTION
## Summary

- include the LiteLLM master-key value hash in its endpoint-and-role credential identity, keeping repeated values idempotent while separating distinct accepted keys
- keep protected Open WebUI authentication posture invariant across anonymous and credential-bearing planner attempts
- document the role-aware credential identity contract and add collector, planner, and server-writer regressions

## Product contract preserved

Identical concrete secrets discovered across agent configurations still collapse into one value-hash credential with plural provenance. Planner candidates still deduplicate the same value per endpoint. Service-role observations remain separate evidence nodes and correlate through value_hash; this change does not use hash-only service identity or create one service node per attempt.

## Validation

- go test ./modules/litellmcollect ./modules/openwebuicollect ./collector/cli ./server/internal/graph -count=1
- make check
- PATH="$(pwd)/.venv/bin:$PATH" make docs-check
- make integration
- make upstream-test
- make version-check

The upstream active/stealth harness and manual server ingest now pass at the prior collision point.