### PR TITLE
feat(graph): type Jupyter and MLflow resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ The collector writes an ingest-valid artifact before collection and checkpoints 
 | **LiteLLM** | Gateway posture, observed master keys, upstream-provider references, virtual-key hashes, models, aliases, and spend context | Compatible credential reuse, credential-chain correlation, and exposed-master-key findings |
 | **Ollama / vLLM** | Ollama model inventory, digests, modelfiles, templates, system prompts, and fine-tune signals; vLLM fingerprinting | Deep active mode invokes a bounded embedding request to prove model-compute access |
 | **Qdrant** | Typed vector collections, point counts, schema context, and bounded point references in deep mode | Anonymous exposure and sensitive vector-data analysis without retaining vector payloads |
-| **MLflow** | Experiments, runs, registered models, model versions, and artifact/storage URIs | Anonymous tracking and registry exposure analysis |
-| **Jupyter** | Sessions and bounded notebook/content trees, first anonymously and then with a compatible token | Distinguishes public from credential-gated notebook access |
+| **MLflow** | Experiment/run counts, typed model versions, sanitized storage URIs, and safely identified artifact-store roots | Anonymous tracking and registry exposure analysis without treating persisted artifacts as served models |
+| **Jupyter** | Sessions and typed workspace files from bounded notebook/content trees, first anonymously and then with a compatible token | Distinguishes public from credential-gated notebook access; incomplete walks preserve earlier files |
 | **Open WebUI / LangServe** | Open WebUI authentication posture and authenticated upstream/RAG credential inventory; LangServe fingerprinting | Credential expansion and exposed-service analysis |
 
 ## 🚀 Quick start

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -19,6 +19,8 @@ Concrete AI-service nodes also carry the `AIService` label. The umbrella label i
 
 `AIModel` is a model served by a runtime such as Ollama. A persisted MLflow model version is a `ModelArtifact`, not an `AIModel`. `VectorCollection` represents a Qdrant collection; bounded deep reads retain individual point references as `VectorPoint` without treating them as MCP resources. `WorkspaceFile` represents either a notebook or a regular file through its `entry_type` property.
 
+Resource identities use the owning service identity plus the resource's stable key: exact Qdrant collection name, normalized Jupyter workspace path, or MLflow registered-model name and immutable version. Mutable storage URIs never define `ModelArtifact` identity.
+
 ### Credential material
 
 | Property | Meaning |
@@ -74,6 +76,8 @@ Raw edges come from collectors or same-scan proof actions.
 `CREDENTIAL_ACCESS_OBSERVED` connects a Credential to the exact MCPResource read successfully after the anonymous control was denied. `PUBLIC_ACCESS_OBSERVED` connects the MCPServer to a resource read anonymously. Both are supporting evidence rather than general traversal shortcuts.
 
 `PROVIDES_RESOURCE` retains historical service-to-`MCPResource` variants for V1 artifacts. New collection emits typed pairs: QdrantInstance→VectorCollection, VectorCollection→VectorPoint, JupyterServer→WorkspaceFile, and MLflowServer→ModelArtifact. `USES_BACKEND` records an explicit service dependency; `STORED_IN` records a model artifact's reported physical store.
+
+`ArtifactStore` is created only for a safely canonicalized physical root such as a cloud bucket, container, filesystem, DBFS root, or HDFS authority. Local filesystem and DBFS roots are scoped to their owning MLflow service. Indirect `models:`, `runs:`, and `mlflow-artifacts:` locators remain sanitized `ModelArtifact` metadata and do not create a store node.
 
 New typed-resource and backend edges include `evidence_state`: `configured` proves only that the source contains the reference, `observed` means the source API reported it, and `verified` requires authoritative enumeration or a bounded request through the source. Probing a destination separately does not upgrade a configured backend relationship.
 

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -19,7 +19,7 @@ Concrete AI-service nodes also carry the `AIService` label. The umbrella label i
 
 `AIModel` is a model served by a runtime such as Ollama. A persisted MLflow model version is a `ModelArtifact`, not an `AIModel`. `VectorCollection` represents a Qdrant collection; bounded deep reads retain individual point references as `VectorPoint` without treating them as MCP resources. `WorkspaceFile` represents either a notebook or a regular file through its `entry_type` property.
 
-Resource identities use the owning service identity plus the resource's stable key: exact Qdrant collection name, normalized Jupyter workspace path, or MLflow registered-model name and immutable version. Mutable storage URIs never define `ModelArtifact` identity.
+Resource identities use the owning service identity plus the resource's stable key: exact Qdrant collection name, the source-reported Jupyter workspace path, or MLflow registered-model name and immutable version. Mutable storage URIs never define `ModelArtifact` identity. Jupyter path identity preserves whitespace and literal backslashes because the contents API can report them as filename material.
 
 ### Credential material
 
@@ -77,7 +77,7 @@ Raw edges come from collectors or same-scan proof actions.
 
 `PROVIDES_RESOURCE` retains historical service-to-`MCPResource` variants for V1 artifacts. New collection emits typed pairs: QdrantInstance→VectorCollection, VectorCollection→VectorPoint, JupyterServer→WorkspaceFile, and MLflowServer→ModelArtifact. `USES_BACKEND` records an explicit service dependency; `STORED_IN` records a model artifact's reported physical store.
 
-`ArtifactStore` is created only for a safely canonicalized physical root such as a cloud bucket, container, filesystem, DBFS root, or HDFS authority. Local filesystem and DBFS roots are scoped to their owning MLflow service. Indirect `models:`, `runs:`, and `mlflow-artifacts:` locators remain sanitized `ModelArtifact` metadata and do not create a store node.
+`ArtifactStore` is created only for a safely canonicalized physical root such as a cloud bucket, container, filesystem, DBFS root, or HDFS authority. Azure ABFS/WASB filesystem or container names are part of that root identity. Object-store key paths are retained as reported rather than cleaned as local filesystem paths. Local filesystem and DBFS roots are scoped to their owning MLflow service. Indirect `models:`, `runs:`, and `mlflow-artifacts:` locators remain sanitized `ModelArtifact` metadata and do not create a store node.
 
 New typed-resource and backend edges include `evidence_state`: `configured` proves only that the source contains the reference, `observed` means the source API reported it, and `verified` requires authoritative enumeration or a bounded request through the source. Probing a destination separately does not upgrade a configured backend relationship.
 
@@ -110,6 +110,12 @@ Raw IDs are deterministic SHA-256 values derived from kind-specific identity fie
 - Global value identity is reserved for explicit merge primitives such as concrete credential hashes.
 
 Display names, timestamps, and mutable descriptions do not define identity. Reference-only contributions follow the authoritative observation for the same raw ID.
+
+### Typed-resource migration
+
+The current server continues to accept historical V1 `JupyterServer`, `MLflowServer`, and `QdrantInstance` relationships to `MCPResource`. A new complete observation replaces those current-projection rows with the corresponding typed resource; partial or failed observations preserve them. Historical scan artifacts and captured finding evidence remain attached to their original scan and IDs.
+
+The migrated resource kinds are not inputs to the existing finding processors, so this change does not create or rename a finding fingerprint and does not move cross-scan triage. A copied raw graph `objectid` is an identity for that representation, not a permanent alias: use the typed resource's source key (`path`, model `name` plus `version`, collection `name`, or point `uri`) to locate the same reported object after migration.
 
 ## Coverage and lifecycle
 

--- a/modules/jupytercollect/collector.go
+++ b/modules/jupytercollect/collector.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	pathpkg "path"
 	"strings"
 	"time"
 
