### PR TITLE
Coordinate collector and server release compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,6 +388,56 @@ jobs:
             [[ "$(crane digest "${image}")" == "${digest}" ]]
           done < "${records}/images.tsv"
 
+      - name: Promote, sign, and verify immutable production images
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          records="${RUNNER_TEMP}/release-candidate"
+          for pair in \
+            "${STAGING_COLLECTOR} ${PRODUCTION_COLLECTOR}" \
+            "${STAGING_SERVER} ${PRODUCTION_SERVER}"; do
+            read -r staging production <<<"${pair}"
+            for arch in amd64 arm64; do
+              crane copy "${staging}:${tag}-${arch}" "${production}:${tag}-${arch}"
+              expected="$(crane digest "${staging}:${tag}-${arch}")"
+              [[ "$(crane digest "${production}:${tag}-${arch}")" == "${expected}" ]]
+            done
+            crane copy "${staging}:${tag}" "${production}:${tag}"
+            expected="$(crane digest "${staging}:${tag}")"
+            [[ "$(crane digest "${production}:${tag}")" == "${expected}" ]]
+            if ! cosign verify \
+              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${tag}" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${production}@${expected}" >/dev/null 2>&1; then
+              cosign sign --yes "${production}@${expected}"
+            fi
+            cosign verify \
+              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${tag}" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${production}@${expected}" >/dev/null
+          done
+
+          while IFS=$'\t' read -r staging_ref expected; do
+            staging_repo="${staging_ref%%:*}"
+            suffix="${staging_ref##*:}"
+            production="${PRODUCTION_COLLECTOR}"
+            [[ "${staging_repo}" == "${STAGING_SERVER}" ]] && production="${PRODUCTION_SERVER}"
+            [[ "$(crane digest "${production}:${suffix}")" == "${expected}" ]]
+          done < "${records}/images.tsv"
+
+          mapfile -t compose_refs < <(
+            grep -E '^[[:space:]]+image:[[:space:]]+ghcr\.io/adithyan-ak/agenthound-server:' \
+              docker/docker-compose.public.yml |
+              sed -E 's/^[[:space:]]+image:[[:space:]]+//'
+          )
+          [[ "${#compose_refs[@]}" == 1 ]]
+          [[ "${compose_refs[0]}" == "${PRODUCTION_SERVER}:${tag}" ]]
+          expected_server="$(awk -F '\t' -v ref="${STAGING_SERVER}:${tag}" \
+            '$1 == ref { print $2 }' "${records}/images.tsv")"
+          [[ -n "${expected_server}" ]]
+          [[ "$(crane digest "${compose_refs[0]}")" == "${expected_server}" ]]
+
       - name: Publish and prove the immutable GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -416,47 +466,24 @@ jobs:
           [[ "$(jq -r '.body' <<<"${published}")" == "$(cat "${records}/release-notes.md")" ]]
           [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')" == "${tag}" ]]
 
-      - name: Promote verified image digests and sign production identities
+      - name: Update mutable latest image aliases
         shell: bash
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          records="${RUNNER_TEMP}/release-candidate"
           for pair in \
             "${STAGING_COLLECTOR} ${PRODUCTION_COLLECTOR}" \
             "${STAGING_SERVER} ${PRODUCTION_SERVER}"; do
             read -r staging production <<<"${pair}"
             for arch in amd64 arm64; do
-              crane copy "${staging}:${tag}-${arch}" "${production}:${tag}-${arch}"
               crane copy "${staging}:${tag}-${arch}" "${production}:latest-${arch}"
               expected="$(crane digest "${staging}:${tag}-${arch}")"
-              [[ "$(crane digest "${production}:${tag}-${arch}")" == "${expected}" ]]
               [[ "$(crane digest "${production}:latest-${arch}")" == "${expected}" ]]
             done
-            crane copy "${staging}:${tag}" "${production}:${tag}"
             crane copy "${staging}:${tag}" "${production}:latest"
             expected="$(crane digest "${staging}:${tag}")"
-            [[ "$(crane digest "${production}:${tag}")" == "${expected}" ]]
             [[ "$(crane digest "${production}:latest")" == "${expected}" ]]
-            if ! cosign verify \
-              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${tag}" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-              "${production}@${expected}" >/dev/null 2>&1; then
-              cosign sign --yes "${production}@${expected}"
-            fi
-            cosign verify \
-              --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${tag}" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-              "${production}@${expected}" >/dev/null
           done
-
-          while IFS=$'\t' read -r staging_ref expected; do
-            staging_repo="${staging_ref%%:*}"
-            suffix="${staging_ref##*:}"
-            production="${PRODUCTION_COLLECTOR}"
-            [[ "${staging_repo}" == "${STAGING_SERVER}" ]] && production="${PRODUCTION_SERVER}"
-            [[ "$(crane digest "${production}:${suffix}")" == "${expected}" ]]
-          done < "${records}/images.tsv"
 
       - name: Publish the exact verified Homebrew formulas
         env:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -16,6 +16,7 @@ on:
       - "docs/getting-started/install.md"
       - "docs/getting-started/quickstart.md"
       - "docs/operator/deployment.md"
+      - "docker/docker-compose.public.yml"
       - "go.mod"
       - ".goreleaser.yml"
       - "Makefile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Public Compose deployments now pin the coordinated AgentHound server release, and release publication verifies the signed production image before making the GitHub release public.
+- Server ingestion now reports collector, artifact-contract, and server versions while retaining backward compatibility with supported historical V1 artifacts.
+
 ## 1.1.1 — Evidence Precision and Reliability
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ docker compose -f agenthound-compose.yml -p agenthound exec -T agenthound \
 
 Open [http://127.0.0.1:8080](http://127.0.0.1:8080/) to inspect findings, attack paths, credentials, risk, queries, scan history, and triage.
 
+Collector and server are released as one coordinated version. Compose files
+created under the current release policy pin that exact server image; historical
+releases through `1.1.1` retain their original `latest` reference. The current
+server accepts supported historical V1 artifacts; upgrade the server if a newer
+artifact reports an unsupported ingest contract.
+
 <p align="center">
   <img src="docs/readme-assets/agenthound-dashboard.png" alt="AgentHound attack-surface dashboard" width="900">
 </p>

--- a/docker/docker-compose.public.yml
+++ b/docker/docker-compose.public.yml
@@ -37,7 +37,7 @@ services:
   # Pulls the pre-built server image from GHCR — no source checkout needed.
   # Operators who want to build from source should use docker-compose.yml instead.
   agenthound:
-    image: ghcr.io/adithyan-ak/agenthound-server:latest
+    image: ghcr.io/adithyan-ak/agenthound-server:1.1.1
     ports:
       # Bind on the loopback interface only — the server has no application-layer
       # auth. To reach it from another machine, use a VPN / SSH tunnel / Tailscale,

--- a/docs/contributing/modules.md
+++ b/docs/contributing/modules.md
@@ -54,6 +54,11 @@ Do not use `http.DefaultClient`, an unguarded `http.Transport`, or a bare `net.D
 
 Return ingest V1 graph facts with deterministic IDs and explicit observation domains. Every collection outcome needs a matching coverage declaration owned by the same collector prefix.
 
+Treat V1 as a backward-compatible wire contract: new fields must be optional,
+and the current server must continue accepting the frozen historical V1
+fixtures. Any required or otherwise breaking wire change starts a new contract
+version instead of tightening V1 in place.
+
 Preserve useful graph data returned with a structured partial error, but propagate the error so the planner does not record a false success.
 
 Credential nodes follow these rules:

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -34,6 +34,11 @@ docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 
 Open `http://127.0.0.1:8080`. The server binds to loopback by default.
 
+Use the matching collector and server release by default. Exact Compose image
+pinning starts with the first release after `1.1.1`; older immutable Compose
+files retain their historical `latest` reference. The collector still runs
+offline and does not need a live server while it scans.
+
 Homebrew packages the server separately:
 
 ```bash

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -80,7 +80,26 @@ docker compose -f agenthound-compose.yml -p agenthound pull
 docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 ```
 
-The server applies PostgreSQL migrations and Neo4j schema initialization during startup. Keep the collector and server on the same release when ingesting artifacts with same-scan action proof.
+The server applies PostgreSQL migrations and Neo4j schema initialization during startup. Use the coordinated collector and server release pair by default; the artifact compatibility policy is described below.
+
+## Collector and server compatibility
+
+AgentHound publishes the collector and server together under one product
+version. For releases created under this policy, the installation examples pin
+that matching pair so a deployment does not depend on mutable image aliases.
+
+Artifact admission is based on the ingest contract, not exact binary version
+equality. The current server accepts supported historical V1 artifacts,
+including artifacts whose `collector_version` is older. An older server is not
+guaranteed to understand artifacts from a newer collector; when ingest reports
+an unsupported contract or structure, upgrade the server. Additive V1 changes
+must remain optional and backward-compatible. A breaking wire-format change
+requires a new contract version such as V2.
+
+Exact server-image pinning applies to releases created after this policy was
+introduced. Historical tags `1.0.0` through `1.1.1` retain their original
+Compose file, which referenced the mutable `latest` image; those immutable Git
+tags are not rewritten.
 
 ## Capacity
 

--- a/scripts/release-process-test.sh
+++ b/scripts/release-process-test.sh
@@ -14,7 +14,7 @@ trap 'rm -rf "$test_root"' EXIT
 
 new_fixture() {
   local name=$1 root="$test_root/$1"
-  mkdir -p "$root/scripts" "$root/docs/getting-started" "$root/docs/operator"
+  mkdir -p "$root/scripts" "$root/docs/getting-started" "$root/docs/operator" "$root/docker"
   cp "$repo_root/scripts/version-check.sh" "$root/scripts/"
   cp "$repo_root/scripts/sync-version.sh" "$root/scripts/"
   cp "$repo_root/scripts/release-version-pins.sh" "$root/scripts/"
@@ -50,7 +50,22 @@ EOF
 curl -sSfL ${pin_base}/1.0.0/docker/docker-compose.public.yml
 curl -sSfL ${pin_base}/1.0.0/docker/docker-compose.public.yml
 EOF
+  cat > "$root/docker/docker-compose.public.yml" <<'EOF'
+services:
+  agenthound:
+    image: ghcr.io/adithyan-ak/agenthound-server:1.0.0
+EOF
   printf '%s\n' "$root"
+}
+
+fixture_checksum() {
+  local root=$1
+  (
+    cd "$root"
+    cksum install.sh README.md docs/getting-started/install.md \
+      docs/getting-started/quickstart.md docs/operator/deployment.md \
+      docker/docker-compose.public.yml | sort
+  )
 }
 
 expect_failure() {
@@ -77,6 +92,41 @@ sed -i.bak 's#/1\.0\.0/docker/#/1.0.1/docker/#' \
 rm "$compose_mismatch/docs/getting-started/quickstart.md.bak"
 expect_failure "mismatched documentation Compose pin" \
   bash "$compose_mismatch/scripts/version-check.sh"
+
+server_image_mismatch=$(new_fixture server-image-mismatch)
+sed -i.bak 's/agenthound-server:1\.0\.0/agenthound-server:1.0.1/' \
+  "$server_image_mismatch/docker/docker-compose.public.yml"
+rm "$server_image_mismatch/docker/docker-compose.public.yml.bak"
+expect_failure "mismatched Compose server image pin" \
+  bash "$server_image_mismatch/scripts/version-check.sh"
+
+server_image_missing=$(new_fixture server-image-missing)
+sed -i.bak '/agenthound-server:/d' "$server_image_missing/docker/docker-compose.public.yml"
+rm "$server_image_missing/docker/docker-compose.public.yml.bak"
+expect_failure "missing Compose server image pin" \
+  bash "$server_image_missing/scripts/version-check.sh"
+before_sync=$(fixture_checksum "$server_image_missing")
+expect_failure "sync with missing Compose server image pin" \
+  bash "$server_image_missing/scripts/sync-version.sh" 1.0.2
+after_sync=$(fixture_checksum "$server_image_missing")
+if [ "$before_sync" != "$after_sync" ]; then
+  echo "release-process-test: failed image-pin sync mutated a fixture" >&2
+  exit 1
+fi
+
+server_image_duplicate=$(new_fixture server-image-duplicate)
+printf '    image: ghcr.io/adithyan-ak/agenthound-server:1.0.0\n' \
+  >> "$server_image_duplicate/docker/docker-compose.public.yml"
+expect_failure "duplicate Compose server image pin" \
+  bash "$server_image_duplicate/scripts/version-check.sh"
+before_sync=$(fixture_checksum "$server_image_duplicate")
+expect_failure "sync with duplicate Compose server image pin" \
+  bash "$server_image_duplicate/scripts/sync-version.sh" 1.0.2
+after_sync=$(fixture_checksum "$server_image_duplicate")
+if [ "$before_sync" != "$after_sync" ]; then
+  echo "release-process-test: failed duplicate image-pin sync mutated a fixture" >&2
+  exit 1
+fi
 
 duplicate=$(new_fixture duplicate)
 printf '%s/1.0.0/install.sh\n' "$pin_base" >> "$duplicate/README.md"
@@ -108,6 +158,8 @@ sync=$(new_fixture sync)
 (sed -i.bak 's/## 1\.0\.0 —/## 1.0.2 —/' "$sync/CHANGELOG.md" && rm "$sync/CHANGELOG.md.bak")
 (cd "$sync" && bash scripts/sync-version.sh 1.0.2 >/dev/null)
 (cd "$sync" && RELEASE_CHECK=1 bash scripts/version-check.sh >/dev/null)
+grep -Fqx '    image: ghcr.io/adithyan-ak/agenthound-server:1.0.2' \
+  "$sync/docker/docker-compose.public.yml"
 
 notes=$(new_fixture notes)
 rendered=$(cd "$notes" && sh scripts/release-notes.sh CHANGELOG.md 1.0.0)

--- a/scripts/release-version-pins.sh
+++ b/scripts/release-version-pins.sh
@@ -17,6 +17,7 @@ environment|docs/getting-started/install.md|1
 compose|docs/getting-started/install.md|1
 compose|docs/getting-started/quickstart.md|1
 compose|docs/operator/deployment.md|2
+server-image|docker/docker-compose.public.yml|1
 EOF
 }
 
@@ -35,6 +36,9 @@ release_version_pin_pattern() {
       ;;
     readme-label)
       printf '%s' "Install the ${semver} static binary"
+      ;;
+    server-image)
+      printf '%s' "ghcr\.io/adithyan-ak/agenthound-server:${semver}"
       ;;
     *)
       echo "unknown release-version pin kind: $kind" >&2
