### PR TITLE
fix(collectors): stop serial walks on cancellation

### DIFF
--- a/modules/mlflowcollect/collector.go
+++ b/modules/mlflowcollect/collector.go
@@ -104,10 +104,16 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 		props["experiment_count"] = len(experiments)
 		markAnonymousInventorySuccess(props)
 	}
+	if ctx.Err() != nil {
+		return res, nil
+	}
 
 	// 2. /runs/search per experiment (paginated).
 	var totalRuns int
 	for _, exp := range experiments {
+		if ctx.Err() != nil {
+			break
+		}
 		runs, err := fetchRuns(ctx, client, baseURL, exp.ID, maxItems)
 		res.Summary.EndpointsProbed++
 		if err != nil {
@@ -117,6 +123,9 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 		totalRuns += len(runs)
 	}
 	res.IngestData.Graph.Nodes[0].Properties["total_runs"] = totalRuns
+	if ctx.Err() != nil {
+		return res, nil
+	}
 
 	// 3. Model Registry: registered-models/search + model-versions/search
 	//    + per-version get-download-uri. All GET, all paginated. Any
@@ -136,6 +145,9 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 		}
 		res.IngestData.Graph.Nodes[0].Properties["registered_models"] = names
 	}
+	if ctx.Err() != nil {
+		return res, nil
+	}
 
 	versions, verErr := fetchModelVersions(ctx, client, baseURL, maxItems)
 	res.Summary.EndpointsProbed++
@@ -146,11 +158,17 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 	} else {
 		res.IngestData.Graph.Nodes[0].Properties["model_version_count"] = len(versions)
 	}
+	if ctx.Err() != nil {
+		return res, nil
+	}
 
 	// For each model version, fetch the download URI and emit an
 	// :MCPResource + PROVIDES_RESOURCE edge. Individual failures are
 	// per-version partials — one bad model shouldn't kill the walk.
 	for _, v := range versions {
+		if ctx.Err() != nil {
+			break
+		}
 		uri, err := fetchDownloadURI(ctx, client, baseURL, v.Name, v.Version)
 		res.Summary.EndpointsProbed++
 		if err != nil {

--- a/modules/mlflowcollect/collector_test.go
+++ b/modules/mlflowcollect/collector_test.go
@@ -10,7 +10,9 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/adithyan-ak/agenthound/modules/mlflowfp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
@@ -490,5 +492,92 @@ func TestCollect_MLflow_RegistryPartialFailure(t *testing.T) {
 	// Registry probes recorded as partials.
 	if res.Summary.PartialFailures < 2 {
 		t.Errorf("partial failures: got %d, want at least 2 (registered-models + model-versions)", res.Summary.PartialFailures)
+	}
+}
+
+func TestCollect_CancellationStopsPerItemWalks(t *testing.T) {
+	tests := []struct {
+		name            string
+		cancelPath      string
+		experimentsBody string
+		versionsBody    string
+		wantProbes      int
+	}{
+		{
+			name:            "runs",
+			cancelPath:      "/api/2.0/mlflow/runs/search",
+			experimentsBody: `{"experiments":[{"experiment_id":"1"},{"experiment_id":"2"},{"experiment_id":"3"}]}`,
+			versionsBody:    `{"model_versions":[]}`,
+			wantProbes:      3,
+		},
+		{
+			name:            "download URI",
+			cancelPath:      "/api/2.0/mlflow/model-versions/get-download-uri",
+			experimentsBody: `{"experiments":[]}`,
+			versionsBody:    `{"model_versions":[{"name":"one","version":"1"},{"name":"two","version":"1"},{"name":"three","version":"1"}]}`,
+			wantProbes:      5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			started := make(chan struct{})
+			requestRelease := make(chan struct{})
+			var canceledCalls atomic.Int32
+			var signalOnce sync.Once
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == tc.cancelPath {
+					canceledCalls.Add(1)
+					signalOnce.Do(func() { close(started) })
+					<-requestRelease
+					return
+				}
+				switch r.URL.Path {
+				case "/api/2.0/mlflow/experiments/search":
+					_, _ = w.Write([]byte(tc.experimentsBody))
+				case "/api/2.0/mlflow/registered-models/search":
+					_, _ = w.Write([]byte(`{"registered_models":[]}`))
+				case "/api/2.0/mlflow/model-versions/search":
+					_, _ = w.Write([]byte(tc.versionsBody))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan *action.CollectResult, 1)
+			go func() {
+				res, _ := (&Collector{}).Collect(ctx, action.Target{
+					Kind:    "host",
+					Address: strings.TrimPrefix(srv.URL, "http://"),
+				}, action.CollectOptions{})
+				done <- res
+			}()
+
+			select {
+			case <-started:
+				cancel()
+				close(requestRelease)
+			case <-time.After(2 * time.Second):
+				cancel()
+				close(requestRelease)
+				t.Fatalf("request to %s did not start", tc.cancelPath)
+			}
+
+			var res *action.CollectResult
+			select {
+			case res = <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("Collect did not return after cancellation")
+			}
+			if got := canceledCalls.Load(); got != 1 {
+				t.Fatalf("requests to %s after cancellation = %d, want 1", tc.cancelPath, got)
+			}
+			if got := res.Summary.EndpointsProbed; got != tc.wantProbes {
+				t.Fatalf("endpoints probed = %d, want %d", got, tc.wantProbes)
+			}
+		})
 	}
 }

--- a/modules/ollamacollect/collector.go
+++ b/modules/ollamacollect/collector.go
@@ -129,6 +129,9 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 	markAnonymousInventorySuccess(res.IngestData.Graph.Nodes[0].Properties)
 
 	for _, tag := range tags {
+		if ctx.Err() != nil {
+			break
+		}
 		showURL := strings.TrimRight(baseURL, "/") + "/api/show"
 		show, showErr := fetchShow(ctx, client, showURL, tag.Model)
 		res.Summary.EndpointsProbed++
@@ -175,6 +178,11 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges,
 			providesModelEdge(ollamaID, modelID, tag.Digest))
 		res.Summary.CredentialsFound++
+	}
+
+	// Do not start optional work after the caller has canceled collection.
+	if ctx.Err() != nil {
+		return res, nil
 	}
 
 	// 3. Flag-gated embedding probe (POST exception — see package doc).

