### PR TITLE
release: prepare 1.1.1

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,7 +1,7 @@
 name: Version Check
 
 # Early-feedback check on the hand-maintained version strings: surfaces (as a red
-# check) a release-prep PR whose install.sh / README pins disagree with the
+# check) a release-prep PR whose public installation pins disagree with the
 # CHANGELOG. Path-filtered to those files, so do NOT make it a required status
 # check -- a skipped path-filtered workflow stays "pending" and would block
 # code-only PRs. The hard guarantee is the release pipeline: release.yml ->
@@ -13,12 +13,16 @@ on:
       - "install.sh"
       - "README.md"
       - "CHANGELOG.md"
+      - "docs/getting-started/install.md"
+      - "docs/getting-started/quickstart.md"
+      - "docs/operator/deployment.md"
       - "go.mod"
       - ".goreleaser.yml"
       - "Makefile"
       - "scripts/release-notes.sh"
       - "scripts/release-process-test.sh"
       - "scripts/release-tag-check.sh"
+      - "scripts/release-version-pins.sh"
       - "scripts/sync-version.sh"
       - "scripts/verify-homebrew-formula.sh"
       - "scripts/version-check.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.1.1 — Evidence Precision and Reliability
+
 ### Added
 
 - Instruction findings now preserve bounded matched excerpts, source positions, scope, and file metadata from the scan artifact through the dashboard and copied report.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ make check
 
 Changes spanning collection, planning, artifacts, ingestion, or findings also run `make integration`. Documentation changes run `make docs-check`.
 
-Before a release tag, run `make prerelease` and `make docs-check`. Release tags are numeric SemVer without a `v` prefix. The first numeric heading in `CHANGELOG.md` is the version source of truth; `make sync-version` updates the installer pins in `README.md` and `install.sh`.
+Before a release tag, run `make prerelease` and `make docs-check`. Release tags are numeric SemVer without a `v` prefix. The first numeric heading in `CHANGELOG.md` is the version source of truth; `make sync-version` updates every live installer, environment, and Docker Compose pin in the README, installer, and operator documentation.
 
 Release from a clean commit already merged into `main`:
 

--- a/Makefile
+++ b/Makefile
@@ -158,15 +158,15 @@ size-check:
 installer-test:
 	@bash scripts/install-atomic-test.sh
 
-# Assert the install.sh + README version pins match the CHANGELOG (the version
-# source of truth). Also runs inside `make prerelease`, so release.yml enforces
-# it at tag time too.
+# Assert every live installer, environment, and Compose pin matches the
+# CHANGELOG (the version source of truth). Also runs inside `make prerelease`,
+# so release.yml enforces it at tag time too.
 version-check:
 	@bash scripts/version-check.sh
 	@bash scripts/release-process-test.sh
 
-# Rewrite the install.sh + README version pins from the CHANGELOG top header
-# (or VERSION=). Usage: make sync-version   or   make sync-version VERSION=0.7.1
+# Rewrite all live release pins from the CHANGELOG top header (or VERSION=).
+# Usage: make sync-version   or   make sync-version VERSION=0.7.1
 sync-version:
 	@bash scripts/sync-version.sh $(VERSION)
 
@@ -182,7 +182,7 @@ docs-check:
 # to keep this gate Go/Node-only.)
 prerelease:
 	@echo "=== [1/4] version-check ==="
-	$(MAKE) version-check
+	RELEASE_CHECK=1 $(MAKE) version-check
 	@echo "=== [2/4] contributor checks ==="
 	$(MAKE) check
 	@echo "=== [3/4] security checks ==="

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ The collector writes an ingest-valid artifact before collection and checkpoints 
 
 ### 1. Install the collector
 
-Install the 1.1.0 static binary to `~/.local/bin`:
+Install the 1.1.1 static binary to `~/.local/bin`:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/install.sh \
-  | AGENTHOUND_VERSION=1.1.0 sh
+curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/install.sh \
+  | AGENTHOUND_VERSION=1.1.1 sh
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
@@ -170,7 +170,7 @@ The server is optional during collection. Start it on the analysis system when y
 
 ```bash
 curl -sSfL \
-  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/docker/docker-compose.public.yml \
+  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/docker/docker-compose.public.yml \
   -o agenthound-compose.yml
 docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 docker compose -f agenthound-compose.yml -p agenthound exec -T agenthound \

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -7,8 +7,8 @@ Install the collector on the system where the scan will run. Deploy the analysis
 The release installer selects the platform archive and installs `agenthound` under `$HOME/.local/bin` by default:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/install.sh \
-  | AGENTHOUND_VERSION=1.1.0 sh
+curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/install.sh \
+  | AGENTHOUND_VERSION=1.1.1 sh
 export PATH="$HOME/.local/bin:$PATH"
 agenthound version
 ```