@@ -57,6 +61,9 @@ release_version_pin_replacement() {
       ;;
     readme-label)
       printf 'Install the %s static binary' "$version"
+      ;;
+    server-image)
+      printf 'ghcr.io/adithyan-ak/agenthound-server:%s' "$version"
       ;;
     *)
       echo "unknown release-version pin kind: $kind" >&2

--- a/server/cli/ingest.go
+++ b/server/cli/ingest.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +17,12 @@ import (
 )
 
 var bootstrapForIngest = Bootstrap
+
+type ingestCompatibility struct {
+	CollectorVersion string
+	ContractVersion  int
+	ServerVersion    string
+}
 
 var ingestCmd = &cobra.Command{
 	Use:   "ingest <file.json | ->",
@@ -47,13 +54,42 @@ for generic automation that already has a complete ingest envelope on stdin:
 		}
 
 		version, err := ingest.DecodeVersion(data)
-		if err != nil || version != ingest.CurrentVersion {
-			return fmt.Errorf("unsupported V1 ingest contract")
+		if err != nil {
+			return fmt.Errorf(
+				"invalid ingest artifact; agenthound-server %s requires contract V%d: %w",
+				serverVersionDisplay(),
+				ingest.CurrentVersion,
+				err,
+			)
+		}
+		if version <= 0 {
+			return fmt.Errorf(
+				"invalid ingest artifact; agenthound-server %s requires a positive contract version and supports V%d",
+				serverVersionDisplay(),
+				ingest.CurrentVersion,
+			)
+		}
+		collectorVersion := decodeCollectorVersion(data)
+		if version != ingest.CurrentVersion {
+			return fmt.Errorf(
+				"artifact uses ingest contract V%d from collector %q; agenthound-server %s supports V%d; upgrade agenthound-server to a release that supports V%d",
+				version,
+				collectorVersion,
+				serverVersionDisplay(),
+				ingest.CurrentVersion,
+				version,
+			)
 		}
 
 		var ingestData ingest.IngestData
 		if err := ingest.DecodeStrict(bytes.NewReader(data), &ingestData); err != nil {
-			return fmt.Errorf("unsupported V1 ingest contract")
+			return fmt.Errorf(
+				"artifact from collector %q is not compatible with agenthound-server %s (supported contract V%d); upgrade the server or use a collector and server from one coordinated release: %w",
+				collectorVersion,
+				serverVersionDisplay(),
+				ingest.CurrentVersion,
+				err,
+			)
 		}
 		if err := serveringest.Preflight(&ingestData); err != nil {
 			return fmt.Errorf("ingest preflight: %w", err)
@@ -66,18 +102,50 @@ for generic automation that already has a complete ingest envelope on stdin:
 		defer cleanup()
 
 		result, ingestErr := infra.Pipeline.Ingest(ctx, &ingestData)
-		return finishIngestCommand(cmd.OutOrStdout(), result, ingestErr)
+		return finishIngestCommand(cmd.OutOrStdout(), result, ingestErr, ingestCompatibility{
+			CollectorVersion: ingestData.Meta.CollectorVersion,
+			ContractVersion:  ingestData.Meta.Version,
+			ServerVersion:    serverVersionDisplay(),
+		})
 	},
+}
+
+func decodeCollectorVersion(document []byte) string {
+	var envelope struct {
+		Meta *struct {
+			CollectorVersion string `json:"collector_version"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(document, &envelope); err != nil || envelope.Meta == nil {
+		return "unknown"
+	}
+	version := strings.TrimSpace(envelope.Meta.CollectorVersion)
+	if version == "" {
+		return "unknown"
+	}
+	return version
+}
+
+func serverVersionDisplay() string {
+	version := strings.TrimSpace(rootCmd.Version)
+	if version == "" {
+		return "dev"
+	}
+	return version
 }
 
 func finishIngestCommand(
 	w io.Writer,
 	result *ingest.IngestResult,
 	ingestErr error,
+	compatibility ingestCompatibility,
 ) error {
 	var resultErr error
 	if result != nil {
-		resultErr = writeIngestResult(w, result)
+		resultErr = writeIngestCompatibility(w, compatibility)
+		if resultErr == nil {
+			resultErr = writeIngestResult(w, result)
+		}
 	}
 	if ingestErr != nil {
 		// A write-stage failure can return a useful typed result and the original
@@ -90,6 +158,20 @@ func finishIngestCommand(
 		return fmt.Errorf("ingest returned no result")
 	}
 	return resultErr
+}
+
+func writeIngestCompatibility(w io.Writer, compatibility ingestCompatibility) error {
+	_, err := fmt.Fprintf(
+		w,
+		"Compatibility:\n  Collector version:  %q\n  Artifact contract:  V%d\n  Server version:     %s\n",
+		compatibility.CollectorVersion,
+		compatibility.ContractVersion,
+		compatibility.ServerVersion,
+	)
+	if err != nil {
+		return fmt.Errorf("write ingest compatibility: %w", err)
+	}
+	return nil
 }
 
 func writeIngestResult(w io.Writer, result *ingest.IngestResult) error {

--- a/server/cli/ingest_test.go
+++ b/server/cli/ingest_test.go
@@ -63,12 +63,15 @@ func TestIngestCommandRejectsUnsupportedV1ContractBeforeBootstrap(t *testing.T) 
 			if bootstrapCalled {
 				t.Fatal("Bootstrap ran before contract preflight")
 			}
-			if err == nil || err.Error() != "unsupported V1 ingest contract" {
-				t.Fatalf(
-					"error = %T %v, want generic unsupported V1 contract error",
-					err,
-					err,
-				)
+			if err == nil || !strings.Contains(err.Error(), "V1") {
+				t.Fatalf("error = %T %v, want supported contract diagnostic", err, err)
+			}
+			if name == "non-v1" {
+				for _, want := range []string{"contract V2", `collector "dev"`, "upgrade agenthound-server"} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error missing %q: %v", want, err)
+					}
+				}
 			}
 		})
 	}
@@ -126,6 +129,55 @@ func TestWriteIngestResultComplete(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestFinishIngestCommandReportsCompatibilityOnSuccess(t *testing.T) {
+	revision := int64(7)
+	result := &ingest.IngestResult{
+		ScanID:            "scan-compatible",
+		Outcome:           ingest.OutcomeComplete,
+		ProjectionStatus:  model.ProjectionComplete,
+		PublishedRevision: &revision,
+		Collection:        ingest.CollectionReport{State: ingest.OutcomeComplete},
+	}
+
+	var output bytes.Buffer
+	err := finishIngestCommand(&output, result, nil, ingestCompatibility{
+		CollectorVersion: "1.0.0",
+		ContractVersion:  ingest.CurrentVersion,
+		ServerVersion:    "1.1.1 (commit: test)",
+	})
+	if err != nil {
+		t.Fatalf("finishIngestCommand returned error: %v", err)
+	}
+	for _, want := range []string{
+		`Collector version:  "1.0.0"`,
+		"Artifact contract:  V1",
+		"Server version:     1.1.1 (commit: test)",
+		"Ingest complete",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestWriteIngestCompatibilityEscapesUntrustedCollectorVersion(t *testing.T) {
+	var output bytes.Buffer
+	err := writeIngestCompatibility(&output, ingestCompatibility{
+		CollectorVersion: "\x1b[31mdev\nspoof",
+		ContractVersion:  ingest.CurrentVersion,
+		ServerVersion:    "1.1.1",
+	})
+	if err != nil {
+		t.Fatalf("writeIngestCompatibility returned error: %v", err)
+	}
+	if strings.Contains(output.String(), "\x1b") || strings.Contains(output.String(), "dev\nspoof") {
+		t.Fatalf("compatibility output contains raw terminal controls: %q", output.String())
+	}
+	if !strings.Contains(output.String(), `"\x1b[31mdev\nspoof"`) {
+		t.Fatalf("compatibility output did not quote collector version: %q", output.String())
 	}
 }
 
@@ -231,11 +283,18 @@ func TestFinishIngestCommandRendersFailedResultAndPreservesPipelineError(t *test
 	}
 
 	var output bytes.Buffer
-	err := finishIngestCommand(&output, result, pipelineErr)
+	err := finishIngestCommand(&output, result, pipelineErr, ingestCompatibility{
+		CollectorVersion: "1.0.0",
+		ContractVersion:  ingest.CurrentVersion,
+		ServerVersion:    "1.1.1 (commit: test)",
+	})
 	if !errors.Is(err, pipelineErr) {
 		t.Fatalf("finish error = %v, want wrapped pipeline error", err)
 	}
 	for _, want := range []string{
+		`Collector version:  "1.0.0"`,
+		"Artifact contract:  V1",
+		"Server version:     1.1.1 (commit: test)",
 		"Ingest failed:",
 		"Scan ID:            scan-write-failure",
 		"Node write rows:    3",

--- a/server/internal/ingest/compatibility_test.go
+++ b/server/internal/ingest/compatibility_test.go
@@ -1,0 +1,66 @@
+package ingest
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sdkingest "github.com/adithyan-ak/agenthound/sdk/ingest"
+	"github.com/adithyan-ak/agenthound/server/model"
+)
+
+const (
+	historicalV1Fixture = "v1-tag-1.1.0-valid-mcp.json"
+	// This digest records the byte-for-byte provenance of
+	// testdata/valid_mcp_scan.json at the immutable 1.1.0 tag.
+	historicalV1FixtureSHA256 = "8ce201b5dfcf2ccb8269d327ad565209a6593a9a20c5a11ef2c5b09a3436b35d"
+)
+
+func decodeHistoricalV1Fixture(t *testing.T) *sdkingest.IngestData {
+	t.Helper()
+	path := filepath.Join("testdata", "compat", historicalV1Fixture)
+	document, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read historical V1 fixture: %v", err)
+	}
+	if digest := fmt.Sprintf("%x", sha256.Sum256(document)); digest != historicalV1FixtureSHA256 {
+		t.Fatalf("historical V1 fixture digest = %s, want %s", digest, historicalV1FixtureSHA256)
+	}
+
+	var data sdkingest.IngestData
+	if err := sdkingest.DecodeStrict(bytes.NewReader(document), &data); err != nil {
+		t.Fatalf("strictly decode historical V1 fixture: %v", err)
+	}
+	return &data
+}
+
+func TestHistoricalV1Tag110FixtureRemainsCompatible(t *testing.T) {
+	data := decodeHistoricalV1Fixture(t)
+	if data.Meta.Version != sdkingest.CurrentVersion {
+		t.Fatalf("artifact contract = V%d, want V%d", data.Meta.Version, sdkingest.CurrentVersion)
+	}
+	if data.Meta.CollectorVersion != "0.1.0" {
+		t.Fatalf("collector version = %q, want historical 0.1.0", data.Meta.CollectorVersion)
+	}
+	if err := NewValidator().Validate(data); err != nil {
+		t.Fatalf("validate historical V1 fixture: %v", err)
+	}
+}
+
+func TestIntegrationHistoricalV1Tag110Publishes(t *testing.T) {
+	ctx, pipeline, _, _, _ := publicationIntegrationHarness(t, false)
+	data := decodeHistoricalV1Fixture(t)
+
+	result, err := pipeline.Ingest(ctx, data)
+	if err != nil {
+		t.Fatalf("ingest historical V1 fixture: %v", err)
+	}
+	if result.Outcome != sdkingest.OutcomeComplete ||
+		result.ProjectionStatus != model.ProjectionComplete ||
+		result.PublishedRevision == nil {
+		t.Fatalf("historical V1 publication result = %+v", result)
+	}
+}

--- a/server/internal/ingest/testdata/compat/v1-tag-1.1.0-valid-mcp.json
+++ b/server/internal/ingest/testdata/compat/v1-tag-1.1.0-valid-mcp.json
@@ -1,0 +1,181 @@
+{
+  "meta": {
+    "version": 1,
+    "type": "agenthound-ingest",
+    "identity": {"scheme":"agenthound_collection_v1","version":1,"collection_point_id":"sha256:e6336f15741e16f96744c54acd80daf85747bbb7c2b61e50cc4427317dda797a","network_context_id":"sha256:2c5259a97214a5ab63f8838345e49160950c61f9310bb947f9cf3f3ceeca043a","quality":"strong","network_quality":"strong","network_class":"private","evidence":[{"kind":"os_instance","digest":"hmac-sha256:1111111111111111111111111111111111111111111111111111111111111111"},{"kind":"principal","digest":"hmac-sha256:2222222222222222222222222222222222222222222222222222222222222222"}],"network_evidence":[{"kind":"route_private","digest":"hmac-sha256:3333333333333333333333333333333333333333333333333333333333333333"}]},
+    "collector": "mcp",
+    "collector_version": "0.1.0",
+    "timestamp": "2026-04-07T10:00:00Z",
+    "scan_id": "scan-mcp-001",
+    "collection": {
+      "state": "complete",
+      "coverage_keys": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"],
+      "outcomes": [{
+        "collector": "mcp",
+        "coverage_key": "mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267",
+        "target": "valid-mcp",
+        "method": "fixture",
+        "state": "complete",
+        "items": 5
+      }]
+    },
+    "ruleset": {
+      "digest": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e64a8f8bff093b2f5f2cf4e",
+      "entries": [],
+      "load_state": "complete",
+      "errors": [],
+      "authenticity": "unverified"
+    },
+    "identity_schemes": [{
+      "entity_kind": "MCPServer",
+      "transport": "stdio",
+      "scheme": "mcp_stdio_v1_hashed_argv",
+      "version": 1
+    }]
+  },
+  "graph": {
+    "nodes": [
+      {
+        "id": "sha256:509a1d13d8f91f03a8c9d389c392a08323c5d6b731ab6f29a9ed15f5cbaa8bd8",
+        "kinds": ["MCPServer"],
+        "properties": {
+          "name": "postgres-server",
+          "transport": "stdio",
+          "command": "npx",
+          "arg_hashes": ["sha256:a01cf5b8e65799111f549b4245b226642e4fb78561e4a7bb738dab94f812c68a", "sha256:64274e858605926f9602c5b5a75dd19cc222cfb50c7101ab56bfeed597b6e023"],
+          "arg_count": 2,
+          "id_scheme": "mcp_stdio_v1_hashed_argv",
+          "protocol_version": "2025-03-26",
+          "instructions": "PostgreSQL database access server",
+          "capabilities": ["tools", "resources"],
+          "auth_method": "unknown",
+          "auth_assurance": "unknown",
+          "auth_evidence": "unknown",
+          "is_pinned": false,
+          "objectid": "sha256:509a1d13d8f91f03a8c9d389c392a08323c5d6b731ab6f29a9ed15f5cbaa8bd8"
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      },
+      {
+        "id": "sha256:8d6603e56f345041b9362fe8d36f69bbeb4c6b809526eefbcd664abbcb259d91",
+        "kinds": ["MCPTool"],
+        "properties": {
+          "name": "execute_sql",
+          "description": "Execute a SQL query against the connected PostgreSQL database",
+          "input_schema": "{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]}",
+          "description_hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+          "capability_surface": ["database_access"],
+          "has_injection_patterns": false,
+          "has_cross_references": false,
+          "objectid": "sha256:8d6603e56f345041b9362fe8d36f69bbeb4c6b809526eefbcd664abbcb259d91"
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      },
+      {
+        "id": "sha256:9ceb5db7191c9f325b715c1bd547b68dee153f9c02a7531f85fdd6aedd2d8ec1",
+        "kinds": ["MCPTool"],
+        "properties": {
+          "name": "list_tables",
+          "description": "List all tables in the connected PostgreSQL database",
+          "input_schema": "{\"type\":\"object\",\"properties\":{}}",
+          "description_hash": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+          "capability_surface": ["database_access"],
+          "has_injection_patterns": false,
+          "has_cross_references": false,
+          "objectid": "sha256:9ceb5db7191c9f325b715c1bd547b68dee153f9c02a7531f85fdd6aedd2d8ec1"
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      },
+      {
+        "id": "sha256:511648784420415b23e27c7cf1e110c1d4421a202b3e09448a54d00771b36e90",
+        "kinds": ["MCPTool"],
+        "properties": {
+          "name": "get_schema",
+          "description": "Get the schema of a specific table in the PostgreSQL database",
+          "input_schema": "{\"type\":\"object\",\"properties\":{\"table\":{\"type\":\"string\"}},\"required\":[\"table\"]}",
+          "description_hash": "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+          "capability_surface": ["database_access"],
+          "has_injection_patterns": false,
+          "has_cross_references": false,
+          "objectid": "sha256:511648784420415b23e27c7cf1e110c1d4421a202b3e09448a54d00771b36e90"
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      },
+      {
+        "id": "sha256:ddfab567d28431bff228ee6a7312ff3c4f7cf0aaf1ec542fd29897d3256d00d6",
+        "kinds": ["MCPResource"],
+        "properties": {
+          "uri": "postgres://prod-db:5432/customers",
+          "name": "customers-database",
+          "mime_type": "application/x-postgresql",
+          "uri_scheme": "postgres",
+          "sensitivity": "critical",
+          "objectid": "sha256:ddfab567d28431bff228ee6a7312ff3c4f7cf0aaf1ec542fd29897d3256d00d6"
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      }
+    ],
+    "edges": [
+      {
+        "source": "sha256:509a1d13d8f91f03a8c9d389c392a08323c5d6b731ab6f29a9ed15f5cbaa8bd8",
+        "target": "sha256:8d6603e56f345041b9362fe8d36f69bbeb4c6b809526eefbcd664abbcb259d91",
+        "kind": "PROVIDES_TOOL",
+        "source_kind": "MCPServer",
+        "target_kind": "MCPTool",
+        "properties": {
+          "scan_id": "scan-mcp-001",
+          "last_seen": "2026-04-07T10:00:00Z",
+          "confidence": 1.0,
+          "risk_weight": 0.1,
+          "is_composite": false
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      },
+      {
+        "source": "sha256:509a1d13d8f91f03a8c9d389c392a08323c5d6b731ab6f29a9ed15f5cbaa8bd8",
+        "target": "sha256:9ceb5db7191c9f325b715c1bd547b68dee153f9c02a7531f85fdd6aedd2d8ec1",
+        "kind": "PROVIDES_TOOL",
+        "source_kind": "MCPServer",
+        "target_kind": "MCPTool",
+        "properties": {
+          "scan_id": "scan-mcp-001",
+          "last_seen": "2026-04-07T10:00:00Z",
+          "confidence": 1.0,
+          "risk_weight": 0.1,
+          "is_composite": false
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      },
+      {
+        "source": "sha256:509a1d13d8f91f03a8c9d389c392a08323c5d6b731ab6f29a9ed15f5cbaa8bd8",
+        "target": "sha256:511648784420415b23e27c7cf1e110c1d4421a202b3e09448a54d00771b36e90",
+        "kind": "PROVIDES_TOOL",
+        "source_kind": "MCPServer",
+        "target_kind": "MCPTool",
+        "properties": {
+          "scan_id": "scan-mcp-001",
+          "last_seen": "2026-04-07T10:00:00Z",
+          "confidence": 1.0,
+          "risk_weight": 0.1,
+          "is_composite": false
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      },
+      {
+        "source": "sha256:509a1d13d8f91f03a8c9d389c392a08323c5d6b731ab6f29a9ed15f5cbaa8bd8",
+        "target": "sha256:ddfab567d28431bff228ee6a7312ff3c4f7cf0aaf1ec542fd29897d3256d00d6",
+        "kind": "PROVIDES_RESOURCE",
+        "source_kind": "MCPServer",
+        "target_kind": "MCPResource",
+        "properties": {
+          "scan_id": "scan-mcp-001",
+          "last_seen": "2026-04-07T10:00:00Z",
+          "confidence": 1.0,
+          "risk_weight": 0.2,
+          "is_composite": false
+        },
+        "observation_domains": ["mcp:fixture:sha256:b45789dcd85e58b98e62ebc088142e4d53ffdc72f5e065fa12c4f9423db48267"]
+      }
+    ]
+  }
+}

--- a/server/internal/ingest/validator.go
+++ b/server/internal/ingest/validator.go
@@ -27,7 +27,10 @@ func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation failed: %d errors", len(e.Errors))
 }
 
-const produceV1ArtifactAction = "produce a V1 artifact with the same collector and server build"
+const (
+	upgradeServerForArtifactAction  = "upgrade agenthound-server to a release that supports this artifact contract"
+	produceCompatibleRegistryAction = "produce a V1 artifact with a compatible instruction registry contract"
+)
 
 type UnsupportedVersionError struct {
 	Received  int    `json:"received_version"`
@@ -87,7 +90,7 @@ func Preflight(data *ingest.IngestData) error {
 		return &UnsupportedVersionError{
 			Received:  data.Meta.Version,
 			Supported: ingest.CurrentVersion,
-			Action:    produceV1ArtifactAction,
+			Action:    upgradeServerForArtifactAction,
 		}
 	}
 	if _, legacyCampaign := data.Meta.Extra["campaign_artifact"]; legacyCampaign {
@@ -594,7 +597,7 @@ func preflightRegistryContracts(report *ingest.CollectionReport) error {
 				RootCoverageKey: root.CoverageKey,
 				Received:        cloneRegistryContract(root.RegistryContract),
 				Supported:       current,
-				Action:          produceV1ArtifactAction,
+				Action:          produceCompatibleRegistryAction,
 			}
 		}
 		rootState := stateByRoot[root.CoverageKey]

--- a/server/internal/ingest/validator_test.go
+++ b/server/internal/ingest/validator_test.go
@@ -1008,6 +1008,9 @@ func TestValidatorRejectsBadVersion(t *testing.T) {
 	if !strings.Contains(versionErr.Error(), "requires version 1") {
 		t.Fatalf("version error is not actionable: %v", versionErr)
 	}
+	if !strings.Contains(versionErr.Action, "upgrade agenthound-server") {
+		t.Fatalf("version action is not actionable: %q", versionErr.Action)
+	}
 }
 
 func TestValidatorRejectsMissingVersion(t *testing.T) {


### PR DESCRIPTION
## Summary

- pin public Compose to the coordinated server release and validate it through release version tooling
- promote, sign, and verify immutable production images before publishing GitHub releases
- preserve V1 backward compatibility with actionable ingest diagnostics and a frozen historical publication fixture
- document the coordinated release and contract compatibility policy

## Validation

- make check
- make version-check
- strict MkDocs build
- actionlint for modified workflows
- shell syntax and Docker Compose validation
- historical fixture provenance check

The database-backed historical publication test is wired into the existing isolated Neo4j 4 and 5 CI matrix.