### PR TITLE
docs: improve installation and deployment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **MCP · A2A · agent clients · model gateways · inference servers · vector stores · MLOps · notebooks**
 
-[![DEF CON 34 · Red Team Village](https://img.shields.io/badge/🎤_DEF_CON_34-Red_Team_Village-E4002B?style=for-the-badge)](https://redteamvillage.io/)
+<a href="https://redteamvillage.io/"><img src="https://img.shields.io/badge/🎤_DEF_CON_34-Red_Team_Village-E4002B?style=for-the-badge" alt="DEF CON 34 · Red Team Village" height="28"></a> <a href="https://trendshift.io/repositories/96078?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-96078" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/96078" alt="adithyan-ak/AgentHound | Trendshift" height="28"></a>
 
 [Quickstart](#-quick-start) ·
 [Capabilities](#-offensive-capabilities) ·
@@ -131,20 +131,22 @@ brew install adithyan-ak/agenthound/agenthound
 ```
 
 The collector has no Neo4j, PostgreSQL, Node.js, or server dependency.
+The shell installer supports macOS and Linux on amd64 or arm64. Windows builds
+are available from [GitHub Releases](https://github.com/adithyan-ak/AgentHound/releases).
 
 ### 2. Run one scan
 
 Start with the compromised host and everything it can immediately reveal:
 
 ```bash
-agenthound scan
+agenthound scan --output scan.json
 ```
 
 Add a host, CIDR, or targets file without disabling local collection:
 
 ```bash
-agenthound scan 10.20.0.0/24
-agenthound scan @targets.txt --deep --exclude 10.20.0.15
+agenthound scan 10.20.0.0/24 --output scan.json
+agenthound scan @targets.txt --deep --exclude 10.20.0.15 --output scan.json
 ```
 
 Choose the mode that matches the operation:
@@ -156,12 +158,12 @@ Choose the mode that matches the operation:
 | `agenthound scan --stealth` | Anonymous and exact configured read-only collection; no cross-target credential reuse, model invocation, tool invocation, or mutation |
 | `agenthound scan --stealth --deep` | Adds deep filesystem and payload reads while retaining stealth restrictions |
 
-The result is `scan-<scan_id>.json` unless `--output` selects another file. Concrete credentials and collected content are stored directly in the artifact; treat it as operationally sensitive.
+These commands are alternatives and write `scan.json`. Without `--output`, the result is `scan-<scan_id>.json`. An explicit output path replaces an existing file, so use a new name for each scan. Concrete credentials and collected content are stored directly in the artifact; treat it as operationally sensitive.
 
 If the final summary reports unresolved cleanup, preserve the artifact and retry safely:
 
 ```bash
-agenthound revert scan-<scan_id>.json
+agenthound revert scan.json
 ```
 
 ### 3. Analyze the attack graph
@@ -174,16 +176,16 @@ curl -sSfL \
   -o agenthound-compose.yml
 docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 docker compose -f agenthound-compose.yml -p agenthound exec -T agenthound \
-  agenthound-server ingest - < scan-6c6306d5.json
+  agenthound-server ingest - < scan.json
 ```
 
 Open [http://127.0.0.1:8080](http://127.0.0.1:8080/) to inspect findings, attack paths, credentials, risk, queries, scan history, and triage.
 
-Collector and server are released as one coordinated version. Compose files
-created under the current release policy pin that exact server image; historical
-releases through `1.1.1` retain their original `latest` reference. The current
-server accepts supported historical V1 artifacts; upgrade the server if a newer
-artifact reports an unsupported ingest contract.
+Use the collector and server from the same release. Releases after `1.1.1` pin
+the exact server image in Compose; older Compose files retain their historical
+`latest` reference. A current server accepts supported older V1 artifacts. If
+ingest reports an unsupported contract, upgrade the server instead of editing
+the artifact.
 
 <p align="center">
   <img src="docs/readme-assets/agenthound-dashboard.png" alt="AgentHound attack-surface dashboard" width="900">

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -2,6 +2,15 @@
 
 Install the collector on the system where the scan will run. Deploy the analysis server only where you want to ingest and inspect artifacts.
 
+## Requirements
+
+| Goal | Supported environment |
+|---|---|
+| Install with the shell installer | macOS or Linux on amd64 or arm64, with a POSIX shell, `curl`, `tar`, and either `sha256sum` or `shasum` |
+| Install with Homebrew | macOS or Linux with Homebrew |
+| Install on Windows | Download the amd64 or arm64 zip from [GitHub Releases](https://github.com/adithyan-ak/AgentHound/releases) and place `agenthound.exe` on `PATH` |
+| Run the analysis stack | Docker with Compose v2 |
+
 ## Collector
 
 The release installer selects the platform archive and installs `agenthound` under `$HOME/.local/bin` by default:
@@ -34,16 +43,20 @@ docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 
 Open `http://127.0.0.1:8080`. The server binds to loopback by default.
 
-Use the matching collector and server release by default. Exact Compose image
-pinning starts with the first release after `1.1.1`; older immutable Compose
-files retain their historical `latest` reference. The collector still runs
-offline and does not need a live server while it scans.
+Use the collector and server from the same release. Releases after `1.1.1` pin
+the exact server image in Compose. Older Compose files retain their historical
+`latest` reference. The collector still runs offline and does not need a live
+server while it scans.
 
 Homebrew packages the server separately:
 
 ```bash
 brew install adithyan-ak/agenthound/agenthound-server
 ```
+
+Homebrew installs only the server binary. You must provide Neo4j and PostgreSQL
+and configure the [server connection settings](../reference/configuration.md#analysis-server)
+yourself. Use Docker Compose unless you already operate those databases.
 
 ## Build from source
 
@@ -58,14 +71,38 @@ The binaries are written to `bin/`. Building the server also builds and embeds t
 
 ## Verify a release
 
-Release archives include checksums, a Sigstore bundle, and SPDX SBOMs. Verify the checksum bundle with cosign:
+The installer always verifies the selected archive against `checksums.txt`. If
+`cosign` is on `PATH`, it also downloads and verifies the Sigstore bundle.
+
+To verify the signed checksum file yourself, download both files from the same
+release and run:
 
 ```bash
+VERSION="$(agenthound --version | awk '{print $3}')"
+BASE_URL="https://github.com/adithyan-ak/AgentHound/releases/download/$VERSION"
+curl -sSfLO "$BASE_URL/checksums.txt"
+curl -sSfLO "$BASE_URL/checksums.txt.sigstore.json"
 cosign verify-blob \
   --bundle checksums.txt.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/adithyan-ak/AgentHound/.*' \
-  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --certificate-identity "https://github.com/adithyan-ak/AgentHound/.github/workflows/release.yml@refs/tags/$VERSION" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   checksums.txt
 ```
+
+Release archives also include SPDX SBOMs.
+
+## Upgrade or remove the collector
+
+To upgrade an installer-managed collector, rerun the pinned install command with
+the desired version. For Homebrew, run `brew upgrade agenthound`.
+
+Remove the default installer-managed binary with:
+
+```bash
+rm -f "$HOME/.local/bin/agenthound"
+```
+
+For Homebrew installations, run `brew uninstall agenthound` or
+`brew uninstall agenthound-server`.
 
 Continue with the [Quickstart](quickstart.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -5,7 +5,7 @@
 An active targetless scan is the fastest useful starting point:
 
 ```bash
-agenthound scan
+agenthound scan --output scan.json
 ```
 
 It collects local MCP configuration, instruction sources, and credentials; seeds loopback, active local interfaces, and configured endpoints; discovers supported AI services; and runs eligible same-scan access proofs.
@@ -13,24 +13,28 @@ It collects local MCP configuration, instruction sources, and credentials; seeds
 Add network scope when needed:
 
 ```bash
-agenthound scan 10.20.0.0/24
-agenthound scan @targets.txt --deep --exclude 10.20.0.15
+agenthound scan 10.20.0.0/24 --output scan.json
+agenthound scan @targets.txt --deep --exclude 10.20.0.15 --output scan.json
 ```
 
 Use stealth mode when the operation must remain read-only:
 
 ```bash
-agenthound scan --stealth
+agenthound scan --stealth --output scan.json
 ```
 
 ## 2. Preserve the result
 
-The collector continuously updates `scan-<scan_id>.json`. The artifact contains the collected graph, raw credential values, action outcomes, and any recovery records.
+Choose one of the commands above. Each continuously updates `scan.json`.
+Without `--output`, the collector writes `scan-<scan_id>.json`. An explicit
+output path replaces an existing file, so use a new name for each scan. The
+artifact contains the collected graph, raw credential values, action outcomes,
+and any recovery records.
 
 The final summary reports nodes, edges, actions, and unresolved cleanup. If cleanup needs another attempt, keep the artifact and run:
 
 ```bash
-agenthound revert scan-<scan_id>.json
+agenthound revert scan.json
 ```
 
 ## 3. Ingest for full analysis
@@ -48,10 +52,15 @@ Move the artifact to that system and ingest it:
 
 ```bash
 docker compose -f agenthound-compose.yml -p agenthound exec -T agenthound \
-  agenthound-server ingest - < scan-6c6306d5.json
+  agenthound-server ingest - < scan.json
 ```
 
-If `agenthound-server` is installed directly on the analysis host, use `agenthound-server ingest scan-6c6306d5.json` instead.
+If `agenthound-server` is installed directly on the analysis host, use `agenthound-server ingest scan.json` instead.
+
+The ingest result reports the collector version, artifact contract, and server
+version. An unsupported-contract error reports the same compatibility details
+before database initialization. Upgrade the server instead of editing the
+artifact.
 
 Open `http://127.0.0.1:8080` to inspect attack paths, findings, risk, queries, history, and triage. Credential values are masked in the normal property view and remain available through Reveal and Copy.
 

--- a/docs/operator/deployment.md
+++ b/docs/operator/deployment.md
@@ -29,6 +29,22 @@ curl -fsS http://127.0.0.1:8080/api/v1/health
 
 For a source checkout, use `docker compose -f docker/docker-compose.yml up -d --wait`.
 
+### Database credentials
+
+The published file uses development credentials and keeps every port on
+loopback. Before the first start of a shared or remotely accessible deployment,
+edit the downloaded file and change all matching credential references:
+
+- `NEO4J_AUTH`
+- the Neo4j health check password after `-p`
+- `POSTGRES_PASSWORD`
+- `AGENTHOUND_NEO4J_PASSWORD`
+- the password inside `AGENTHOUND_PG_URI`
+
+Database images apply their initialization credentials only when creating a new
+volume. If the volumes already contain data, follow the Neo4j and PostgreSQL
+password-rotation procedures instead of changing only the Compose environment.
+
 ## Remote access
 
 Prefer an SSH tunnel when one operator needs remote access:
@@ -39,11 +55,15 @@ ssh -L 8080:localhost:8080 operator@analysis-box
 
 Then open `http://localhost:8080` locally.
 
-For a private mesh, bind the host port on the mesh interface and restrict it with Tailscale ACLs, WireGuard AllowedIPs, or equivalent firewall policy. For a shared HTTPS endpoint, place the loopback server behind an authenticated reverse proxy such as mTLS and set:
+For a private mesh, bind the host port on the mesh interface and restrict it with Tailscale ACLs, WireGuard AllowedIPs, or equivalent firewall policy. For a shared HTTPS endpoint, place the loopback server behind an authenticated reverse proxy such as mTLS. Add the browser origin under the `agenthound` service's `environment` block in the downloaded Compose file:
 
-```bash
-AGENTHOUND_CORS_ORIGINS=https://agenthound.internal
+```yaml
+environment:
+  AGENTHOUND_CORS_ORIGINS: https://agenthound.internal
 ```
+
+When running the server binary directly, export the same variable before
+`agenthound-server serve`.
 
 OriginGuard protects browser mutations from unapproved origins; it is not user authentication. Requests from local processes without an `Origin` header remain inside the server's trust boundary.
 
@@ -51,19 +71,25 @@ OriginGuard protects browser mutations from unapproved origins; it is not user a
 
 Neo4j holds the graph projection. PostgreSQL holds scan lifecycle, finding snapshots, triage, coverage heads, and publication revisions. The server writes a shared binding marker to both stores and refuses to start against a crossed pair.
 
-Back up and restore both databases as one coordinated set. For the source Compose file:
+Back up and restore both databases as one coordinated set. Stop the AgentHound
+service first so neither store changes between snapshots. Neo4j 4.4 dump also
+requires the database to be offline:
 
 ```bash
-mkdir -p backups
-docker compose -f docker/docker-compose.yml exec graph-db \
-  neo4j-admin dump --database=neo4j --to=/tmp/neo4j.dump
-docker compose -f docker/docker-compose.yml cp \
-  graph-db:/tmp/neo4j.dump backups/neo4j.dump
-docker compose -f docker/docker-compose.yml exec -T app-db \
-  pg_dump -U agenthound agenthound > backups/postgres.sql
+agenthound_backup_dir="backups/$(date -u +%Y%m%dT%H%M%SZ)"
+install -d -m 700 "$agenthound_backup_dir"
+docker compose -f agenthound-compose.yml -p agenthound stop agenthound
+docker compose -f agenthound-compose.yml -p agenthound exec -T app-db \
+  pg_dump -U agenthound agenthound > "$agenthound_backup_dir/postgres.sql"
+docker compose -f agenthound-compose.yml -p agenthound stop graph-db
+docker compose -f agenthound-compose.yml -p agenthound run --rm --no-deps -T \
+  graph-db neo4j-admin dump --database=neo4j --to=- > "$agenthound_backup_dir/neo4j.dump"
+docker compose -f agenthound-compose.yml -p agenthound up -d --wait
 ```
 
-Use the same timestamp or release identifier for both files. Test restores on an isolated stack before depending on them operationally.
+The command keeps both files under one timestamp. They can contain sensitive
+data. Test the database-vendor restore procedures on an isolated stack before
+depending on them operationally.
 
 ## Upgrade
 
@@ -84,22 +110,47 @@ The server applies PostgreSQL migrations and Neo4j schema initialization during 
 
 ## Collector and server compatibility
 
-AgentHound publishes the collector and server together under one product
-version. For releases created under this policy, the installation examples pin
-that matching pair so a deployment does not depend on mutable image aliases.
+AgentHound releases the collector and server together under one product version.
+Use the matching pair unless you are intentionally testing another combination.
 
-Artifact admission is based on the ingest contract, not exact binary version
-equality. The current server accepts supported historical V1 artifacts,
-including artifacts whose `collector_version` is older. An older server is not
-guaranteed to understand artifacts from a newer collector; when ingest reports
-an unsupported contract or structure, upgrade the server. Additive V1 changes
-must remain optional and backward-compatible. A breaking wire-format change
-requires a new contract version such as V2.
+| Combination | Support |
+|---|---|
+| Collector and server from the same release | Recommended and tested together |
+| Older V1 artifact ingested by a current server | Supported |
+| Newer artifact ingested by an older server | Not guaranteed; upgrade the server |
+| Breaking artifact change | Requires a new contract version, such as V2 |
 
-Exact server-image pinning applies to releases created after this policy was
-introduced. Historical tags `1.0.0` through `1.1.1` retain their original
-Compose file, which referenced the mutable `latest` image; those immutable Git
-tags are not rewritten.
+Compatibility follows the artifact contract, not exact binary-version equality.
+The `collector_version` is diagnostic information. Releases after `1.1.1` pin
+the exact server image in Compose. Immutable Compose files from `1.0.0` through
+`1.1.1` keep their original `latest` reference.
+
+## Stop or remove the stack
+
+Stop and remove the containers while retaining both database volumes:
+
+```bash
+docker compose -f agenthound-compose.yml -p agenthound down
+```
+
+To permanently delete the AgentHound containers and both database volumes, run:
+
+```bash
+docker compose -f agenthound-compose.yml -p agenthound down -v
+```
+
+The second command deletes scan history, findings, triage, and the graph. Back
+up both databases first if any of that data must be retained.
+
+## Troubleshooting
+
+If startup or upgrade does not become healthy, inspect service state and recent
+logs:
+
+```bash
+docker compose -f agenthound-compose.yml -p agenthound ps
+docker compose -f agenthound-compose.yml -p agenthound logs --tail=100 agenthound graph-db app-db
+```
 
 ## Capacity
 
@@ -110,7 +161,7 @@ PostgreSQL normally needs no special tuning beyond durable storage and regular b
 ## Operational checklist
 
 - Keep API, Neo4j, and PostgreSQL on loopback or a protected private network.
-- Change the default database credentials before shared deployment.
+- Change every matching database credential before the first shared deployment.
 - Configure `AGENTHOUND_CORS_ORIGINS` for the browser URL.
 - Back up PostgreSQL and Neo4j together.
 - Store scan artifacts with restricted permissions; they can contain raw credentials and collected service content.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,7 @@ Local configuration, instruction, and credential collection always runs. One pos
 | `--deep` | `false` | Add bounded recursive and high-cost evidence collection. |
 | `--exclude <value>` | none | Exclude an exact hostname, IP, or CIDR; repeatable. |
 | `--insecure` | `false` | Skip TLS certificate verification. |
-| `--output <path>` | `scan-<scan_id>.json` | Write the artifact to a file. Directories and `-` are rejected. |
+| `--output <path>` | `scan-<scan_id>.json` | Write the artifact to a file, replacing an existing file at that path. Directories and `-` are rejected. |
 | `--quiet` | `false` | Suppress non-error progress, discovered-secret output, and instruction-signal excerpts. |
 | `--stealth` | `false` | Keep the scan read-only and disable credential reuse and active probes. |
 | `--timeout <duration>` | `15m` | Set the overall scan deadline. |
@@ -70,8 +70,13 @@ Starts the REST API and embedded dashboard after validating the PostgreSQL and N
 Ingests a complete JSON envelope from a file. `-` reads a complete envelope from standard input for automation.
 
 ```bash
-agenthound-server ingest scan-6c6306d5.json
+agenthound-server ingest scan.json
 ```
+
+A completed ingest prints the collector version, artifact contract, and running
+server version. Unsupported-contract errors include the same compatibility
+details, reject the artifact before database bootstrap or writes, and tell the
+operator to upgrade the server.
 
 ### `agenthound-server query`
 

--- a/install.sh
+++ b/install.sh
@@ -132,14 +132,11 @@ if command -v cosign >/dev/null 2>&1; then
 else
   cat <<EOF >&2
 
-NOTE: cosign not found on PATH; skipping signature verification.
-To verify manually, install cosign and run:
+NOTE: cosign not found on PATH. The archive checksum was verified, but the
+release signature was not. Install cosign before rerunning this installer if
+signature verification is required.
 
-  cosign verify-blob \\
-    --bundle ${BASE_URL}/checksums.txt.sigstore.json \\
-    --certificate-identity 'https://github.com/${GITHUB_REPO}/.github/workflows/release.yml@refs/tags/${VERSION}' \\
-    --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
-    checksums.txt
+See https://docs.agenthound.io/getting-started/install/#verify-a-release
 
 EOF
 fi


### PR DESCRIPTION
## Summary

- make the README and quickstart copy-paste flow deterministic and document output replacement
- clarify supported platforms, Homebrew server dependencies, release pairing, upgrades, removal, and signed-release verification
- document Compose credential changes, effective CORS configuration, coordinated offline backups, safe stack removal, and troubleshooting
- add the Trendshift repository badge beside the DEF CON badge at the same rendered height
- replace the installer manual-verification hint that referenced temporary or remote files incorrectly

## Validation

- `.venv/bin/mkdocs build --strict`
- `make version-check`
- `make installer-test`
- `sh -n install.sh`
- `docker compose -f docker/docker-compose.public.yml config --quiet`
- `git diff --check`
- real Cosign verification against the 1.1.1 release assets: `Verified OK`
- GitHub GFM render check for inline badge placement and sizing