@@ -27,7 +27,7 @@ Docker Compose provides `agenthound-server`, Neo4j, and PostgreSQL:
 
 ```bash
 curl -sSfL \
-  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/docker/docker-compose.public.yml \
+  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/docker/docker-compose.public.yml \
   -o agenthound-compose.yml
 docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -39,7 +39,7 @@ Start the optional analysis stack:
 
 ```bash
 curl -sSfL \
-  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/docker/docker-compose.public.yml \
+  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/docker/docker-compose.public.yml \
   -o agenthound-compose.yml
 docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 ```

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -8,7 +8,7 @@ Run the published stack:
 
 ```bash
 curl -sSfL \
-  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/docker/docker-compose.public.yml \
+  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/docker/docker-compose.public.yml \
   -o agenthound-compose.yml
 docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 ```
@@ -74,7 +74,7 @@ Use the same timestamp or release identifier for both files. Test restores on an
 
 ```bash
 curl -sSfL \
-  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/docker/docker-compose.public.yml \
+  https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/docker/docker-compose.public.yml \
   -o agenthound-compose.yml
 docker compose -f agenthound-compose.yml -p agenthound pull
 docker compose -f agenthound-compose.yml -p agenthound up -d --wait

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 # AgentHound collector installer.
 #
 # Pin to a release tag for integrity:
-#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.0/install.sh \
-#     | AGENTHOUND_VERSION=1.1.0 sh
+#   curl -sSfL https://raw.githubusercontent.com/adithyan-ak/agenthound/1.1.1/install.sh \
+#     | AGENTHOUND_VERSION=1.1.1 sh
 #
 # Verifies the downloaded archive against checksums.txt before extracting,
 # and against cosign signatures if cosign is available on $PATH.