--- a/modules/ollamacollect/collector_test.go
+++ b/modules/ollamacollect/collector_test.go
@@ -9,7 +9,9 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/adithyan-ak/agenthound/modules/ollamafp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
@@ -429,5 +431,62 @@ func TestCollect_NoModels(t *testing.T) {
 	}
 	if got := len(res.IngestData.Graph.Edges); got != 0 {
 		t.Errorf("edges: got %d, want 0", got)
+	}
+}
+
+func TestCollect_CancellationStopsShowWalk(t *testing.T) {
+	started := make(chan struct{})
+	requestRelease := make(chan struct{})
+	var showCalls atomic.Int32
+	var signalOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/tags":
+			_, _ = w.Write([]byte(`{"models":[{"model":"one"},{"model":"two"},{"model":"three"}]}`))
+		case "/api/show":
+			showCalls.Add(1)
+			signalOnce.Do(func() { close(started) })
+			<-requestRelease
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan *action.CollectResult, 1)
+	go func() {
+		res, _ := (&Collector{}).Collect(ctx, action.Target{
+			Kind:    "host",
+			Address: strings.TrimPrefix(srv.URL, "http://"),
+		}, action.CollectOptions{})
+		done <- res
+	}()
+
+	select {
+	case <-started:
+		cancel()
+		close(requestRelease)
+	case <-time.After(2 * time.Second):
+		cancel()
+		close(requestRelease)
+		t.Fatal("first /api/show request did not start")
+	}
+
+	var res *action.CollectResult
+	select {
+	case res = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Collect did not return after cancellation")
+	}
+	if got := showCalls.Load(); got != 1 {
+		t.Fatalf("/api/show calls after cancellation = %d, want 1", got)
+	}
+	if got := res.Summary.EndpointsProbed; got != 3 {
+		t.Fatalf("endpoints probed = %d, want 3", got)
+	}
+	if got := len(res.IngestData.Graph.Nodes); got != 2 {
+		t.Fatalf("nodes = %d, want Ollama instance plus first partial model", got)
 	}
 }


### PR DESCRIPTION
## Summary

- stop Ollama model-detail and MLflow per-item walks once their context is canceled
- preserve useful results already collected and avoid starting later optional probes
- add focused cancellation tests for Ollama show, MLflow runs, and MLflow download-URI collection
- keep the collectors serial; measurements do not justify worker pools for realistic inventories

## Benchmark decision

Synthetic local HTTP measurements covered 1, 10, 100, and 1,000 items with both zero delay and a conservative 2 ms response delay. At 10 items, all three walks completed in about 1.5-1.6 ms locally or 25-26 ms with delay. At 100 items, they completed in about 7-8 ms locally or 292-315 ms with delay. The roughly 3-second delayed result appeared only at the adversarial 1,000-item case, which is especially unrealistic for a single Ollama inventory.

A bounded worker pool is therefore not warranted now. Qdrant remains a measured one-off, and no shared fan-out abstraction is added.

Cancellation medians improved from approximately 8.6 ms to 0.46 ms for Ollama show, 4.45 ms to 0.19 ms for MLflow runs, and 4.11 ms to 0.14 ms for MLflow download URIs. Cancellation-related partial errors fell from 1,000/2/1,000 to 1/0/1 respectively.

## Validation

- `go test ./... -short -race -count=1`
- `make lint`
- `make deps-check`
- `make size-check`
- focused cancellation tests repeated 10 times

Addresses #55.