@@ -40,7 +41,7 @@ func (l *Collector) Collect(
 	target action.Target,
 	opts action.CollectOptions,
 ) (*action.CollectResult, error) {
-	_, host, port := action.EndpointParts(target, DefaultPort, "http")
+	_, host, _ := action.EndpointParts(target, DefaultPort, "http")
 	baseURL := action.EndpointBaseURL(target, DefaultPort, "http")
 	jupyterID := ingest.ComputeNodeID("JupyterServer", baseURL)
 
@@ -62,7 +63,12 @@ func (l *Collector) Collect(
 	}
 
 	client := common.NoRedirectClient(timeout)
-	res := &action.CollectResult{IngestData: &ingest.IngestData{}}
+	res := &action.CollectResult{
+		IngestData: &ingest.IngestData{},
+		Inventory: &action.InventoryResult{
+			Name: "contents", State: ingest.OutcomeFailed,
+		},
+	}
 
 	sessions, sessionsAccess, sessionsErr := fetchSessionsWithFallback(
 		ctx,
@@ -97,6 +103,7 @@ func (l *Collector) Collect(
 			fmt.Sprintf("api/contents: %v", contentsErr),
 		)
 		res.Summary.PartialFailures++
+		res.Inventory.Error = fmt.Sprintf("api/contents: %v", contentsErr)
 	}
 	if contentsTruncation.maxItems {
 		res.PartialErrors = append(
@@ -104,6 +111,11 @@ func (l *Collector) Collect(
 			fmt.Sprintf("api/contents: truncated at max_items=%d", maxItems),
 		)
 		res.Summary.PartialFailures++
+		res.Inventory.State = ingest.OutcomeTruncated
+		res.Inventory.Error = appendInventoryError(
+			res.Inventory.Error,
+			fmt.Sprintf("truncated at max_items=%d", maxItems),
+		)
 	}
 	if contentsTruncation.maxDepth {
 		res.PartialErrors = append(
@@ -111,6 +123,11 @@ func (l *Collector) Collect(
 			fmt.Sprintf("api/contents: truncated at max_depth=%d", maxDepth),
 		)
 		res.Summary.PartialFailures++
+		res.Inventory.State = ingest.OutcomeTruncated
+		res.Inventory.Error = appendInventoryError(
+			res.Inventory.Error,
+			fmt.Sprintf("truncated at max_depth=%d", maxDepth),
+		)
 	}
 	for _, perDirectoryErr := range perDirErrs {
 		slog.Debug(
@@ -120,6 +137,16 @@ func (l *Collector) Collect(
 		)
 		res.PartialErrors = append(res.PartialErrors, perDirectoryErr)
 		res.Summary.PartialFailures++
+		if res.Inventory.State != ingest.OutcomeTruncated {
+			res.Inventory.State = ingest.OutcomePartial
+		}
+		res.Inventory.Error = appendInventoryError(res.Inventory.Error, perDirectoryErr)
+	}
+	res.Inventory.Items = len(notebooks)
+	if contentsErr == nil && !contentsTruncation.maxItems &&
+		!contentsTruncation.maxDepth && len(perDirErrs) == 0 {
+		res.Inventory.State = ingest.OutcomeComplete
+		res.Inventory.Error = ""
 	}
 
 	props := map[string]any{
@@ -142,18 +169,27 @@ func (l *Collector) Collect(
 		},
 	)
 
+	lastSeen := time.Now().UTC().Format(time.RFC3339)
 	for _, nb := range notebooks {
-		uri := fmt.Sprintf("jupyter://%s:%d/%s", host, port, nb.Path)
-		resID := ingest.ComputeNodeID("MCPResource", jupyterID, uri)
+		workspacePath := normalizeWorkspacePath(nb.Path)
+		if workspacePath == "" {
+			message := fmt.Sprintf("api/contents: entry %q has no usable path", nb.Name)
+			res.PartialErrors = append(res.PartialErrors, message)
+			res.Summary.PartialFailures++
+			res.Inventory.State = ingest.OutcomePartial
+			res.Inventory.Error = appendInventoryError(res.Inventory.Error, message)
+			continue
+		}
+		resID := ingest.ComputeNodeID("WorkspaceFile", jupyterID, workspacePath)
 		res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
 			ID:    resID,
-			Kinds: []string{"MCPResource"},
+			Kinds: []string{"WorkspaceFile"},
 			Properties: map[string]any{
 				"objectid":    resID,
-				"uri":         uri,
+				"path":        workspacePath,
 				"name":        nb.Name,
+				"entry_type":  nb.Type,
 				"mime_type":   nb.MimeType,
-				"uri_scheme":  "jupyter",
 				"sensitivity": "high",
 			},
 		})
@@ -163,13 +199,16 @@ func (l *Collector) Collect(
 				Target:     resID,
 				Kind:       "PROVIDES_RESOURCE",
 				SourceKind: "JupyterServer",
-				TargetKind: "MCPResource",
+				TargetKind: "WorkspaceFile",
 				Properties: map[string]any{
-					"confidence":  1.0,
-					"risk_weight": 0.2,
+					"confidence":     1.0,
+					"risk_weight":    0.2,
+					"evidence_state": string(ingest.EvidenceVerified),
+					"last_seen":      lastSeen,
 					"evidence": map[string]any{
 						"endpoint": baseURL,
 						"source":   "api/contents",
+						"path":     workspacePath,
 					},
 				},
 			})
@@ -181,6 +220,25 @@ func (l *Collector) Collect(
 		"per_directory_failures", len(perDirErrs),
 		"partial_failures", res.Summary.PartialFailures)
 	return res, nil
+}
+
+func normalizeWorkspacePath(raw string) string {
+	raw = strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
+	if raw == "" {
+		return ""
+	}
+	cleaned := pathpkg.Clean("/" + strings.TrimLeft(raw, "/"))
+	return strings.TrimPrefix(cleaned, "/")
+}
+
+func appendInventoryError(current, next string) string {
+	if current == "" {
+		return next
+	}
+	if next == "" || strings.Contains(current, next) {
+		return current
+	}
+	return current + "; " + next
 }
 
 type accessEvidence struct {

--- a/modules/jupytercollect/collector.go
+++ b/modules/jupytercollect/collector.go
@@ -12,7 +12,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	pathpkg "path"
 	"strings"
 	"time"
 
@@ -223,12 +222,13 @@ func (l *Collector) Collect(
 }
 
 func normalizeWorkspacePath(raw string) string {
-	raw = strings.ReplaceAll(strings.TrimSpace(raw), "\\", "/")
 	if raw == "" {
 		return ""
 	}
-	cleaned := pathpkg.Clean("/" + strings.TrimLeft(raw, "/"))
-	return strings.TrimPrefix(cleaned, "/")
+	// Jupyter's contents API returns a slash-delimited path relative to the
+	// workspace root. Preserve every source-significant character; a literal
+	// backslash and trailing whitespace are valid Unix filename material.
+	return strings.TrimLeft(raw, "/")
 }
 
 func appendInventoryError(current, next string) string {

--- a/modules/jupytercollect/collector_test.go
+++ b/modules/jupytercollect/collector_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
 // sessionsBody now includes an empty-path console kernel — must still
@@ -95,22 +96,32 @@ func TestCollect_JupyterHappy(t *testing.T) {
 		props["contents_access"] != "anonymous" {
 		t.Errorf("protected endpoint access = %+v", props)
 	}
-	// Every subsequent node is an :MCPResource with jupyter:// URI.
+	// Every subsequent node is a typed workspace file with a normalized path.
 	for _, n := range res.IngestData.Graph.Nodes[1:] {
-		if n.Kinds[0] != "MCPResource" {
-			t.Errorf("resource node kind = %v, want MCPResource", n.Kinds)
+		if n.Kinds[0] != "WorkspaceFile" {
+			t.Errorf("resource node kind = %v, want WorkspaceFile", n.Kinds)
 		}
-		if uri, _ := n.Properties["uri"].(string); !strings.HasPrefix(uri, "jupyter://") {
-			t.Errorf("uri = %q, want jupyter:// prefix", uri)
+		if path, _ := n.Properties["path"].(string); path == "" || strings.HasPrefix(path, "/") {
+			t.Errorf("path = %q, want normalized workspace-relative path", path)
+		}
+		if entryType, _ := n.Properties["entry_type"].(string); entryType != "notebook" && entryType != "file" {
+			t.Errorf("entry_type = %q, want notebook or file", entryType)
 		}
 	}
 	for _, e := range res.IngestData.Graph.Edges {
 		if e.Kind != "PROVIDES_RESOURCE" {
 			t.Errorf("edge kind = %q, want PROVIDES_RESOURCE", e.Kind)
 		}
-		if e.SourceKind != "JupyterServer" || e.TargetKind != "MCPResource" {
-			t.Errorf("edge endpoints = %s -> %s, want JupyterServer -> MCPResource", e.SourceKind, e.TargetKind)
+		if e.SourceKind != "JupyterServer" || e.TargetKind != "WorkspaceFile" {
+			t.Errorf("edge endpoints = %s -> %s, want JupyterServer -> WorkspaceFile", e.SourceKind, e.TargetKind)
 		}
+		if e.Properties["evidence_state"] != "verified" {
+			t.Errorf("edge evidence = %+v, want verified", e.Properties)
+		}
+	}
+	if res.Inventory == nil || res.Inventory.Name != "contents" ||
+		res.Inventory.State != ingest.OutcomeComplete || res.Inventory.Items != 4 {
+		t.Fatalf("inventory = %+v, want complete four-file contents", res.Inventory)
 	}
 }
 
@@ -156,6 +167,9 @@ func TestCollect_Jupyter_SessionsFail(t *testing.T) {
 		props["contents_access"] != "anonymous" {
 		t.Errorf("mixed protected endpoint access = %+v", props)
 	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeComplete {
+		t.Fatalf("sessions failure downgraded complete contents inventory: %+v", res.Inventory)
+	}
 }
 
 func TestCollect_Jupyter_AllFail(t *testing.T) {
@@ -183,6 +197,9 @@ func TestCollect_Jupyter_AllFail(t *testing.T) {
 		props["auth_assurance"] != "unknown" ||
 		props["auth_evidence"] != "unknown" {
 		t.Errorf("indeterminate protected endpoint posture = %+v", props)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeFailed {
+		t.Fatalf("failed contents inventory = %+v, want failed", res.Inventory)
 	}
 }
 
@@ -347,6 +364,9 @@ func TestCollect_Jupyter_MaxDepthCap(t *testing.T) {
 		!strings.Contains(res.PartialErrors[0], "max_depth=2") {
 		t.Fatalf("depth truncation diagnostic = %v", res.PartialErrors)
 	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeTruncated {
+		t.Fatalf("depth-limited inventory = %+v, want truncated", res.Inventory)
+	}
 }
 
 func TestFetchContentsRecursiveCountsDirectoriesAgainstMaxItems(t *testing.T) {
@@ -449,6 +469,9 @@ func TestCollect_Jupyter_SubdirForbidden(t *testing.T) {
 	if !sawForbidden {
 		t.Errorf("PartialErrors missing entry with prefix %q; got %v", wantPrefix, res.PartialErrors)
 	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomePartial {
+		t.Fatalf("directory-failed inventory = %+v, want partial", res.Inventory)
+	}
 	// Confirm the forbidden dir was probed exactly once (walk did not
 	// retry).
 	mu.Lock()
@@ -458,27 +481,31 @@ func TestCollect_Jupyter_SubdirForbidden(t *testing.T) {
 	mu.Unlock()
 }
 
-// notebookPaths returns the path property of every :MCPResource node.
+// notebookPaths returns the normalized path of every WorkspaceFile node.
 func notebookPaths(res *action.CollectResult) []string {
 	var out []string
 	for _, n := range res.IngestData.Graph.Nodes {
-		if len(n.Kinds) == 0 || n.Kinds[0] != "MCPResource" {
+		if len(n.Kinds) == 0 || n.Kinds[0] != "WorkspaceFile" {
 			continue
 		}
-		uri, _ := n.Properties["uri"].(string)
-		// Extract the path portion after jupyter://host:port/
-		idx := strings.Index(uri, "://")
-		if idx < 0 {
-			continue
-		}
-		rest := uri[idx+3:]
-		slash := strings.Index(rest, "/")
-		if slash < 0 {
-			continue
-		}
-		out = append(out, rest[slash+1:])
+		path, _ := n.Properties["path"].(string)
+		out = append(out, path)
 	}
 	return out
+}
+
+func TestNormalizeWorkspacePathAndIdentity(t *testing.T) {
+	serverID := "jupyter-server"
+	for _, spelling := range []string{"work/./notes.ipynb", "/work/notes.ipynb", `work\\notes.ipynb`} {
+		path := normalizeWorkspacePath(spelling)
+		if path != "work/notes.ipynb" {
+			t.Fatalf("normalizeWorkspacePath(%q) = %q", spelling, path)
+		}
+		if got, want := ingest.ComputeNodeID("WorkspaceFile", serverID, path),
+			ingest.ComputeNodeID("WorkspaceFile", serverID, "work/notes.ipynb"); got != want {
+			t.Fatalf("equivalent workspace paths produced different IDs: %q != %q", got, want)
+		}
+	}
 }
 
 // Force fmt import so build stays green if imports narrow later.

--- a/modules/jupytercollect/collector_test.go
+++ b/modules/jupytercollect/collector_test.go
@@ -496,14 +496,21 @@ func notebookPaths(res *action.CollectResult) []string {
 
 func TestNormalizeWorkspacePathAndIdentity(t *testing.T) {
 	serverID := "jupyter-server"
-	for _, spelling := range []string{"work/./notes.ipynb", "/work/notes.ipynb", `work\\notes.ipynb`} {
-		path := normalizeWorkspacePath(spelling)
-		if path != "work/notes.ipynb" {
-			t.Fatalf("normalizeWorkspacePath(%q) = %q", spelling, path)
+	if got := normalizeWorkspacePath("/work/notes.ipynb"); got != "work/notes.ipynb" {
+		t.Fatalf("leading-root normalization = %q", got)
+	}
+	for _, pair := range [][2]string{
+		{"notes ", "notes"},
+		{`folder/a\b.ipynb`, "folder/a/b.ipynb"},
+	} {
+		left := normalizeWorkspacePath(pair[0])
+		right := normalizeWorkspacePath(pair[1])
+		if left == right {
+			t.Fatalf("distinct workspace paths collapsed: %q and %q", pair[0], pair[1])
 		}
-		if got, want := ingest.ComputeNodeID("WorkspaceFile", serverID, path),
-			ingest.ComputeNodeID("WorkspaceFile", serverID, "work/notes.ipynb"); got != want {
-			t.Fatalf("equivalent workspace paths produced different IDs: %q != %q", got, want)
+		if ingest.ComputeNodeID("WorkspaceFile", serverID, left) ==
+			ingest.ComputeNodeID("WorkspaceFile", serverID, right) {
+			t.Fatalf("distinct workspace paths produced the same identity: %q and %q", left, right)
 		}
 	}
 }

--- a/modules/mlflowcollect/collector.go
+++ b/modules/mlflowcollect/collector.go
@@ -17,9 +17,9 @@
 // presigned URL and NOT credential material (mlflow/store/model_registry/
 // sqlalchemy_store.py::get_model_version_download_uri returns
 // sql_model_version.storage_location or sql_model_version.source
-// verbatim). Each URI is emitted as an :MCPResource joined to the
-// MLflowServer via PROVIDES_RESOURCE, with sensitivity auto-classified
-// by scheme + path pattern per docs/reference/graph-model.md.
+// verbatim). Each registered model version is emitted as a ModelArtifact.
+// Safely canonicalizable physical roots are represented once as ArtifactStore
+// and joined with STORED_IN; unresolved MLflow locators remain metadata only.
 //
 // Every probe sends max_results and follows next_page_token; modern
 // MLflow (2.22.x+) rejects GET /experiments/search without max_results
@@ -34,9 +34,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -77,7 +79,12 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 
 	client := common.NoRedirectClient(timeout)
 
-	res := &action.CollectResult{IngestData: &ingest.IngestData{}}
+	res := &action.CollectResult{
+		IngestData: &ingest.IngestData{},
+		Inventory: &action.InventoryResult{
+			Name: "model_registry", State: ingest.OutcomeFailed,
+		},
+	}
 
 	res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
 		ID:    mlflowID,
@@ -131,7 +138,7 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 	//    + per-version get-download-uri. All GET, all paginated. Any
 	//    probe returning non-2xx records a partial failure and the
 	//    Registry branch stops; the MLflow inventory props still land.
-	registered, regErr := fetchRegisteredModels(ctx, client, baseURL, maxItems)
+	registered, registeredTruncated, regErr := fetchRegisteredModels(ctx, client, baseURL, maxItems)
 	res.Summary.EndpointsProbed++
 	if regErr != nil {
 		slog.Warn("mlflow collection: registered-models/search failed", "error", regErr)
@@ -149,7 +156,7 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 		return res, nil
 	}
 
-	versions, verErr := fetchModelVersions(ctx, client, baseURL, maxItems)
+	versions, versionsTruncated, verErr := fetchModelVersions(ctx, client, baseURL, maxItems)
 	res.Summary.EndpointsProbed++
 	if verErr != nil {
 		slog.Warn("mlflow collection: model-versions/search failed", "error", verErr)
@@ -158,57 +165,116 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 	} else {
 		res.IngestData.Graph.Nodes[0].Properties["model_version_count"] = len(versions)
 	}
+	res.Inventory.Items = len(versions)
+	res.Inventory.State = modelRegistryState(
+		regErr, verErr, registeredTruncated, versionsTruncated,
+	)
+	for _, inventoryErr := range []error{regErr, verErr} {
+		if inventoryErr != nil {
+			res.Inventory.Error = appendInventoryError(res.Inventory.Error, inventoryErr.Error())
+		}
+	}
+	if registeredTruncated {
+		message := fmt.Sprintf("registered models truncated at max_items=%d", maxItems)
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		res.Inventory.Error = appendInventoryError(res.Inventory.Error, message)
+	}
+	if versionsTruncated {
+		message := fmt.Sprintf("model versions truncated at max_items=%d", maxItems)
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		res.Inventory.Error = appendInventoryError(res.Inventory.Error, message)
+	}
 	if ctx.Err() != nil {
+		res.Inventory.State = ingest.OutcomePartial
+		res.Inventory.Error = appendInventoryError(res.Inventory.Error, ctx.Err().Error())
 		return res, nil
 	}
 
-	// For each model version, fetch the download URI and emit an
-	// :MCPResource + PROVIDES_RESOURCE edge. Individual failures are
-	// per-version partials — one bad model shouldn't kill the walk.
+	// Each enumerated immutable model version becomes a ModelArtifact. The
+	// download URI enriches that artifact but never defines its identity.
+	// Individual lookup failures keep this inventory non-authoritative.
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].Name == versions[j].Name {
+			return versions[i].Version < versions[j].Version
+		}
+		return versions[i].Name < versions[j].Name
+	})
+	lastSeen := time.Now().UTC().Format(time.RFC3339)
+	storeNodes := make(map[string]bool)
 	for _, v := range versions {
 		if ctx.Err() != nil {
+			res.Inventory.State = ingest.OutcomePartial
+			res.Inventory.Error = appendInventoryError(res.Inventory.Error, ctx.Err().Error())
 			break
 		}
-		uri, err := fetchDownloadURI(ctx, client, baseURL, v.Name, v.Version)
+		artifactID := ingest.ComputeNodeID("ModelArtifact", mlflowID, v.Name, v.Version)
+		artifactProps := map[string]any{
+			"objectid": artifactID, "name": v.Name, "version": v.Version,
+			"display_name": v.Name + ":" + v.Version, "sensitivity": "high",
+		}
+		uri, downloadErr := fetchDownloadURI(ctx, client, baseURL, v.Name, v.Version)
 		res.Summary.EndpointsProbed++
-		if err != nil {
+		if downloadErr != nil {
 			slog.Debug("mlflow collection: get-download-uri failed",
-				"model", v.Name, "version", v.Version, "error", err)
+				"model", v.Name, "version", v.Version, "error", downloadErr)
+			message := fmt.Sprintf(
+				"model-versions/get-download-uri %s:%s: %v",
+				v.Name, v.Version, downloadErr,
+			)
 			res.PartialErrors = append(res.PartialErrors,
-				fmt.Sprintf("model-versions/get-download-uri %s:%s: %v", v.Name, v.Version, err))
+				message)
 			res.Summary.PartialFailures++
-			continue
+			if res.Inventory.State == ingest.OutcomeComplete {
+				res.Inventory.State = ingest.OutcomePartial
+			}
+			res.Inventory.Error = appendInventoryError(res.Inventory.Error, message)
+		} else if sanitizedURI := sanitizeArtifactURI(uri); sanitizedURI != "" {
+			artifactProps["storage_uri"] = sanitizedURI
+			artifactProps["storage_scheme"] = parseURIScheme(sanitizedURI)
+			artifactProps["sensitivity"] = classifyArtifactSensitivity(sanitizedURI)
 		}
-		if uri == "" {
-			continue
-		}
-		resourceID := ingest.ComputeNodeID("MCPResource", mlflowID, uri)
 		res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
-			ID:    resourceID,
-			Kinds: []string{"MCPResource"},
-			Properties: map[string]any{
-				"objectid":    resourceID,
-				"uri":         uri,
-				"name":        v.Name + ":" + v.Version,
-				"mime_type":   "application/x-mlflow-model",
-				"uri_scheme":  parseURIScheme(uri),
-				"sensitivity": classifyArtifactSensitivity(uri),
-			},
+			ID: artifactID, Kinds: []string{"ModelArtifact"}, Properties: artifactProps,
 		})
 		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges, ingest.Edge{
-			Source:     mlflowID,
-			Target:     resourceID,
-			Kind:       "PROVIDES_RESOURCE",
-			SourceKind: "MLflowServer",
-			TargetKind: "MCPResource",
+			Source: mlflowID, Target: artifactID, Kind: "PROVIDES_RESOURCE",
+			SourceKind: "MLflowServer", TargetKind: "ModelArtifact",
 			Properties: map[string]any{
-				"confidence":  1.0,
-				"risk_weight": 0.2,
+				"confidence": 1.0, "risk_weight": 0.2,
+				"evidence_state": string(ingest.EvidenceVerified), "last_seen": lastSeen,
 				"evidence": map[string]any{
-					"endpoint":      baseURL,
-					"source":        "model_registry",
-					"model_name":    v.Name,
-					"model_version": v.Version,
+					"endpoint": baseURL, "source": "model-versions/search",
+					"model_name": v.Name, "model_version": v.Version,
+				},
+			},
+		})
+
+		store, ok := canonicalArtifactStore(uri, mlflowID)
+		if !ok {
+			continue
+		}
+		if !storeNodes[store.ID] {
+			storeNodes[store.ID] = true
+			res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
+				ID: store.ID, Kinds: []string{"ArtifactStore"},
+				Properties: map[string]any{
+					"objectid": store.ID, "name": store.RootURI,
+					"provider": store.Provider, "root_uri": store.RootURI,
+					"scope": store.Scope, "sensitivity": "high",
+				},
+			})
+		}
+		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges, ingest.Edge{
+			Source: artifactID, Target: store.ID, Kind: "STORED_IN",
+			SourceKind: "ModelArtifact", TargetKind: "ArtifactStore",
+			Properties: map[string]any{
+				"confidence": 1.0, "risk_weight": 0.2,
+				"evidence_state": string(ingest.EvidenceObserved), "last_seen": lastSeen,
+				"evidence": map[string]any{
+					"source": "get-download-uri", "provider": store.Provider,
+					"root_uri": store.RootURI,
 				},
 			},
 		})
@@ -348,12 +414,14 @@ type registeredModel struct {
 // fetchRegisteredModels enumerates the Model Registry via GET
 // /api/2.0/mlflow/registered-models/search. Anonymous-readable on stock
 // MLflow, paginated via next_page_token.
-func fetchRegisteredModels(ctx context.Context, client *http.Client, baseURL string, maxItems int) ([]registeredModel, error) {
+func fetchRegisteredModels(ctx context.Context, client *http.Client, baseURL string, maxItems int) ([]registeredModel, bool, error) {
 	var out []registeredModel
 	pageToken := ""
+	truncated := false
 	for {
 		remaining := maxItems - len(out)
 		if remaining <= 0 {
+			truncated = pageToken != ""
 			break
 		}
 		u := fmt.Sprintf("%s/api/2.0/mlflow/registered-models/search?max_results=%d",
@@ -364,27 +432,29 @@ func fetchRegisteredModels(ctx context.Context, client *http.Client, baseURL str
 		body, err := common.GetJSON(ctx, client, u, "", 4<<20)
 		if err != nil {
 			if len(out) == 0 {
-				return nil, err
+				return nil, false, err
 			}
-			return out, fmt.Errorf("page: %w", err)
+			return out, false, fmt.Errorf("page: %w", err)
 		}
 		var parsed struct {
 			RegisteredModels []registeredModel `json:"registered_models"`
 			NextPageToken    string            `json:"next_page_token"`
 		}
 		if err := json.Unmarshal(body, &parsed); err != nil {
-			return nil, fmt.Errorf("decode registered_models: %w", err)
+			return nil, false, fmt.Errorf("decode registered_models: %w", err)
 		}
 		out = append(out, parsed.RegisteredModels...)
+		if len(out) > maxItems {
+			out = out[:maxItems]
+			truncated = true
+			break
+		}
 		if parsed.NextPageToken == "" || len(parsed.RegisteredModels) == 0 {
 			break
 		}
 		pageToken = parsed.NextPageToken
 	}
-	if len(out) > maxItems {
-		out = out[:maxItems]
-	}
-	return out, nil
+	return out, truncated, nil
 }
 
 type modelVersion struct {
@@ -396,12 +466,14 @@ type modelVersion struct {
 // registered models via GET /api/2.0/mlflow/model-versions/search.
 // MLflow returns (name, version) pairs which the caller uses to build
 // per-version get-download-uri probes.
-func fetchModelVersions(ctx context.Context, client *http.Client, baseURL string, maxItems int) ([]modelVersion, error) {
+func fetchModelVersions(ctx context.Context, client *http.Client, baseURL string, maxItems int) ([]modelVersion, bool, error) {
 	var out []modelVersion
 	pageToken := ""
+	truncated := false
 	for {
 		remaining := maxItems - len(out)
 		if remaining <= 0 {
+			truncated = pageToken != ""
 			break
 		}
 		u := fmt.Sprintf("%s/api/2.0/mlflow/model-versions/search?max_results=%d",
@@ -412,27 +484,29 @@ func fetchModelVersions(ctx context.Context, client *http.Client, baseURL string
 		body, err := common.GetJSON(ctx, client, u, "", 4<<20)
 		if err != nil {
 			if len(out) == 0 {
-				return nil, err
+				return nil, false, err
 			}
-			return out, fmt.Errorf("page: %w", err)
+			return out, false, fmt.Errorf("page: %w", err)
 		}
 		var parsed struct {
 			ModelVersions []modelVersion `json:"model_versions"`
 			NextPageToken string         `json:"next_page_token"`
 		}
 		if err := json.Unmarshal(body, &parsed); err != nil {
-			return nil, fmt.Errorf("decode model_versions: %w", err)
+			return nil, false, fmt.Errorf("decode model_versions: %w", err)
 		}
 		out = append(out, parsed.ModelVersions...)
+		if len(out) > maxItems {
+			out = out[:maxItems]
+			truncated = true
+			break
+		}
 		if parsed.NextPageToken == "" || len(parsed.ModelVersions) == 0 {
 			break
 		}
 		pageToken = parsed.NextPageToken
 	}
-	if len(out) > maxItems {
-		out = out[:maxItems]
-	}
-	return out, nil
+	return out, truncated, nil
 }
 
 // fetchDownloadURI issues GET /api/2.0/mlflow/model-versions/get-download-uri
@@ -508,6 +582,133 @@ func classifyArtifactSensitivity(uri string) string {
 		return "medium"
 	}
 	return "high"
+}
+
+func modelRegistryState(
+	registeredErr error,
+	versionsErr error,
+	registeredTruncated bool,
+	versionsTruncated bool,
+) ingest.OutcomeState {
+	if registeredErr != nil && versionsErr != nil {
+		return ingest.OutcomeFailed
+	}
+	if registeredErr != nil || versionsErr != nil {
+		return ingest.OutcomePartial
+	}
+	if registeredTruncated || versionsTruncated {
+		return ingest.OutcomeTruncated
+	}
+	return ingest.OutcomeComplete
+}
+
+func appendInventoryError(current, next string) string {
+	if current == "" {
+		return next
+	}
+	if next == "" || strings.Contains(current, next) {
+		return current
+	}
+	return current + "; " + next
+}
+
+type artifactStoreRef struct {
+	ID       string
+	Provider string
+	RootURI  string
+	Scope    string
+}
+
+// sanitizeArtifactURI removes credential-bearing and request-specific URL
+// components before a registry locator is retained as graph metadata.
+func sanitizeArtifactURI(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Opaque != "" {
+		return ""
+	}
+	if parsed.Scheme == "" {
+		if !strings.HasPrefix(parsed.Path, "/") {
+			return ""
+		}
+		return path.Clean(parsed.Path)
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	if parsed.Host != "" {
+		host := strings.ToLower(parsed.Hostname())
+		if host == "" {
+			return ""
+		}
+		if port := parsed.Port(); port != "" {
+			parsed.Host = net.JoinHostPort(host, port)
+		} else if strings.Contains(host, ":") {
+			parsed.Host = "[" + host + "]"
+		} else {
+			parsed.Host = host
+		}
+	}
+	if parsed.Path != "" {
+		parsed.Path = path.Clean(parsed.Path)
+		if parsed.Path == "." {
+			parsed.Path = ""
+		}
+		parsed.RawPath = ""
+	}
+	return parsed.String()
+}
+
+// canonicalArtifactStore returns a logical physical storage root. MLflow
+// indirection schemes (models, runs, mlflow-artifacts) intentionally return
+// no store because they do not identify a physical root.
+func canonicalArtifactStore(raw, mlflowID string) (artifactStoreRef, bool) {
+	sanitized := sanitizeArtifactURI(raw)
+	if sanitized == "" {
+		return artifactStoreRef{}, false
+	}
+	parsed, err := url.Parse(sanitized)
+	if err != nil {
+		return artifactStoreRef{}, false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	remoteProviders := map[string]bool{
+		"s3": true, "gs": true, "azure": true, "abfs": true, "abfss": true,
+		"wasb": true, "wasbs": true, "hdfs": true,
+	}
+	if remoteProviders[scheme] {
+		if parsed.Hostname() == "" {
+			return artifactStoreRef{}, false
+		}
+		root := (&url.URL{Scheme: scheme, Host: parsed.Host}).String()
+		return artifactStoreRef{
+			ID: ingest.ComputeNodeID("ArtifactStore", root), Provider: scheme,
+			RootURI: root, Scope: "remote",
+		}, true
+	}
+
+	var root string
+	switch {
+	case scheme == "file":
+		root = (&url.URL{Scheme: "file", Host: parsed.Host, Path: "/"}).String()
+	case scheme == "dbfs":
+		root = "dbfs:/"
+	case scheme == "" && strings.HasPrefix(sanitized, "/"):
+		scheme = "file"
+		root = "file:///"
+	default:
+		return artifactStoreRef{}, false
+	}
+	return artifactStoreRef{
+		ID: ingest.ComputeNodeID("ArtifactStore", mlflowID, root), Provider: scheme,
+		RootURI: root, Scope: "service",
+	}, true
 }
 
 func postJSON(ctx context.Context, client *http.Client, url string, payload []byte) ([]byte, error) {

--- a/modules/mlflowcollect/collector.go
+++ b/modules/mlflowcollect/collector.go
@@ -528,7 +528,7 @@ func fetchDownloadURI(ctx context.Context, client *http.Client, baseURL, name, v
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return "", fmt.Errorf("decode get-download-uri: %w", err)
 	}
-	return strings.TrimSpace(parsed.ArtifactURI), nil
+	return parsed.ArtifactURI, nil
 }
 
 // parseURIScheme extracts the scheme (before "://") from a storage URI.
@@ -622,8 +622,7 @@ type artifactStoreRef struct {
 // sanitizeArtifactURI removes credential-bearing and request-specific URL
 // components before a registry locator is retained as graph metadata.
 func sanitizeArtifactURI(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
+	if strings.TrimSpace(raw) == "" {
 		return ""
 	}
 	parsed, err := url.Parse(raw)
@@ -637,7 +636,18 @@ func sanitizeArtifactURI(raw string) string {
 		return path.Clean(parsed.Path)
 	}
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	parsed.User = nil
+	containerUserScheme := parsed.Scheme == "abfs" || parsed.Scheme == "abfss" ||
+		parsed.Scheme == "wasb" || parsed.Scheme == "wasbs"
+	if containerUserScheme {
+		// Azure ABFS/WASB locators encode the filesystem/container before @;
+		// it is identity, not authentication. Retain it while dropping any
+		// nonstandard password component.
+		if parsed.User != nil {
+			parsed.User = url.User(parsed.User.Username())
+		}
+	} else {
+		parsed.User = nil
+	}
 	parsed.RawQuery = ""
 	parsed.ForceQuery = false
 	parsed.Fragment = ""
@@ -655,7 +665,7 @@ func sanitizeArtifactURI(raw string) string {
 			parsed.Host = host
 		}
 	}
-	if parsed.Path != "" {
+	if parsed.Path != "" && (parsed.Scheme == "file" || parsed.Scheme == "dbfs") {
 		parsed.Path = path.Clean(parsed.Path)
 		if parsed.Path == "." {
 			parsed.Path = ""
@@ -686,7 +696,14 @@ func canonicalArtifactStore(raw, mlflowID string) (artifactStoreRef, bool) {
 		if parsed.Hostname() == "" {
 			return artifactStoreRef{}, false
 		}
-		root := (&url.URL{Scheme: scheme, Host: parsed.Host}).String()
+		rootURL := &url.URL{Scheme: scheme, Host: parsed.Host}
+		if scheme == "abfs" || scheme == "abfss" || scheme == "wasb" || scheme == "wasbs" {
+			if parsed.User == nil || parsed.User.Username() == "" {
+				return artifactStoreRef{}, false
+			}
+			rootURL.User = url.User(parsed.User.Username())
+		}
+		root := rootURL.String()
 		return artifactStoreRef{
 			ID: ingest.ComputeNodeID("ArtifactStore", root), Provider: scheme,
 			RootURI: root, Scope: "remote",

--- a/modules/mlflowcollect/collector_test.go
+++ b/modules/mlflowcollect/collector_test.go
@@ -518,6 +518,31 @@ func TestCanonicalArtifactStoreIdentityAndRedaction(t *testing.T) {
 	}
 }
 
+func TestArtifactLocationPreservesSchemeSpecificIdentity(t *testing.T) {
+	t.Run("Azure filesystem is part of identity", func(t *testing.T) {
+		alpha := "abfss://alpha@account.dfs.core.windows.net/models/v1"
+		beta := "abfss://beta@account.dfs.core.windows.net/models/v1"
+		if got := sanitizeArtifactURI(alpha); got != alpha {
+			t.Fatalf("sanitized ABFSS locator = %q, want %q", got, alpha)
+		}
+		alphaStore, alphaOK := canonicalArtifactStore(alpha, "mlflow")
+		betaStore, betaOK := canonicalArtifactStore(beta, "mlflow")
+		if !alphaOK || !betaOK || alphaStore.ID == betaStore.ID {
+			t.Fatalf("distinct Azure filesystems collapsed: %+v/%t %+v/%t", alphaStore, alphaOK, betaStore, betaOK)
+		}
+		if alphaStore.RootURI != "abfss://alpha@account.dfs.core.windows.net" {
+			t.Fatalf("Azure root = %q", alphaStore.RootURI)
+		}
+	})
+
+	t.Run("object key path is reported material", func(t *testing.T) {
+		raw := "s3://fixture-bucket/models/./version"
+		if got := sanitizeArtifactURI(raw); got != raw {
+			t.Fatalf("sanitized object locator = %q, want %q", got, raw)
+		}
+	})
+}
+
 func TestCollect_MLflow_RegistryLimitAndLookupFailureAreIncomplete(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/modules/mlflowcollect/collector_test.go
+++ b/modules/mlflowcollect/collector_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/adithyan-ak/agenthound/modules/mlflowfp"
 	"github.com/adithyan-ak/agenthound/sdk/action"
 	"github.com/adithyan-ak/agenthound/sdk/common"
+	"github.com/adithyan-ak/agenthound/sdk/ingest"
 )
 
 const experimentsBody = `{"experiments":[{"experiment_id":"0","name":"Default"},{"experiment_id":"1","name":"Fine-tune-v3"}],"next_page_token":""}`
@@ -115,6 +116,10 @@ func TestCollect_MLflowHappy(t *testing.T) {
 	}
 	if res.Summary.CredentialsFound != 0 {
 		t.Errorf("CredentialsFound = %d, want 0 for metadata-only discoveries", res.Summary.CredentialsFound)
+	}
+	if res.Inventory == nil || res.Inventory.Name != "model_registry" ||
+		res.Inventory.State != ingest.OutcomeComplete || res.Inventory.Items != 0 {
+		t.Fatalf("inventory = %+v, want complete empty model registry", res.Inventory)
 	}
 	assertAnonymousInventoryClaim(t, node.Properties)
 }
@@ -361,8 +366,8 @@ func TestCollect_MLflow_Paginates(t *testing.T) {
 }
 
 // TestCollect_MLflow_RegisteredModels stubs the Registry endpoints and
-// asserts each model version emits one :MCPResource + PROVIDES_RESOURCE
-// edge — NOT a :Credential (verified via mlflow/store/model_registry/
+// asserts each model version emits one ModelArtifact, while their shared S3
+// root emits one ArtifactStore — NOT a Credential (verified via mlflow/store/model_registry/
 // sqlalchemy_store.py:1291-1306: get_model_version_download_uri
 // returns raw storage URIs, not presigned credentials).
 func TestCollect_MLflow_RegisteredModels(t *testing.T) {
@@ -399,38 +404,57 @@ func TestCollect_MLflow_RegisteredModels(t *testing.T) {
 	if got, _ := res.IngestData.Graph.Nodes[0].Properties["model_version_count"].(int); got != 2 {
 		t.Errorf("model_version_count = %v, want 2", got)
 	}
-	var resourceNodes, credNodes int
+	var artifactNodes, storeNodes, resourceNodes, credNodes int
 	for _, n := range res.IngestData.Graph.Nodes {
 		if len(n.Kinds) == 0 {
 			continue
 		}
 		switch n.Kinds[0] {
+		case "ModelArtifact":
+			artifactNodes++
+			if uri, _ := n.Properties["storage_uri"].(string); !strings.HasPrefix(uri, "s3://ml-artifacts/") {
+				t.Errorf("artifact storage_uri = %q, want sanitized s3 fixture URI", uri)
+			}
+		case "ArtifactStore":
+			storeNodes++
+			if n.Properties["root_uri"] != "s3://ml-artifacts" || n.Properties["scope"] != "remote" {
+				t.Errorf("artifact store = %+v", n.Properties)
+			}
 		case "MCPResource":
 			resourceNodes++
-			if uri, _ := n.Properties["uri"].(string); !strings.HasPrefix(uri, "s3://") {
-				t.Errorf("resource uri = %q, want s3:// prefix from fixture", uri)
-			}
-			if mt, _ := n.Properties["mime_type"].(string); mt != "application/x-mlflow-model" {
-				t.Errorf("resource mime_type = %q, want application/x-mlflow-model", mt)
-			}
 		case "Credential":
 			credNodes++
 		}
 	}
-	if resourceNodes != 2 {
-		t.Errorf(":MCPResource count = %d, want 2 (one per model version)", resourceNodes)
+	if artifactNodes != 2 || storeNodes != 1 {
+		t.Errorf("typed nodes = artifacts:%d stores:%d, want 2 and 1", artifactNodes, storeNodes)
+	}
+	if resourceNodes != 0 {
+		t.Errorf(":MCPResource count = %d, want zero non-MCP resources", resourceNodes)
 	}
 	if credNodes != 0 {
 		t.Errorf(":Credential count = %d, want 0 (Model Registry URIs are NOT credentials)", credNodes)
 	}
-	var edges int
+	var provides, stored int
 	for _, e := range res.IngestData.Graph.Edges {
-		if e.Kind == "PROVIDES_RESOURCE" && e.SourceKind == "MLflowServer" && e.TargetKind == "MCPResource" {
-			edges++
+		if e.Kind == "PROVIDES_RESOURCE" && e.SourceKind == "MLflowServer" && e.TargetKind == "ModelArtifact" {
+			provides++
+			if e.Properties["evidence_state"] != "verified" {
+				t.Errorf("model inventory evidence = %+v", e.Properties)
+			}
+		}
+		if e.Kind == "STORED_IN" && e.SourceKind == "ModelArtifact" && e.TargetKind == "ArtifactStore" {
+			stored++
+			if e.Properties["evidence_state"] != "observed" {
+				t.Errorf("storage evidence = %+v", e.Properties)
+			}
 		}
 	}
-	if edges != 2 {
-		t.Errorf("PROVIDES_RESOURCE edges = %d, want 2", edges)
+	if provides != 2 || stored != 2 {
+		t.Errorf("typed edges = provides:%d stored:%d, want 2 and 2", provides, stored)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeComplete || res.Inventory.Items != 2 {
+		t.Fatalf("inventory = %+v, want complete two-version registry", res.Inventory)
 	}
 }
 
@@ -456,6 +480,105 @@ func TestCollect_MLflow_ArtifactSensitivity(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("classifyArtifactSensitivity(%q) = %q, want %q", tc.uri, got, tc.want)
 		}
+	}
+}
+
+func TestCanonicalArtifactStoreIdentityAndRedaction(t *testing.T) {
+	sanitized := sanitizeArtifactURI("s3://user:secret@ML-BUCKET/models/v1?token=secret#fragment")
+	if sanitized != "s3://ml-bucket/models/v1" {
+		t.Fatalf("sanitized URI = %q", sanitized)
+	}
+	remoteA, ok := canonicalArtifactStore(sanitized, "mlflow-a")
+	if !ok || remoteA.RootURI != "s3://ml-bucket" || remoteA.Scope != "remote" {
+		t.Fatalf("remote store = %+v, ok=%v", remoteA, ok)
+	}
+	remoteB, ok := canonicalArtifactStore("s3://ml-bucket/other", "mlflow-b")
+	if !ok || remoteA.ID != remoteB.ID {
+		t.Fatalf("same remote root did not converge: %+v %+v", remoteA, remoteB)
+	}
+
+	localA, ok := canonicalArtifactStore("file:///tmp/a/model", "mlflow-a")
+	if !ok || localA.RootURI != "file:///" || localA.Scope != "service" {
+		t.Fatalf("local store = %+v, ok=%v", localA, ok)
+	}
+	localB, ok := canonicalArtifactStore("file:///tmp/b/model", "mlflow-b")
+	if !ok || localA.ID == localB.ID {
+		t.Fatalf("local stores from different services merged: %+v %+v", localA, localB)
+	}
+
+	for _, unresolved := range []string{
+		"models:/fraud/1", "runs:/run-1/model", "mlflow-artifacts:/exp/run/artifacts/model",
+	} {
+		if _, ok := canonicalArtifactStore(unresolved, "mlflow-a"); ok {
+			t.Errorf("unresolved locator %q created an ArtifactStore", unresolved)
+		}
+		if got := sanitizeArtifactURI(unresolved); got == "" {
+			t.Errorf("unresolved locator %q was not retained as sanitized metadata", unresolved)
+		}
+	}
+}
+
+func TestCollect_MLflow_RegistryLimitAndLookupFailureAreIncomplete(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		download  int
+		wantState ingest.OutcomeState
+	}{
+		{name: "pagination limit", download: http.StatusOK, wantState: ingest.OutcomeTruncated},
+		{name: "download lookup failure", download: http.StatusInternalServerError, wantState: ingest.OutcomePartial},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/2.0/mlflow/experiments/search":
+					_, _ = w.Write([]byte(`{"experiments":[],"next_page_token":""}`))
+				case "/api/2.0/mlflow/registered-models/search":
+					next := ""
+					if tc.wantState == ingest.OutcomeTruncated {
+						next = "more"
+					}
+					_, _ = fmt.Fprintf(w, `{"registered_models":[{"name":"model"}],"next_page_token":%q}`, next)
+				case "/api/2.0/mlflow/model-versions/search":
+					next := ""
+					if tc.wantState == ingest.OutcomeTruncated {
+						next = "more"
+					}
+					_, _ = fmt.Fprintf(w, `{"model_versions":[{"name":"model","version":"1"}],"next_page_token":%q}`, next)
+				case "/api/2.0/mlflow/model-versions/get-download-uri":
+					if tc.download != http.StatusOK {
+						w.WriteHeader(tc.download)
+						return
+					}
+					_, _ = w.Write([]byte(`{"artifact_uri":"s3://bucket/model/1"}`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			res, err := (&Collector{}).Collect(context.Background(), action.Target{
+				Address: strings.TrimPrefix(srv.URL, "http://"),
+			}, action.CollectOptions{MaxItems: 1})
+			if err != nil {
+				t.Fatalf("Collect: %v", err)
+			}
+			if res.Inventory == nil || res.Inventory.State != tc.wantState || res.Inventory.Items != 1 {
+				t.Fatalf("inventory = %+v, want %s with one artifact", res.Inventory, tc.wantState)
+			}
+			var artifacts, resources int
+			for _, node := range res.IngestData.Graph.Nodes {
+				switch node.Kinds[0] {
+				case "ModelArtifact":
+					artifacts++
+				case "MCPResource":
+					resources++
+				}
+			}
+			if artifacts != 1 || resources != 0 {
+				t.Fatalf("nodes = artifacts:%d MCPResources:%d", artifacts, resources)
+			}
+		})
 	}
 }
 
@@ -492,6 +615,9 @@ func TestCollect_MLflow_RegistryPartialFailure(t *testing.T) {
 	// Registry probes recorded as partials.
 	if res.Summary.PartialFailures < 2 {
 		t.Errorf("partial failures: got %d, want at least 2 (registered-models + model-versions)", res.Summary.PartialFailures)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeFailed {
+		t.Fatalf("unavailable registry inventory = %+v, want failed", res.Inventory)
 	}
 }
 
@@ -577,6 +703,9 @@ func TestCollect_CancellationStopsPerItemWalks(t *testing.T) {
 			}
 			if got := res.Summary.EndpointsProbed; got != tc.wantProbes {
 				t.Fatalf("endpoints probed = %d, want %d", got, tc.wantProbes)
+			}
+			if res.Inventory == nil || res.Inventory.State == ingest.OutcomeComplete {
+				t.Fatalf("canceled inventory became authoritative: %+v", res.Inventory)
 			}
 		})
 	}

--- a/server/internal/ingest/publication_integration_test.go
+++ b/server/internal/ingest/publication_integration_test.go
@@ -896,6 +896,141 @@ func TestIntegrationServiceInventoryPreservesThenRetiresLegacyResources(t *testi
 	}
 }
 
+func TestIntegrationTypedResourceMigrationKeepsHistoricalScan(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		serviceKind     string
+		endpoint        string
+		inventoryName   string
+		legacyURI       string
+		typedKind       string
+		typedProperties map[string]any
+	}{
+		{
+			name: "jupyter", serviceKind: "JupyterServer", endpoint: "http://jupyter.example:8888",
+			inventoryName: "contents", legacyURI: "jupyter://jupyter.example:8888/work/demo.ipynb",
+			typedKind: "WorkspaceFile", typedProperties: map[string]any{
+				"name": "demo.ipynb", "path": "work/demo.ipynb", "entry_type": "notebook",
+			},
+		},
+		{
+			name: "mlflow", serviceKind: "MLflowServer", endpoint: "http://mlflow.example:5000",
+			inventoryName: "model_registry", legacyURI: "s3://models/fraud/3",
+			typedKind: "ModelArtifact", typedProperties: map[string]any{
+				"name": "fraud", "version": "3", "storage_uri": "s3://models/fraud/3",
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, pipeline, db, _, pool := publicationIntegrationHarness(t, false)
+			identity := testCollectionIdentity()
+			root := sdkingest.CollectorRootCoverageKey("scan")
+			serviceID := sdkingest.ComputeNodeID(test.serviceKind, test.endpoint)
+			inventory := sdkingest.CanonicalCoverageKey(
+				"scan", "service_inventory", test.name+".collect\x00"+serviceID+"\x00"+test.inventoryName,
+			)
+			legacyID := sdkingest.ComputeNodeID("MCPResource", serviceID, test.legacyURI)
+			var typedID string
+			switch test.typedKind {
+			case "WorkspaceFile":
+				workspacePath, ok := test.typedProperties["path"].(string)
+				if !ok {
+					t.Fatalf("workspace path fixture = %v", test.typedProperties["path"])
+				}
+				typedID = sdkingest.ComputeNodeID(test.typedKind, serviceID, workspacePath)
+			case "ModelArtifact":
+				name, nameOK := test.typedProperties["name"].(string)
+				version, versionOK := test.typedProperties["version"].(string)
+				if !nameOK || !versionOK {
+					t.Fatalf("model identity fixture = %+v", test.typedProperties)
+				}
+				typedID = sdkingest.ComputeNodeID(
+					test.typedKind, serviceID, name, version,
+				)
+			}
+			serviceNode := func() sdkingest.Node {
+				return sdkingest.Node{
+					ID: serviceID, Kinds: []string{test.serviceKind, "AIService"},
+					Properties:         map[string]any{"objectid": serviceID, "name": test.name, "endpoint": test.endpoint},
+					ObservationDomains: []string{root},
+				}
+			}
+			report := func(withInventory bool) *sdkingest.CollectionReport {
+				outcomes := []sdkingest.CollectionOutcome{{
+					Collector: "scan", CoverageKey: root, Target: "scan", Method: "collect", State: sdkingest.OutcomeComplete,
+				}}
+				keys := []string{root}
+				if withInventory {
+					keys = append(keys, inventory)
+					outcomes = append(outcomes, sdkingest.CollectionOutcome{
+						Collector: "scan", CoverageKey: inventory, ParentCoverageKey: root,
+						Target: serviceID, Method: "service_inventory:" + test.inventoryName, State: sdkingest.OutcomeComplete,
+					})
+				}
+				return &sdkingest.CollectionReport{State: sdkingest.OutcomeComplete, CoverageKeys: keys, Outcomes: outcomes}
+			}
+			ingestGraph := func(scanID string, collection *sdkingest.CollectionReport, graphData sdkingest.GraphData) {
+				t.Helper()
+				data := newPublicationIntegrationData("scan", scanID)
+				data.Meta.Collection = collection
+				data.Graph = graphData
+				if _, err := pipeline.Ingest(ctx, data); err != nil {
+					t.Fatalf("ingest %s: %v", scanID, err)
+				}
+			}
+
+			oldScanID := "typed-migration-" + test.name + "-old"
+			ingestGraph(oldScanID, report(false), sdkingest.GraphData{
+				Nodes: []sdkingest.Node{serviceNode(), {
+					ID: legacyID, Kinds: []string{"MCPResource"},
+					Properties:         map[string]any{"objectid": legacyID, "name": test.name + " legacy", "uri": test.legacyURI},
+					ObservationDomains: []string{root},
+				}},
+				Edges: []sdkingest.Edge{{
+					Source: serviceID, Target: legacyID, Kind: "PROVIDES_RESOURCE",
+					SourceKind: test.serviceKind, TargetKind: "MCPResource",
+					Properties: map[string]any{"risk_weight": 0.2}, ObservationDomains: []string{root},
+				}},
+			})
+
+			typedProps := map[string]any{"objectid": typedID, "sensitivity": "high"}
+			for key, value := range test.typedProperties {
+				typedProps[key] = value
+			}
+			ingestGraph("typed-migration-"+test.name+"-new", report(true), sdkingest.GraphData{
+				Nodes: []sdkingest.Node{serviceNode(), {
+					ID: typedID, Kinds: []string{test.typedKind}, Properties: typedProps,
+					ObservationDomains: []string{inventory},
+				}},
+				Edges: []sdkingest.Edge{{
+					Source: serviceID, Target: typedID, Kind: "PROVIDES_RESOURCE",
+					SourceKind: test.serviceKind, TargetKind: test.typedKind,
+					Properties: map[string]any{
+						"risk_weight": 0.2, "confidence": 1.0, "evidence_state": "verified",
+						"last_seen": "2026-09-04T12:00:00Z", "evidence": map[string]any{"source": test.inventoryName},
+					},
+					ObservationDomains: []string{inventory},
+				}},
+			})
+
+			present := func(rawID string) bool {
+				scopedID := sdkingest.ScopedNodeID(sdkingest.ScopeNetworkContext, identity.NetworkContextID, rawID)
+				node, _, err := db.GetNode(ctx, scopedID)
+				if err != nil {
+					t.Fatalf("read node %s: %v", scopedID, err)
+				}
+				return node != nil
+			}
+			if present(legacyID) || !present(typedID) {
+				t.Fatalf("current projection did not migrate %s resource", test.name)
+			}
+			if historical, err := appdb.NewScanStore(pool).GetScan(ctx, oldScanID); err != nil || historical == nil {
+				t.Fatalf("historical scan after migration = %+v, %v", historical, err)
+			}
+		})
+	}
+}
+
 func TestIntegrationExhaustiveRootRemovesMissingChildAcrossGraphAndPublication(t *testing.T) {
 	ctx, pipeline, db, _, pool := freshPublicationIntegrationHarness(t)
 	root := sdkingest.CanonicalCoverageKey("mcp", "root", "collect")

--- a/server/internal/ingest/validator_test.go
+++ b/server/internal/ingest/validator_test.go
@@ -164,6 +164,91 @@ func TestValidatorTypedResourceRequiresExactPairAndEvidence(t *testing.T) {
 	}
 }
 
+func TestValidatorAcceptsJupyterAndMLflowTypedResources(t *testing.T) {
+	evidence := func(state string) map[string]any {
+		return map[string]any{
+			"risk_weight": 0.2, "confidence": 1.0, "evidence_state": state,
+			"last_seen": "2026-08-27T12:00:00Z",
+			"evidence":  map[string]any{"source": "collector"},
+		}
+	}
+	t.Run("Jupyter workspace file", func(t *testing.T) {
+		data := validIngestData()
+		scope := data.Meta.Collection.CoverageKeys[0]
+		serverID := "sha256:jupyter"
+		fileID := ingest.ComputeNodeID("WorkspaceFile", serverID, "work/demo.ipynb")
+		data.Graph.Nodes = []ingest.Node{
+			{
+				ID: serverID, Kinds: []string{"JupyterServer", "AIService"},
+				Properties:         map[string]any{"objectid": serverID, "endpoint": "http://jupyter:8888"},
+				ObservationDomains: []string{scope},
+			},
+			{
+				ID: fileID, Kinds: []string{"WorkspaceFile"},
+				Properties: map[string]any{
+					"objectid": fileID, "path": "work/demo.ipynb", "entry_type": "notebook",
+				},
+				ObservationDomains: []string{scope},
+			},
+		}
+		data.Graph.Edges = []ingest.Edge{{
+			Source: serverID, Target: fileID, Kind: "PROVIDES_RESOURCE",
+			SourceKind: "JupyterServer", TargetKind: "WorkspaceFile",
+			Properties: evidence("verified"), ObservationDomains: []string{scope},
+		}}
+		if err := NewValidator().Validate(data); err != nil {
+			t.Fatalf("valid WorkspaceFile graph rejected: %v", err)
+		}
+		data.Graph.Nodes[1].ID = "sha256:wrong"
+		data.Graph.Edges[0].Target = "sha256:wrong"
+		assertValidationError(t, NewValidator().Validate(data), "graph.edges[0].target")
+	})
+
+	t.Run("MLflow model artifact and store", func(t *testing.T) {
+		data := validIngestData()
+		scope := data.Meta.Collection.CoverageKeys[0]
+		serverID := "sha256:mlflow"
+		artifactID := ingest.ComputeNodeID("ModelArtifact", serverID, "fraud", "3")
+		storeID := ingest.ComputeNodeID("ArtifactStore", "s3://models")
+		data.Graph.Nodes = []ingest.Node{
+			{
+				ID: serverID, Kinds: []string{"MLflowServer", "AIService"},
+				Properties:         map[string]any{"objectid": serverID, "endpoint": "http://mlflow:5000"},
+				ObservationDomains: []string{scope},
+			},
+			{
+				ID: artifactID, Kinds: []string{"ModelArtifact"},
+				Properties:         map[string]any{"objectid": artifactID, "name": "fraud", "version": "3"},
+				ObservationDomains: []string{scope},
+			},
+			{
+				ID: storeID, Kinds: []string{"ArtifactStore"},
+				Properties:         map[string]any{"objectid": storeID, "root_uri": "s3://models"},
+				ObservationDomains: []string{scope},
+			},
+		}
+		data.Graph.Edges = []ingest.Edge{
+			{
+				Source: serverID, Target: artifactID, Kind: "PROVIDES_RESOURCE",
+				SourceKind: "MLflowServer", TargetKind: "ModelArtifact",
+				Properties: evidence("verified"), ObservationDomains: []string{scope},
+			},
+			{
+				Source: artifactID, Target: storeID, Kind: "STORED_IN",
+				SourceKind: "ModelArtifact", TargetKind: "ArtifactStore",
+				Properties: evidence("observed"), ObservationDomains: []string{scope},
+			},
+		}
+		if err := NewValidator().Validate(data); err != nil {
+			t.Fatalf("valid MLflow typed graph rejected: %v", err)
+		}
+		data.Graph.Nodes[1].ID = "sha256:wrong"
+		data.Graph.Edges[0].Target = "sha256:wrong"
+		data.Graph.Edges[1].Source = "sha256:wrong"
+		assertValidationError(t, NewValidator().Validate(data), "graph.edges[0].target")
+	})
+}
+
 func validInstructionEvidenceData(t *testing.T) *ingest.IngestData {
 	t.Helper()
 	data := validIngestData()

--- a/server/ui/src/entities/node/model.test.ts
+++ b/server/ui/src/entities/node/model.test.ts
@@ -23,6 +23,17 @@ describe("node evidence accessors", () => {
     ).toBe("Authorization");
   });
 
+  it("uses an explicit display name for versioned artifacts", () => {
+    expect(
+      displayName(
+        node(
+          { name: "fraud-detector", display_name: "fraud-detector:3" },
+          ["ModelArtifact"],
+        ),
+      ),
+    ).toBe("fraud-detector:3");
+  });
+
   it("requires affirmative evidence and renders local processes", () => {
     const unknown = node({});
     const unsupportedClaim = node({ auth_method: "none", auth_evidence: "unknown" });

--- a/server/ui/src/entities/node/model.ts
+++ b/server/ui/src/entities/node/model.ts
@@ -31,7 +31,8 @@ export function displayName(node: APINode): string {
       )
     : undefined;
   return String(
-    node.properties.name ??
+    node.properties.display_name ??
+      node.properties.name ??
       aggregatedName ??
       node.properties.uri ??
       node.properties.path ??

--- a/server/ui/src/features/findings/lib/property-chips.test.ts
+++ b/server/ui/src/features/findings/lib/property-chips.test.ts
@@ -59,3 +59,29 @@ describe("authentication property chips", () => {
     expect(chips).not.toContain("auth-unknown");
   });
 });
+
+describe("typed resource property chips", () => {
+  it("shows the stable distinguishing metadata", () => {
+    expect(
+      getPropertyChips("VectorCollection", {
+        point_count: 1200,
+        sensitivity: "high",
+      }),
+    ).toEqual(["1200 points", "high"]);
+    expect(
+      getPropertyChips("WorkspaceFile", {
+        entry_type: "notebook",
+        mime_type: "application/x-ipynb+json",
+      }),
+    ).toEqual(["notebook", "application/x-ipynb+json"]);
+    expect(
+      getPropertyChips("ModelArtifact", {
+        version: "3",
+        storage_scheme: "s3",
+      }),
+    ).toEqual(["v3", "s3://"]);
+    expect(
+      getPropertyChips("ArtifactStore", { provider: "s3", scope: "remote" }),
+    ).toEqual(["s3", "remote"]);
+  });
+});

--- a/server/ui/src/features/findings/lib/property-chips.ts
+++ b/server/ui/src/features/findings/lib/property-chips.ts
@@ -44,6 +44,34 @@ export function getPropertyChips(kind: string, properties: Record<string, unknow
       chips.push(typeof sensitivity === "string" ? sensitivity : "unknown");
       break;
     }
+    case "VectorCollection": {
+      const pointCount = properties.point_count;
+      if (typeof pointCount === "number") chips.push(`${pointCount} points`);
+      const sensitivity = properties.sensitivity;
+      if (typeof sensitivity === "string") chips.push(sensitivity);
+      break;
+    }
+    case "WorkspaceFile": {
+      const entryType = properties.entry_type;
+      if (typeof entryType === "string") chips.push(entryType);
+      const mimeType = properties.mime_type;
+      if (typeof mimeType === "string" && mimeType !== "") chips.push(mimeType);
+      break;
+    }
+    case "ModelArtifact": {
+      const version = properties.version;
+      if (typeof version === "string") chips.push(`v${version}`);
+      const scheme = properties.storage_scheme;
+      if (typeof scheme === "string" && scheme !== "") chips.push(`${scheme}://`);
+      break;
+    }
+    case "ArtifactStore": {
+      const provider = properties.provider;
+      if (typeof provider === "string") chips.push(provider);
+      const scope = properties.scope;
+      if (typeof scope === "string") chips.push(scope);
+      break;
+    }
     case "Host": {
       const hostname = properties.hostname;
       if (typeof hostname === "string") chips.push(hostname);


### PR DESCRIPTION
## Problem and result

Jupyter workspace entries and MLflow persisted model versions were represented as MCP resources, and generic path cleanup could collapse distinct source identifiers or lose part of a reported storage locator. This change gives those existing inventories accurate resource semantics while preserving source-reported identity and the current scan and investigation workflow.

- emit Jupyter entries as `WorkspaceFile`, preserving source-significant path characters
- emit MLflow registered model versions as immutable `ModelArtifact` resources, distinct from served `AIModel` nodes
- keep reported artifact locators as sanitized metadata
- create `ArtifactStore` only for an unambiguous physical root and connect it with `STORED_IN`
- preserve Azure filesystem/container identity and remote object-key path segments
- scope remote stores deterministically and local/DBFS stores to the owning MLflow service
- document and test current projection migration, historical scan retention, and triage compatibility

## Acceptance checks against #83

- [x] Newly collected Jupyter and MLflow resources use correct non-MCP semantics in artifact, ingest, API, and UI paths.
- [x] Persisted MLflow artifacts remain distinct from models served by runtimes.
- [x] Deterministic identities preserve source-significant Jupyter paths, Azure containers, and remote object keys.
- [x] Ambiguous and indirect locators remain metadata and do not invent a store or access claim.
- [x] Partial, failed, truncated, and targeted observations preserve omitted resources.
- [x] Supported V1 artifacts remain ingestible; complete replacement updates current projection while historical scan evidence remains available.
- [x] Existing processors and triage fingerprints remain compatible without adding findings or reachability claims.
- [x] No commands, provider flags, setup flow, state store, or infrastructure dependency is added.

## Validation

- `go test ./...`
- `golangci-lint run` for changed Go packages: 0 issues
- UI: 273 tests passed; production build passed
- Neo4j 4 + PostgreSQL 16 integration: Jupyter and MLflow typed-resource migration keeps historical scans

The repository-wide `make check` currently stops on six pre-existing `SA5011` findings in unchanged `modules/litellmcollect/collector_test.go`; the changed packages pass lint.

Part 2 of 3 for #83. Stacked on #156.