--- a/scripts/release-process-test.sh
+++ b/scripts/release-process-test.sh
@@ -14,9 +14,10 @@ trap 'rm -rf "$test_root"' EXIT
 
 new_fixture() {
   local name=$1 root="$test_root/$1"
-  mkdir -p "$root/scripts"
+  mkdir -p "$root/scripts" "$root/docs/getting-started" "$root/docs/operator"
   cp "$repo_root/scripts/version-check.sh" "$root/scripts/"
   cp "$repo_root/scripts/sync-version.sh" "$root/scripts/"
+  cp "$repo_root/scripts/release-version-pins.sh" "$root/scripts/"
   cp "$repo_root/scripts/release-notes.sh" "$root/scripts/"
   cp "$repo_root/scripts/release-tag-check.sh" "$root/scripts/"
   cat > "$root/CHANGELOG.md" <<'EOF'
@@ -28,8 +29,27 @@ new_fixture() {
 
 Release body.
 EOF
-  printf '# curl -sSfL %s/1.0.0/install.sh | sh\n' "$pin_base" > "$root/install.sh"
-  printf 'curl -sSfL %s/1.0.0/install.sh | sh\n' "$pin_base" > "$root/README.md"
+  cat > "$root/install.sh" <<EOF
+# curl -sSfL ${pin_base}/1.0.0/install.sh \\
+#   | AGENTHOUND_VERSION=1.0.0 sh
+EOF
+  cat > "$root/README.md" <<EOF
+Install the 1.0.0 static binary:
+curl -sSfL ${pin_base}/1.0.0/install.sh \\
+  | AGENTHOUND_VERSION=1.0.0 sh
+curl -sSfL ${pin_base}/1.0.0/docker/docker-compose.public.yml
+EOF
+  cat > "$root/docs/getting-started/install.md" <<EOF
+curl -sSfL ${pin_base}/1.0.0/install.sh \\
+  | AGENTHOUND_VERSION=1.0.0 sh
+curl -sSfL ${pin_base}/1.0.0/docker/docker-compose.public.yml
+EOF
+  printf 'curl -sSfL %s/1.0.0/docker/docker-compose.public.yml\n' "$pin_base" \
+    > "$root/docs/getting-started/quickstart.md"
+  cat > "$root/docs/operator/deployment.md" <<EOF
+curl -sSfL ${pin_base}/1.0.0/docker/docker-compose.public.yml
+curl -sSfL ${pin_base}/1.0.0/docker/docker-compose.public.yml
+EOF
   printf '%s\n' "$root"
 }
 
@@ -47,9 +67,16 @@ happy=$(new_fixture happy)
 (cd "$happy" && GITHUB_REF_TYPE=tag GITHUB_REF_NAME=1.0.0 bash scripts/version-check.sh >/dev/null)
 
 mismatch=$(new_fixture mismatch)
-sed -i.bak 's/1\.0\.0/1.0.1/' "$mismatch/README.md"
+sed -i.bak 's/AGENTHOUND_VERSION=1\.0\.0/AGENTHOUND_VERSION=1.0.1/' "$mismatch/README.md"
 rm "$mismatch/README.md.bak"
-expect_failure "mismatched installer pin" bash "$mismatch/scripts/version-check.sh"
+expect_failure "mismatched environment pin" bash "$mismatch/scripts/version-check.sh"
+
+compose_mismatch=$(new_fixture compose-mismatch)
+sed -i.bak 's#/1\.0\.0/docker/#/1.0.1/docker/#' \
+  "$compose_mismatch/docs/getting-started/quickstart.md"
+rm "$compose_mismatch/docs/getting-started/quickstart.md.bak"
+expect_failure "mismatched documentation Compose pin" \
+  bash "$compose_mismatch/scripts/version-check.sh"
 
 duplicate=$(new_fixture duplicate)
 printf '%s/1.0.0/install.sh\n' "$pin_base" >> "$duplicate/README.md"
@@ -74,13 +101,13 @@ Pending change.' "$unreleased/CHANGELOG.md"
 rm "$unreleased/CHANGELOG.md.bak"
 expect_failure "non-empty Unreleased on tag" env GITHUB_REF_TYPE=tag GITHUB_REF_NAME=1.0.0 \
   bash "$unreleased/scripts/version-check.sh"
+expect_failure "non-empty Unreleased in pre-tag release mode" env RELEASE_CHECK=1 \
+  bash "$unreleased/scripts/version-check.sh"
 
 sync=$(new_fixture sync)
+(sed -i.bak 's/## 1\.0\.0 —/## 1.0.2 —/' "$sync/CHANGELOG.md" && rm "$sync/CHANGELOG.md.bak")
 (cd "$sync" && bash scripts/sync-version.sh 1.0.2 >/dev/null)
-if [ "$(grep -RhoE 'agenthound/[0-9]+\.[0-9]+\.[0-9]+/install\.sh' "$sync/install.sh" "$sync/README.md" | sort -u)" != "agenthound/1.0.2/install.sh" ]; then
-  echo "release-process-test: sync did not update both pins" >&2
-  exit 1
-fi
+(cd "$sync" && RELEASE_CHECK=1 bash scripts/version-check.sh >/dev/null)
 
 notes=$(new_fixture notes)
 rendered=$(cd "$notes" && sh scripts/release-notes.sh CHANGELOG.md 1.0.0)

--- a/scripts/release-version-pins.sh
+++ b/scripts/release-version-pins.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Shared manifest and patterns for public release-version references.
+
+# Keep this list limited to live installation surfaces. Historical changelog
+# examples, dependency versions, and test fixture versions are intentionally
+# excluded.
+release_version_pin_specs() {
+  cat <<'EOF'
+installer|install.sh|1
+environment|install.sh|1
+readme-label|README.md|1
+installer|README.md|1
+environment|README.md|1
+compose|README.md|1
+installer|docs/getting-started/install.md|1
+environment|docs/getting-started/install.md|1
+compose|docs/getting-started/install.md|1
+compose|docs/getting-started/quickstart.md|1
+compose|docs/operator/deployment.md|2
+EOF
+}
+
+release_version_pin_pattern() {
+  local kind=$1
+  local semver='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+  case "$kind" in
+    installer)
+      printf '%s' "https://raw\.githubusercontent\.com/adithyan-ak/agenthound/(v)?${semver}/install\.sh"
+      ;;
+    environment)
+      printf '%s' "AGENTHOUND_VERSION=${semver}"
+      ;;
+    compose)
+      printf '%s' "https://raw\.githubusercontent\.com/adithyan-ak/agenthound/(v)?${semver}/docker/docker-compose\.public\.yml"
+      ;;
+    readme-label)
+      printf '%s' "Install the ${semver} static binary"
+      ;;
+    *)
+      echo "unknown release-version pin kind: $kind" >&2
+      return 1
+      ;;
+  esac
+}
+
+release_version_pin_replacement() {
+  local kind=$1 version=$2
+  case "$kind" in
+    installer)
+      printf 'https://raw.githubusercontent.com/adithyan-ak/agenthound/%s/install.sh' "$version"
+      ;;
+    environment)
+      printf 'AGENTHOUND_VERSION=%s' "$version"
+      ;;
+    compose)
+      printf 'https://raw.githubusercontent.com/adithyan-ak/agenthound/%s/docker/docker-compose.public.yml' "$version"
+      ;;
+    readme-label)
+      printf 'Install the %s static binary' "$version"
+      ;;
+    *)
+      echo "unknown release-version pin kind: $kind" >&2
+      return 1
+      ;;
+  esac
+}

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# Rewrite the repository's two tagged installer URLs to a release version.
+# Rewrite every live public release-version reference to one version.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+
+source scripts/release-version-pins.sh
 
 ver="${1:-}"
 if [ -z "$ver" ]; then
@@ -15,26 +17,32 @@ if ! printf '%s\n' "$ver" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9
   exit 1
 fi
 
-pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/(v)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)/install\.sh'
-files=(install.sh README.md)
-
-# Validate both files before mutating either one. This prevents a duplicate or
-# missing URL from producing a partially synchronized release-prep diff.
-for file in "${files[@]}"; do
-  count=$(grep -oE "$pin_pattern" "$file" | wc -l | tr -d '[:space:]' || true)
-  if [ "$count" -ne 1 ]; then
-    echo "sync-version: $file has $count tagged installer URLs, expected exactly 1"
+# Validate every location before mutating any file. This prevents a duplicate
+# or missing reference from producing a partially synchronized release diff.
+total=0
+while IFS='|' read -r kind file expected_count; do
+  if [ ! -f "$file" ]; then
+    echo "sync-version: missing release-version file: $file"
     exit 1
   fi
-done
+  pattern=$(release_version_pin_pattern "$kind")
+  count=$(grep -oE "$pattern" "$file" | wc -l | tr -d '[:space:]' || true)
+  if [ "$count" -ne "$expected_count" ]; then
+    echo "sync-version: $file has $count $kind references, expected exactly $expected_count"
+    exit 1
+  fi
+  total=$((total + expected_count))
+done < <(release_version_pin_specs)
 
 sedi() {
   if sed --version >/dev/null 2>&1; then sed -i "$@"; else sed -i '' "$@"; fi
 }
 
-replacement="https://raw.githubusercontent.com/adithyan-ak/agenthound/${ver}/install.sh"
-for file in "${files[@]}"; do
-  sedi -E "s#${pin_pattern}#${replacement}#g" "$file"
-  echo "sync-version: set ${ver} pin in $file"
-done
-echo "sync-version: updated exactly 2 tagged installer URLs. Run 'make version-check' to confirm."
+while IFS='|' read -r kind file expected_count; do
+  pattern=$(release_version_pin_pattern "$kind")
+  replacement=$(release_version_pin_replacement "$kind" "$ver")
+  sedi -E "s#${pattern}#${replacement}#g" "$file"
+  echo "sync-version: set $expected_count $kind reference(s) in $file to $ver"
+done < <(release_version_pin_specs)
+
+echo "sync-version: updated exactly $total live release references. Run 'make version-check' to confirm."

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+source scripts/release-version-pins.sh
+
 fail=0
 release_header=$(grep -m1 -E '^## (0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([[:space:]]|$)' CHANGELOG.md || true)
 ver=$(printf '%s\n' "$release_header" | sed -nE 's/^## ((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)).*/\1/p')
@@ -22,28 +24,36 @@ if [ "$unreleased_count" -ne 1 ] || [ -z "$unreleased_line" ] || [ "$unreleased_
   fail=1
 fi
 
-pin_pattern='https://raw\.githubusercontent\.com/adithyan-ak/agenthound/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)/install\.sh'
-for file in install.sh README.md; do
-  matches=$(grep -oE "$pin_pattern" "$file" || true)
-  count=$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d '[:space:]')
-  if [ "$count" -ne 1 ]; then
-    echo "  FAIL: $file has $count tagged installer URLs, expected exactly 1"
+while IFS='|' read -r kind file expected_count; do
+  if [ ! -f "$file" ]; then
+    echo "  FAIL: missing release-version file: $file"
     fail=1
     continue
   fi
 
-  found=$(printf '%s\n' "$matches" | sed -nE 's#^.*/((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))/install\.sh$#\1#p')
-  if [ "$found" != "$ver" ]; then
-    echo "  FAIL: $file pins $found, expected $ver"
+  pattern=$(release_version_pin_pattern "$kind")
+  expected=$(release_version_pin_replacement "$kind" "$ver")
+  matches=$(grep -oE "$pattern" "$file" || true)
+  count=$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l | tr -d '[:space:]')
+  if [ "$count" -ne "$expected_count" ]; then
+    echo "  FAIL: $file has $count $kind references, expected exactly $expected_count"
+    fail=1
+    continue
+  fi
+
+  mismatches=$(printf '%s\n' "$matches" | grep -Fvx "$expected" || true)
+  if [ -n "$mismatches" ]; then
+    echo "  FAIL: $file has a $kind reference that does not pin $ver"
     fail=1
   else
-    echo "  ok: $file -> $found"
+    echo "  ok: $file $kind ($expected_count) -> $ver"
   fi
-done
+done < <(release_version_pin_specs)
 
 # GitHub supplies these variables for a tag-triggered workflow. A release tag
-# must name the CHANGELOG version, and Unreleased must already be empty so the
-# published notes cannot omit last-minute changes.
+# must name the CHANGELOG version. RELEASE_CHECK=1 gives the pre-tag
+# `make prerelease` gate the same empty-Unreleased safety check, before the
+# immutable tag exists.
 if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
   if [ "${GITHUB_REF_NAME:-}" != "$ver" ]; then
     echo "  FAIL: tag ${GITHUB_REF_NAME:-<none>} != CHANGELOG $ver"
@@ -51,17 +61,19 @@ if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
   else
     echo "  ok: tag ${GITHUB_REF_NAME} matches CHANGELOG"
   fi
+fi
 
+if [ "${GITHUB_REF_TYPE:-}" = "tag" ] || [ "${RELEASE_CHECK:-}" = "1" ]; then
   unreleased_body=$(awk '
     /^## Unreleased[[:space:]]*$/ { in_unreleased = 1; next }
     in_unreleased && /^## / { exit }
     in_unreleased && /[^[:space:]]/ { print }
   ' CHANGELOG.md)
   if [ -n "$unreleased_body" ]; then
-    echo "  FAIL: CHANGELOG.md Unreleased section must be empty on a tag build"
+    echo "  FAIL: CHANGELOG.md Unreleased section must be empty for a release"
     fail=1
   else
-    echo "  ok: Unreleased is empty for tag build"
+    echo "  ok: Unreleased is empty for release"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- cut the current changelog entries into the 1.1.1 release and leave Unreleased empty
- synchronize all 12 live installer, environment, README, and Docker Compose pins
- make the release-version manifest shared by sync and validation
- make prerelease reject non-empty Unreleased before an immutable tag is created
- extend release-process regression coverage and Version Check workflow paths

## Validation

- `make prerelease`
- `PATH="$(pwd)/.venv/bin:$PATH" make docs-check`
- `make integration`
- `make upstream-test`
- `RELEASE_CHECK=1 make version-check`
- `bash -n scripts/release-version-pins.sh scripts/sync-version.sh scripts/version-check.sh scripts/release-process-test.sh`
- `git diff --check`

All gates pass. The full upstream suite completed its independent service checks, deep active scan, targetless stealth scan, unified artifact validation, and manual ingestion.

## Release sequencing

Do not create the immutable `1.1.1` tag until this PR is merged, main CI and Docs pass, and the four release gates are rerun on the exact merge commit.