### PR TITLE
feat(graph): map Open WebUI backend topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The collector writes an ingest-valid artifact before collection and checkpoints 
 | **Qdrant** | Typed vector collections, point counts, schema context, and bounded point references in deep mode | Anonymous exposure and sensitive vector-data analysis without retaining vector payloads |
 | **MLflow** | Experiment/run counts, typed model versions, sanitized storage URIs, and safely identified artifact-store roots | Anonymous tracking and registry exposure analysis without treating persisted artifacts as served models |
 | **Jupyter** | Sessions and typed workspace files from bounded notebook/content trees, first anonymously and then with a compatible token | Distinguishes public from credential-gated notebook access; incomplete walks preserve earlier files |
-| **Open WebUI / LangServe** | Open WebUI authentication posture and authenticated upstream/RAG credential inventory; LangServe fingerprinting | Credential expansion and exposed-service analysis |
+| **Open WebUI / LangServe** | Open WebUI authentication posture, explicit configured Ollama/Qdrant backends, and authenticated upstream/RAG credential inventory; LangServe fingerprinting | Credential expansion and exposed-service analysis; configured backend links do not overclaim reachability |
 
 ## 🚀 Quick start
 

--- a/collector/cli/planner_actions.go
+++ b/collector/cli/planner_actions.go
@@ -34,7 +34,7 @@ var serviceNodeKinds = map[string]string{
 }
 
 var serviceInventoryNames = map[string]string{
-	"litellm": "inventory", "openwebui": "backends", "jupyter": "contents",
+	"litellm": "inventory", "openwebui": "configuration", "jupyter": "contents",
 	"qdrant": "collections", "mlflow": "model_registry", "ollama": "models",
 }
 
@@ -51,6 +51,11 @@ func (a serviceCollectAction) Candidates(view View) []Candidate {
 			if !ok {
 				continue
 			}
+			inventoryName := serviceInventoryNames[service]
+			inventoryKey := serviceInventoryCoverageKey(mod.ID(), node.ID, inventoryName)
+			if service == "openwebui" && view.Completed[completedInventoryKey(inventoryKey)] {
+				continue
+			}
 			base := Candidate{
 				ModuleID: mod.ID(), Target: action.Target{
 					Kind: "url", Address: endpoint,
@@ -58,7 +63,7 @@ func (a serviceCollectAction) Candidates(view View) []Candidate {
 				},
 				Inputs: map[string]string{
 					"service": service, "node_id": node.ID,
-					"inventory_name":      serviceInventoryNames[service],
+					"inventory_name":      inventoryName,
 					"observation_domains": strings.Join(node.ObservationDomains, "\x1f"),
 				},
 			}
@@ -240,17 +245,23 @@ func serviceInventoryOutcome(
 	if serviceID == "" {
 		serviceID = canonicalTarget(candidate.Target.Address)
 	}
-	key := ingest.CanonicalCoverageKey(
-		"scan",
-		"service_inventory",
-		candidate.ModuleID+"\x00"+serviceID+"\x00"+name,
-	)
+	key := serviceInventoryCoverageKey(candidate.ModuleID, serviceID, name)
 	return ingest.CollectionOutcome{
 		Collector: "scan", CoverageKey: key,
 		ParentCoverageKey: ingest.CollectorRootCoverageKey("scan"),
 		Target:            serviceID, Method: "service_inventory:" + name,
 		State: state, Items: items, Error: errorText,
 	}
+}
+
+func serviceInventoryCoverageKey(moduleID, serviceID, name string) string {
+	return ingest.CanonicalCoverageKey(
+		"scan", "service_inventory", moduleID+"\x00"+serviceID+"\x00"+name,
+	)
+}
+
+func completedInventoryKey(coverageKey string) string {
+	return "service_inventory_complete\x00" + coverageKey
 }
 
 // ollamaEmbeddingAction is deliberately separate from ordinary Ollama

--- a/collector/cli/planner_test.go
+++ b/collector/cli/planner_test.go
@@ -11,6 +11,7 @@ import (
 	a2acollector "github.com/adithyan-ak/agenthound/modules/a2a"
 	_ "github.com/adithyan-ak/agenthound/modules/litellmcollect"
 	_ "github.com/adithyan-ak/agenthound/modules/ollamacollect"
+	_ "github.com/adithyan-ak/agenthound/modules/openwebuicollect"
 	_ "github.com/adithyan-ak/agenthound/modules/qdrantcollect"
 
 	"github.com/adithyan-ak/agenthound/sdk/action"
@@ -403,6 +404,37 @@ func TestDeepServiceCollectionDoesNotRepeatBaseInventory(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestCompleteOpenWebUIInventorySuppressesRemainingCredentialGuesses(t *testing.T) {
+	const serviceID = "openwebui-1"
+	graph := ingest.GraphData{Nodes: []ingest.Node{
+		{
+			ID: serviceID, Kinds: []string{"OpenWebUIInstance", "AIService"},
+			Properties: map[string]any{"endpoint": "http://openwebui:3000"},
+		},
+		{
+			ID: "credential-1", Kinds: []string{"Credential"},
+			Properties: map[string]any{
+				"value": "admin-token", "value_hash": "hash",
+				"material_status": string(common.CredentialMaterialObserved),
+				"auth_method":     string(common.AuthAPIKey), "type": "api_key",
+			},
+		},
+	}}
+	coverageKey := serviceInventoryCoverageKey("openwebui.collect", serviceID, "configuration")
+	baseline := buildPlannerView(graph, nil, map[string]bool{}, false, false)
+	if got := len((serviceCollectAction{}).Candidates(baseline)); got < 2 {
+		t.Fatalf("baseline Open WebUI candidates = %d, want anonymous and credential attempts", got)
+	}
+	view := buildPlannerView(
+		graph, nil, map[string]bool{completedInventoryKey(coverageKey): true}, false, false,
+	)
+	for _, candidate := range (serviceCollectAction{}).Candidates(view) {
+		if candidate.Inputs["service"] == "openwebui" {
+			t.Fatalf("complete configuration inventory scheduled another Open WebUI attempt: %+v", candidate)
+		}
 	}
 }
 

--- a/collector/cli/scan_unified.go
+++ b/collector/cli/scan_unified.go
@@ -692,6 +692,12 @@ func (r *scanRuntime) mergeInventoryOutcome(outcome ingest.CollectionOutcome) {
 			r.artifact.Meta.Collection.Outcomes,
 		)
 	}()
+	if outcome.State == ingest.OutcomeComplete {
+		if r.completed == nil {
+			r.completed = make(map[string]bool)
+		}
+		r.completed[completedInventoryKey(outcome.CoverageKey)] = true
+	}
 	declared := false
 	for _, key := range r.artifact.Meta.Collection.CoverageKeys {
 		if key == outcome.CoverageKey {

--- a/collector/cli/scan_unified_test.go
+++ b/collector/cli/scan_unified_test.go
@@ -143,6 +143,9 @@ func TestInventoryOutcomeSuccessDominatesFailedCredentialAttempts(t *testing.T) 
 	if !runtime.inventoryCoverageComplete() {
 		t.Fatal("authoritative success was downgraded by a failed guess")
 	}
+	if !runtime.completed[completedInventoryKey(key)] {
+		t.Fatal("complete Open WebUI inventory did not suppress later credential guesses")
+	}
 	var matches []ingest.CollectionOutcome
 	for _, outcome := range runtime.artifact.Meta.Collection.Outcomes {
 		if outcome.CoverageKey == key {

--- a/docs/operator/scanner.md
+++ b/docs/operator/scanner.md
@@ -55,6 +55,8 @@ For A2A, a bearer retry remains eligible when the bounded anonymous probe is pro
 
 Anonymous collection covers applicable LiteLLM, Open WebUI, Jupyter, Qdrant, MLflow, and Ollama endpoints. New targets and credentials are indexed as they appear, allowing useful authenticated work during the same scan.
 
+Open WebUI configuration inventory requires an authorized credential. AgentHound reads the configured Ollama backends and enabled Qdrant external-knowledge connections, but never stores their backend authentication material. One successful exhaustive configuration pass completes that Open WebUI inventory and suppresses remaining credential guesses; earlier rejected guesses remain in the action journal and do not erase the successful result. A failed or truncated configuration endpoint keeps the inventory incomplete. Backend links mean “configured,” not “reachable”: AgentHound does not infer them from matching hosts or upgrade them because a separate destination probe succeeded.
+
 ## Instruction integrity
 
 AgentHound classifies collected `AGENTS.md`, `CLAUDE.md`, Cursor, Copilot, and related instruction sources with deterministic content rules. Ordinary policy language such as “never use production credentials” or “use X instead of Y” remains clean. Evidence composes only within a bounded directive and cannot cross headings or inert-region boundaries. Explicitly labeled examples and detector fixtures remain clean unless surrounding text tells the agent to execute them.

--- a/docs/reference/graph-model.md
+++ b/docs/reference/graph-model.md
@@ -75,7 +75,7 @@ Raw edges come from collectors or same-scan proof actions.
 
 `CREDENTIAL_ACCESS_OBSERVED` connects a Credential to the exact MCPResource read successfully after the anonymous control was denied. `PUBLIC_ACCESS_OBSERVED` connects the MCPServer to a resource read anonymously. Both are supporting evidence rather than general traversal shortcuts.
 
-`PROVIDES_RESOURCE` retains historical service-to-`MCPResource` variants for V1 artifacts. New collection emits typed pairs: QdrantInstance→VectorCollection, VectorCollection→VectorPoint, JupyterServer→WorkspaceFile, and MLflowServer→ModelArtifact. `USES_BACKEND` records an explicit service dependency; `STORED_IN` records a model artifact's reported physical store.
+`PROVIDES_RESOURCE` retains historical service-to-`MCPResource` variants for V1 artifacts. New collection emits typed pairs: QdrantInstance→VectorCollection, VectorCollection→VectorPoint, JupyterServer→WorkspaceFile, and MLflowServer→ModelArtifact. `USES_BACKEND` records an explicit service dependency; Open WebUI currently emits it for configured Ollama and enabled Qdrant backends. `STORED_IN` records a model artifact's reported physical store. `EXPOSES` remains accepted for historical V1 artifacts but is no longer emitted for Open WebUI backends.
 
 `ArtifactStore` is created only for a safely canonicalized physical root such as a cloud bucket, container, filesystem, DBFS root, or HDFS authority. Azure ABFS/WASB filesystem or container names are part of that root identity. Object-store key paths are retained as reported rather than cleaned as local filesystem paths. Local filesystem and DBFS roots are scoped to their owning MLflow service. Indirect `models:`, `runs:`, and `mlflow-artifacts:` locators remain sanitized `ModelArtifact` metadata and do not create a store node.
 
@@ -119,7 +119,7 @@ The migrated resource kinds are not inputs to the existing finding processors, s
 
 ## Coverage and lifecycle
 
-Each collector reports outcomes such as `complete`, `partial`, `failed`, `truncated`, or `not_applicable`. Service resources belong to a stable service-instance inventory surface. Only a complete surface can reconcile its children; failed credential guesses, truncation, and partial traversal preserve earlier facts. The shared autonomous-scan root becomes complete only when every blocking inventory surface is complete.
+Each collector reports outcomes such as `complete`, `partial`, `failed`, `truncated`, or `not_applicable`. Service resources belong to a stable service-instance inventory surface. Only a complete surface can reconcile its children; failed credential guesses, truncation, and partial traversal preserve earlier facts. For Open WebUI, one authorized exhaustive configuration pass completes only that service's configuration surface and stops later credential guesses; earlier failed attempts remain journal evidence without downgrading it. The shared autonomous-scan root becomes complete only when every blocking inventory surface is complete.
 
 Composite analysis is rebuilt as one epoch after raw reconciliation. Published scan metadata records both submitted counts and the resulting graph totals.
 

--- a/modules/openwebuicollect/canonicalize.go
+++ b/modules/openwebuicollect/canonicalize.go
@@ -3,8 +3,8 @@ package openwebuicollect
 import "github.com/adithyan-ak/agenthound/sdk/action"
 
 // canonicalizeBackendURL applies the same endpoint identity used by Ollama's
-// direct collectors. Absolute URLs use ordinary HTTP effective ports; the
-// Ollama default applies only to host-shaped values.
+// direct collectors. URL-shaped values retain their explicit port and base
+// path; the Ollama default applies only to host-shaped values.
 //
 // Open WebUI's OLLAMA_BASE_URLS entries may lack a scheme (Open WebUI
 // stores host:port in some flows) — we default to http:// so url.Parse
@@ -18,10 +18,12 @@ import "github.com/adithyan-ak/agenthound/sdk/action"
 // canonicalizes each entry before emitting placeholder OllamaInstance
 // nodes.
 func canonicalizeBackendURL(raw string) string {
-	canonical, err := action.CanonicalEndpointIdentity(
+	canonical := action.EndpointBaseURL(
 		action.Target{Kind: "url", Address: raw}, 11434, "http",
 	)
-	if err != nil {
+	if _, err := action.CanonicalEndpointIdentity(
+		action.Target{Kind: "url", Address: canonical}, 11434, "http",
+	); err != nil {
 		return ""
 	}
 	return canonical

--- a/modules/openwebuicollect/canonicalize.go
+++ b/modules/openwebuicollect/canonicalize.go
@@ -1,16 +1,10 @@
 package openwebuicollect
 
-import (
-	"fmt"
-	"net/url"
-	"strconv"
-	"strings"
-)
+import "github.com/adithyan-ak/agenthound/sdk/action"
 
-// canonicalizeBackendURL normalizes a captured backend URL to
-// "scheme://host:port" (no path, no query). Returns empty when the
-// input is unparseable so the caller skips the emission rather than
-// producing a junk endpoint.
+// canonicalizeBackendURL applies the same endpoint identity used by Ollama's
+// direct collectors. Absolute URLs use ordinary HTTP effective ports; the
+// Ollama default applies only to host-shaped values.
 //
 // Open WebUI's OLLAMA_BASE_URLS entries may lack a scheme (Open WebUI
 // stores host:port in some flows) — we default to http:// so url.Parse
@@ -24,29 +18,21 @@ import (
 // canonicalizes each entry before emitting placeholder OllamaInstance
 // nodes.
 func canonicalizeBackendURL(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
+	canonical, err := action.CanonicalEndpointIdentity(
+		action.Target{Kind: "url", Address: raw}, 11434, "http",
+	)
+	if err != nil {
 		return ""
 	}
-	if !strings.Contains(raw, "://") {
-		raw = "http://" + raw
-	}
-	u, err := url.Parse(raw)
-	if err != nil || u.Host == "" {
+	return canonical
+}
+
+func canonicalizeQdrantBackendURL(raw string) string {
+	canonical, err := action.CanonicalEndpointIdentity(
+		action.Target{Kind: "url", Address: raw}, 6333, "http",
+	)
+	if err != nil {
 		return ""
 	}
-	host := u.Hostname()
-	port := u.Port()
-	if port == "" {
-		// Default Ollama port — matches what ollamafp uses for objectid.
-		port = "11434"
-	}
-	if _, err := strconv.Atoi(port); err != nil {
-		return ""
-	}
-	scheme := u.Scheme
-	if scheme == "" {
-		scheme = "http"
-	}
-	return fmt.Sprintf("%s://%s:%s", scheme, host, port)
+	return canonical
 }

--- a/modules/openwebuicollect/collector.go
+++ b/modules/openwebuicollect/collector.go
@@ -10,14 +10,15 @@
 // POSTURE properties onto the existing :OpenWebUIInstance node:
 // signup_enabled and auth_required.
 //
-// CREDENTIAL-BEARING (planner supplies compatible key material): four admin-gated probes
-// enumerate configured upstream provider API keys and emit one
+// CREDENTIAL-BEARING (planner supplies compatible key material): admin-gated probes
+// enumerate configured backends and upstream provider API keys and emit one
 // :Credential per key, each linked via an EXPOSES_CREDENTIAL edge:
 //
 //	GET /openai/config              — OPENAI_API_KEYS[] + OPENAI_API_BASE_URLS[]
 //	GET /ollama/config              — OLLAMA_BASE_URLS[] + OLLAMA_API_CONFIGS{key}
 //	GET /api/v1/retrieval/config    — RAG / OCR / websearch keys (recursive walker)
 //	GET /api/v1/retrieval/embedding — nested openai_config.key / ollama_config.key / ...
+//	GET /api/v1/knowledge/external/connections — sanitized external knowledge backends
 //
 // The Open WebUI upstream field name is `key` (per
 // backend/open_webui/routers/ollama.py:189-192 `get_api_key`); the
@@ -44,6 +45,7 @@
 //	GET /ollama/config             — authenticated Ollama upstream keys
 //	GET /api/v1/retrieval/config   — authenticated RAG + external keys
 //	GET /api/v1/retrieval/embedding — authenticated embedding config
+//	GET /api/v1/knowledge/external/connections — authenticated backend inventory
 //
 // /api/v1/retrieval/reranking does NOT exist on Open WebUI (verified
 // via full route enumeration in retrieval.py). Rerank config
@@ -57,6 +59,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -116,7 +119,13 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 
 	client := common.NoRedirectClient(timeout)
 
-	res := &action.CollectResult{IngestData: &ingest.IngestData{}}
+	res := &action.CollectResult{
+		IngestData: &ingest.IngestData{},
+		Inventory: &action.InventoryResult{
+			Name: "configuration", State: ingest.OutcomeFailed,
+			Error: "authenticated backend configuration was not read",
+		},
+	}
 
 	res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
 		ID:    openwebuiID,
@@ -177,11 +186,19 @@ func (l *Collector) Collect(ctx context.Context, t action.Target, opts action.Co
 	//    still runs.
 	remaining := maxItems
 	remaining = runOpenAIConfig(ctx, client, res, opts, openwebuiID, baseURL, apiKey, remaining)
-	remaining = runOllamaConfig(ctx, client, res, opts, openwebuiID, baseURL, apiKey, remaining)
+	remaining, ollamaInventory := runOllamaConfig(
+		ctx, client, res, opts, openwebuiID, baseURL, apiKey, remaining, maxItems,
+	)
+	qdrantInventory := runExternalKnowledgeConnections(
+		ctx, client, res, openwebuiID, baseURL, apiKey,
+		maxItems-ollamaInventory.Items,
+	)
+	res.Inventory = combineBackendInventory(ollamaInventory, qdrantInventory)
 	remaining = runRetrievalWalk(ctx, client, res, opts, openwebuiID, baseURL, apiKey,
 		"/api/v1/retrieval/config", "retrieval_config", remaining)
-	_ = runRetrievalWalk(ctx, client, res, opts, openwebuiID, baseURL, apiKey,
+	remaining = runRetrievalWalk(ctx, client, res, opts, openwebuiID, baseURL, apiKey,
 		"/api/v1/retrieval/embedding", "retrieval_embedding", remaining)
+	finalizeConfigurationInventory(res, remaining, maxItems)
 
 	slog.Info("openwebui collection complete",
 		"endpoint", baseURL,
@@ -251,6 +268,84 @@ func probeGET(
 		return nil
 	}
 	return body
+}
+
+type backendInventoryProbe struct {
+	State ingest.OutcomeState
+	Items int
+	Error string
+}
+
+func combineBackendInventory(probes ...backendInventoryProbe) *action.InventoryResult {
+	result := &action.InventoryResult{Name: "configuration", State: ingest.OutcomeComplete}
+	var hasFailure, hasPartial, hasTruncation bool
+	for _, probe := range probes {
+		result.Items += probe.Items
+		result.Error = appendInventoryError(result.Error, probe.Error)
+		switch probe.State {
+		case ingest.OutcomeFailed, ingest.OutcomeNotApplicable, ingest.OutcomeUnknown:
+			hasFailure = true
+		case ingest.OutcomePartial:
+			hasPartial = true
+		case ingest.OutcomeTruncated:
+			hasTruncation = true
+		}
+	}
+	switch {
+	case hasFailure && result.Items == 0:
+		result.State = ingest.OutcomeFailed
+	case hasFailure || hasPartial:
+		result.State = ingest.OutcomePartial
+	case hasTruncation:
+		result.State = ingest.OutcomeTruncated
+	}
+	if result.State == ingest.OutcomeComplete {
+		result.Error = ""
+	}
+	return result
+}
+
+func finalizeConfigurationInventory(res *action.CollectResult, remaining, maxItems int) {
+	if res.Inventory == nil {
+		return
+	}
+	hasNonTruncationFailure := false
+	for _, message := range res.PartialErrors {
+		if !strings.Contains(message, "truncated at max_items=") {
+			hasNonTruncationFailure = true
+		}
+		res.Inventory.Error = appendInventoryError(res.Inventory.Error, message)
+	}
+	if res.Inventory.State == ingest.OutcomeFailed && res.Inventory.Items == 0 {
+		return
+	}
+	if res.Inventory.State == ingest.OutcomePartial || hasNonTruncationFailure {
+		res.Inventory.State = ingest.OutcomePartial
+		return
+	}
+	if remaining <= 0 || res.Inventory.State == ingest.OutcomeTruncated {
+		message := fmt.Sprintf("Open WebUI configuration inventory truncated at max_items=%d", maxItems)
+		res.Inventory.State = ingest.OutcomeTruncated
+		res.Inventory.Error = appendInventoryError(res.Inventory.Error, message)
+		if !strings.Contains(strings.Join(res.PartialErrors, "; "), message) {
+			res.PartialErrors = append(res.PartialErrors, message)
+			res.Summary.PartialFailures++
+		}
+		return
+	}
+	res.Inventory.State = ingest.OutcomeComplete
+	res.Inventory.Error = ""
+}
+
+func appendInventoryError(current, next string) string {
+	next = strings.TrimSpace(next)
+	if next == "" || strings.Contains(current, next) {
+		return current
+	}
+	if current == "" {
+		return next
+	}
+	return current + "; " + next
 }
 
 // emitUpstreamCredential builds a :Credential node + EXPOSES_CREDENTIAL
@@ -346,7 +441,7 @@ func runOpenAIConfig(
 // runOllamaConfig probes GET /ollama/config. For each entry in
 // OLLAMA_BASE_URLS:
 //
-//   - Emits a placeholder :OllamaInstance node + :EXPOSES edge from
+//   - Emits a placeholder :OllamaInstance node + :USES_BACKEND edge from
 //     OpenWebUIInstance → OllamaInstance (matches what the old
 //     fingerprinter tried to emit via the dead $.ollama.base_url capture).
 //   - Looks up per-URL API key via OLLAMA_API_CONFIGS (keyed by index
@@ -361,26 +456,30 @@ func runOllamaConfig(
 	opts action.CollectOptions,
 	openwebuiID, baseURL, apiKey string,
 	remaining int,
-) int {
-	if remaining <= 0 {
-		return 0
-	}
+	backendLimit int,
+) (int, backendInventoryProbe) {
 	body := probeGET(ctx, client, res, opts, baseURL, "/ollama/config", apiKey)
 	if body == nil {
-		return remaining
+		return remaining, backendInventoryProbe{
+			State: ingest.OutcomeFailed, Error: "ollama/config was not readable",
+		}
 	}
 	var raw struct {
 		BaseURLs   []string                   `json:"OLLAMA_BASE_URLS"`
 		APIConfigs map[string]json.RawMessage `json:"OLLAMA_API_CONFIGS"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
-		res.PartialErrors = append(res.PartialErrors, fmt.Sprintf("ollama/config decode: %v", err))
+		message := fmt.Sprintf("ollama/config decode: %v", err)
+		res.PartialErrors = append(res.PartialErrors, message)
 		res.Summary.PartialFailures++
-		return remaining
+		return remaining, backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
 	}
 
 	// Track canonical URLs to promote onto the instance node.
 	canonicalBaseURLs := make([]string, 0, len(raw.BaseURLs))
+	seenBackends := make(map[string]bool)
+	inventory := backendInventoryProbe{State: ingest.OutcomeComplete}
+	lastSeen := time.Now().UTC().Format(time.RFC3339)
 
 	for i, base := range raw.BaseURLs {
 		base = strings.TrimSpace(base)
@@ -389,11 +488,31 @@ func runOllamaConfig(
 		}
 		canon := canonicalizeBackendURL(base)
 		if canon == "" {
+			message := fmt.Sprintf("ollama/config backend %d has an invalid endpoint", i)
+			res.PartialErrors = append(res.PartialErrors, message)
+			res.Summary.PartialFailures++
+			inventory.State = ingest.OutcomePartial
+			inventory.Error = appendInventoryError(inventory.Error, message)
 			continue
 		}
+		if seenBackends[canon] {
+			continue
+		}
+		seenBackends[canon] = true
+		if inventory.Items >= backendLimit {
+			message := fmt.Sprintf("backend inventory truncated at max_items=%d", backendLimit)
+			if !strings.Contains(inventory.Error, message) {
+				res.PartialErrors = append(res.PartialErrors, message)
+				res.Summary.PartialFailures++
+			}
+			inventory.State = ingest.OutcomeTruncated
+			inventory.Error = appendInventoryError(inventory.Error, message)
+			continue
+		}
+		inventory.Items++
 		canonicalBaseURLs = append(canonicalBaseURLs, canon)
 
-		// Emit placeholder :OllamaInstance node + :EXPOSES edge — one
+		// Emit placeholder :OllamaInstance node + :USES_BACKEND edge — one
 		// per canonical backend URL. Uses ComputeNodeID with the
 		// canonical URL so ollamafp / ollamacollect fold into the same
 		// node via MERGE-by-objectid.
@@ -414,14 +533,12 @@ func runOllamaConfig(
 		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges, ingest.Edge{
 			Source:     openwebuiID,
 			Target:     ollamaID,
-			Kind:       "EXPOSES",
+			Kind:       "USES_BACKEND",
 			SourceKind: "OpenWebUIInstance",
 			TargetKind: "OllamaInstance",
 			Properties: map[string]any{
-				"confidence":       1.0,
-				"risk_weight":      0.3,
-				"assertion_type":   "configured_reference",
-				"confidence_scope": "configuration_presence",
+				"confidence": 1.0, "risk_weight": 0.3,
+				"evidence_state": string(ingest.EvidenceConfigured), "last_seen": lastSeen,
 				"evidence": map[string]any{
 					"endpoint":    baseURL,
 					"source":      "ollama_config",
@@ -452,6 +569,11 @@ func runOllamaConfig(
 			APIKey string `json:"api_key"`
 		}
 		if err := json.Unmarshal(cfgRaw, &cfg); err != nil {
+			message := fmt.Sprintf("ollama/config API config %d decode: %v", i, err)
+			res.PartialErrors = append(res.PartialErrors, message)
+			res.Summary.PartialFailures++
+			inventory.State = ingest.OutcomePartial
+			inventory.Error = appendInventoryError(inventory.Error, message)
 			continue
 		}
 		key := strings.TrimSpace(cfg.Key)
@@ -473,7 +595,138 @@ func runOllamaConfig(
 		props := res.IngestData.Graph.Nodes[0].Properties
 		props["ollama_backend_urls"] = canonicalBaseURLs
 	}
-	return remaining
+	return remaining, inventory
+}
+
+type externalKnowledgeConnection struct {
+	ID             string `json:"id"`
+	Provider       string `json:"provider"`
+	Endpoint       string `json:"endpoint"`
+	AuthConfigured bool   `json:"auth_configured"`
+	Enabled        bool   `json:"enabled"`
+}
+
+// runExternalKnowledgeConnections reads Open WebUI's admin-sanitized external
+// knowledge configuration. It consumes only enabled Qdrant endpoints and
+// deliberately has no field capable of decoding auth_config material.
+func runExternalKnowledgeConnections(
+	ctx context.Context,
+	client *http.Client,
+	res *action.CollectResult,
+	openwebuiID, baseURL, apiKey string,
+	backendLimit int,
+) backendInventoryProbe {
+	const route = "/api/v1/knowledge/external/connections"
+	body := probeGET(ctx, client, res, action.CollectOptions{}, baseURL, route, apiKey)
+	if body == nil {
+		return backendInventoryProbe{
+			State: ingest.OutcomeFailed,
+			Error: "knowledge external connections were not readable",
+		}
+	}
+	var response struct {
+		Items []externalKnowledgeConnection `json:"items"`
+		Total int                           `json:"total"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		message := fmt.Sprintf("api/v1/knowledge/external/connections decode: %v", err)
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		return backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
+	}
+	inventory := backendInventoryProbe{State: ingest.OutcomeComplete}
+	if response.Total != len(response.Items) {
+		message := fmt.Sprintf(
+			"knowledge external connections total=%d but response contained %d items",
+			response.Total, len(response.Items),
+		)
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		inventory.State = ingest.OutcomePartial
+		inventory.Error = message
+	}
+
+	type aggregatedConnection struct {
+		IDs            []string
+		AuthConfigured bool
+	}
+	byEndpoint := make(map[string]aggregatedConnection)
+	for index, connection := range response.Items {
+		if !connection.Enabled || !strings.EqualFold(strings.TrimSpace(connection.Provider), "qdrant") {
+			continue
+		}
+		endpoint := canonicalizeQdrantBackendURL(connection.Endpoint)
+		if endpoint == "" {
+			message := fmt.Sprintf("external Qdrant connection %d has an invalid endpoint", index)
+			res.PartialErrors = append(res.PartialErrors, message)
+			res.Summary.PartialFailures++
+			inventory.State = ingest.OutcomePartial
+			inventory.Error = appendInventoryError(inventory.Error, message)
+			continue
+		}
+		aggregated := byEndpoint[endpoint]
+		if id := strings.TrimSpace(connection.ID); id != "" {
+			aggregated.IDs = append(aggregated.IDs, id)
+		}
+		aggregated.AuthConfigured = aggregated.AuthConfigured || connection.AuthConfigured
+		byEndpoint[endpoint] = aggregated
+	}
+	endpoints := make([]string, 0, len(byEndpoint))
+	for endpoint := range byEndpoint {
+		endpoints = append(endpoints, endpoint)
+	}
+	sort.Strings(endpoints)
+	lastSeen := time.Now().UTC().Format(time.RFC3339)
+	emittedEndpoints := make([]string, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if inventory.Items >= backendLimit {
+			message := fmt.Sprintf("backend inventory truncated at max_items=%d", backendLimit)
+			if !strings.Contains(inventory.Error, message) {
+				res.PartialErrors = append(res.PartialErrors, message)
+				res.Summary.PartialFailures++
+			}
+			inventory.State = ingest.OutcomeTruncated
+			inventory.Error = appendInventoryError(inventory.Error, message)
+			continue
+		}
+		inventory.Items++
+		emittedEndpoints = append(emittedEndpoints, endpoint)
+		connection := byEndpoint[endpoint]
+		sort.Strings(connection.IDs)
+		_, host, _ := action.EndpointParts(
+			action.Target{Kind: "url", Address: endpoint}, 6333, "http",
+		)
+		qdrantID := ingest.ComputeNodeID("QdrantInstance", endpoint)
+		configuredAuthMethod := string(common.AuthUnknown)
+		if connection.AuthConfigured {
+			configuredAuthMethod = string(common.AuthAPIKey)
+		}
+		res.IngestData.Graph.Nodes = append(res.IngestData.Graph.Nodes, ingest.Node{
+			ID: qdrantID, Kinds: []string{"QdrantInstance", "AIService"},
+			Properties: map[string]any{
+				"objectid": qdrantID, "endpoint": endpoint, "name": host,
+				"service_kind": "qdrant", "configuration_observed": true,
+				"configured_auth_method": configuredAuthMethod,
+			},
+		})
+		res.IngestData.Graph.Edges = append(res.IngestData.Graph.Edges, ingest.Edge{
+			Source: openwebuiID, Target: qdrantID, Kind: "USES_BACKEND",
+			SourceKind: "OpenWebUIInstance", TargetKind: "QdrantInstance",
+			Properties: map[string]any{
+				"confidence": 1.0, "risk_weight": 0.3,
+				"evidence_state": string(ingest.EvidenceConfigured), "last_seen": lastSeen,
+				"evidence": map[string]any{
+					"source": "knowledge_external_connections", "endpoint": endpoint,
+					"connection_ids":  connection.IDs,
+					"auth_configured": connection.AuthConfigured,
+				},
+			},
+		})
+	}
+	if len(emittedEndpoints) > 0 {
+		res.IngestData.Graph.Nodes[0].Properties["qdrant_backend_urls"] = emittedEndpoints
+	}
+	return inventory
 }
 
 // runRetrievalWalk probes an admin-gated retrieval endpoint and runs

--- a/modules/openwebuicollect/collector.go
+++ b/modules/openwebuicollect/collector.go
@@ -465,7 +465,7 @@ func runOllamaConfig(
 		}
 	}
 	var raw struct {
-		BaseURLs   []string                   `json:"OLLAMA_BASE_URLS"`
+		BaseURLs   json.RawMessage            `json:"OLLAMA_BASE_URLS"`
 		APIConfigs map[string]json.RawMessage `json:"OLLAMA_API_CONFIGS"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -474,14 +474,27 @@ func runOllamaConfig(
 		res.Summary.PartialFailures++
 		return remaining, backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
 	}
+	if len(raw.BaseURLs) == 0 || string(raw.BaseURLs) == "null" {
+		message := "ollama/config response omitted OLLAMA_BASE_URLS"
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		return remaining, backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
+	}
+	var baseURLs []string
+	if err := json.Unmarshal(raw.BaseURLs, &baseURLs); err != nil {
+		message := fmt.Sprintf("ollama/config OLLAMA_BASE_URLS decode: %v", err)
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		return remaining, backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
+	}
 
 	// Track canonical URLs to promote onto the instance node.
-	canonicalBaseURLs := make([]string, 0, len(raw.BaseURLs))
+	canonicalBaseURLs := make([]string, 0, len(baseURLs))
 	seenBackends := make(map[string]bool)
 	inventory := backendInventoryProbe{State: ingest.OutcomeComplete}
 	lastSeen := time.Now().UTC().Format(time.RFC3339)
 
-	for i, base := range raw.BaseURLs {
+	for i, base := range baseURLs {
 		base = strings.TrimSpace(base)
 		if base == "" {
 			continue
@@ -625,8 +638,8 @@ func runExternalKnowledgeConnections(
 		}
 	}
 	var response struct {
-		Items []externalKnowledgeConnection `json:"items"`
-		Total int                           `json:"total"`
+		Items json.RawMessage `json:"items"`
+		Total *int            `json:"total"`
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
 		message := fmt.Sprintf("api/v1/knowledge/external/connections decode: %v", err)
@@ -634,11 +647,24 @@ func runExternalKnowledgeConnections(
 		res.Summary.PartialFailures++
 		return backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
 	}
+	if len(response.Items) == 0 || string(response.Items) == "null" || response.Total == nil {
+		message := "api/v1/knowledge/external/connections response omitted items or total"
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		return backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
+	}
+	var items []externalKnowledgeConnection
+	if err := json.Unmarshal(response.Items, &items); err != nil {
+		message := fmt.Sprintf("api/v1/knowledge/external/connections items decode: %v", err)
+		res.PartialErrors = append(res.PartialErrors, message)
+		res.Summary.PartialFailures++
+		return backendInventoryProbe{State: ingest.OutcomeFailed, Error: message}
+	}
 	inventory := backendInventoryProbe{State: ingest.OutcomeComplete}
-	if response.Total != len(response.Items) {
+	if *response.Total < 0 || *response.Total != len(items) {
 		message := fmt.Sprintf(
 			"knowledge external connections total=%d but response contained %d items",
-			response.Total, len(response.Items),
+			*response.Total, len(items),
 		)
 		res.PartialErrors = append(res.PartialErrors, message)
 		res.Summary.PartialFailures++
@@ -651,7 +677,7 @@ func runExternalKnowledgeConnections(
 		AuthConfigured bool
 	}
 	byEndpoint := make(map[string]aggregatedConnection)
-	for index, connection := range response.Items {
+	for index, connection := range items {
 		if !connection.Enabled || !strings.EqualFold(strings.TrimSpace(connection.Provider), "qdrant") {
 			continue
 		}

--- a/modules/openwebuicollect/collector_test.go
+++ b/modules/openwebuicollect/collector_test.go
@@ -35,12 +35,13 @@ type stubRoute struct {
 
 // openwebuiStubOptions configures which endpoints the stub serves.
 type openwebuiStubOptions struct {
-	apiKey             string
-	config             string
-	openaiConfig       string
-	ollamaConfig       string
-	retrievalConfig    string
-	retrievalEmbedding string
+	apiKey              string
+	config              string
+	openaiConfig        string
+	ollamaConfig        string
+	retrievalConfig     string
+	retrievalEmbedding  string
+	externalConnections string
 	// If not nil, override with explicit status codes for specific paths.
 	overrides map[string]stubRoute
 	// Tracks all (method, path) pairs the stub sees.
@@ -77,29 +78,35 @@ func openwebuiStub(t *testing.T, opts openwebuiStubOptions) *httptest.Server {
 			}
 			_, _ = w.Write([]byte(body))
 		case "/openai/config":
-			if opts.openaiConfig == "" {
-				w.WriteHeader(404)
-				return
+			body := opts.openaiConfig
+			if body == "" {
+				body = `{}`
 			}
-			_, _ = w.Write([]byte(opts.openaiConfig))
+			_, _ = w.Write([]byte(body))
 		case "/ollama/config":
-			if opts.ollamaConfig == "" {
-				w.WriteHeader(404)
-				return
+			body := opts.ollamaConfig
+			if body == "" {
+				body = `{}`
 			}
-			_, _ = w.Write([]byte(opts.ollamaConfig))
+			_, _ = w.Write([]byte(body))
 		case "/api/v1/retrieval/config":
-			if opts.retrievalConfig == "" {
-				w.WriteHeader(404)
-				return
+			body := opts.retrievalConfig
+			if body == "" {
+				body = `{}`
 			}
-			_, _ = w.Write([]byte(opts.retrievalConfig))
+			_, _ = w.Write([]byte(body))
 		case "/api/v1/retrieval/embedding":
-			if opts.retrievalEmbedding == "" {
-				w.WriteHeader(404)
-				return
+			body := opts.retrievalEmbedding
+			if body == "" {
+				body = `{}`
 			}
-			_, _ = w.Write([]byte(opts.retrievalEmbedding))
+			_, _ = w.Write([]byte(body))
+		case "/api/v1/knowledge/external/connections":
+			body := opts.externalConnections
+			if body == "" {
+				body = `{"items":[],"total":0}`
+			}
+			_, _ = w.Write([]byte(body))
 		default:
 			w.WriteHeader(404)
 		}
@@ -274,6 +281,9 @@ func TestCollect_OpenWebUI_AnonymousPosture(t *testing.T) {
 	if got := len(res.IngestData.Graph.Edges); got != 0 {
 		t.Errorf("edges: got %d, want 0 in anonymous mode", got)
 	}
+	if res.Inventory == nil || res.Inventory.Name != "configuration" || res.Inventory.State != ingest.OutcomeFailed {
+		t.Fatalf("anonymous backend inventory = %+v, want failed until admin config is read", res.Inventory)
+	}
 }
 
 // TestCollect_OpenWebUI_AuthenticatedCredentials — /openai/config path
@@ -433,7 +443,7 @@ func TestCollect_OpenWebUI_AuthRejected(t *testing.T) {
 	if res.Summary.CredentialsFound != 0 {
 		t.Errorf("CredentialsFound = %d, want 0 when auth rejected", res.Summary.CredentialsFound)
 	}
-	// Four authenticated probes all 401 → 4 partial failures.
+	// Authenticated probes all return 401 and remain non-fatal journal evidence.
 	if res.Summary.PartialFailures < 1 {
 		t.Errorf("PartialFailures = %d, want at least 1", res.Summary.PartialFailures)
 	}
@@ -441,7 +451,7 @@ func TestCollect_OpenWebUI_AuthRejected(t *testing.T) {
 
 // TestCollect_OpenWebUI_OllamaConfig_KeyField — the primary shape:
 // OLLAMA_API_CONFIGS keyed by string index, per-URL config uses `key`.
-// Asserts 1 Credential + 1 :OllamaInstance placeholder + 1 :EXPOSES
+// Asserts 1 Credential + 1 :OllamaInstance placeholder + 1 :USES_BACKEND
 // edge + canonicalized backend URL list.
 func TestCollect_OpenWebUI_OllamaConfig_KeyField(t *testing.T) {
 	const key = "admin-jwt"
@@ -460,7 +470,7 @@ func TestCollect_OpenWebUI_OllamaConfig_KeyField(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Collect: %v", err)
 	}
-	var credCount, ollamaCount, exposesCount int
+	var credCount, ollamaCount, backendEdgeCount int
 	for _, n := range res.IngestData.Graph.Nodes {
 		switch n.Kinds[0] {
 		case "Credential":
@@ -497,22 +507,168 @@ func TestCollect_OpenWebUI_OllamaConfig_KeyField(t *testing.T) {
 	}
 	for _, e := range res.IngestData.Graph.Edges {
 		if e.Kind == "EXPOSES" {
-			exposesCount++
+			t.Fatalf("collector emitted deprecated Open WebUI backend edge: %+v", e)
+		}
+		if e.Kind == "USES_BACKEND" {
+			backendEdgeCount++
 			if e.SourceKind != "OpenWebUIInstance" || e.TargetKind != "OllamaInstance" {
-				t.Errorf("EXPOSES edge kinds = %s -> %s", e.SourceKind, e.TargetKind)
+				t.Errorf("USES_BACKEND edge kinds = %s -> %s", e.SourceKind, e.TargetKind)
 			}
-			if e.Properties["assertion_type"] != "configured_reference" ||
-				e.Properties["confidence_scope"] != "configuration_presence" {
+			if e.Properties["evidence_state"] != "configured" {
 				t.Errorf("configured edge overclaimed verification: %+v", e.Properties)
 			}
 		}
 	}
-	if exposesCount != 1 {
-		t.Errorf("EXPOSES edge count = %d, want 1", exposesCount)
+	if backendEdgeCount != 1 {
+		t.Errorf("USES_BACKEND edge count = %d, want 1", backendEdgeCount)
 	}
 	urls, _ := res.IngestData.Graph.Nodes[0].Properties["ollama_backend_urls"].([]string)
 	if len(urls) != 1 || urls[0] != "http://10.0.0.5:11434" {
 		t.Errorf("ollama_backend_urls = %v, want [http://10.0.0.5:11434]", urls)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeComplete || res.Inventory.Items != 1 {
+		t.Fatalf("backend inventory = %+v, want complete with one Ollama backend", res.Inventory)
+	}
+}
+
+func TestCollect_OpenWebUI_EnabledQdrantBackendIsTypedAndRedacted(t *testing.T) {
+	const key = "admin-jwt"
+	srv := openwebuiStub(t, openwebuiStubOptions{
+		apiKey:       key,
+		ollamaConfig: `{}`,
+		externalConnections: `{
+			"items":[
+				{"id":"q-1","provider":"qdrant","endpoint":"qdrant","enabled":true,"auth_configured":true,"auth_config":{"api_key":"must-not-leak"}},
+				{"id":"q-2","provider":"QDRANT","endpoint":"http://QDRANT:6333/","enabled":true,"auth_configured":false},
+				{"id":"q-disabled","provider":"qdrant","endpoint":"http://disabled:6333","enabled":false,"auth_configured":false},
+				{"id":"milvus","provider":"milvus","endpoint":"http://milvus:19530","enabled":true,"auth_configured":false}
+			],
+			"total":4
+		}`,
+	})
+	defer srv.Close()
+
+	res, err := (&Collector{}).Collect(context.Background(), action.Target{
+		Kind: "host", Address: addrOf(srv),
+	}, action.CollectOptions{Extras: map[string]any{"api-key": key}})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	qdrantID := ingest.ComputeNodeID("QdrantInstance", "http://qdrant:6333")
+	var qdrantNodes, backendEdges int
+	for _, node := range res.IngestData.Graph.Nodes {
+		if node.Kinds[0] != "QdrantInstance" {
+			continue
+		}
+		qdrantNodes++
+		if node.ID != qdrantID || node.Properties["endpoint"] != "http://qdrant:6333" {
+			t.Errorf("Qdrant identity = %+v", node)
+		}
+		if node.Properties["configured_auth_method"] != "apiKey" {
+			t.Errorf("aggregated auth posture = %+v", node.Properties)
+		}
+	}
+	for _, edge := range res.IngestData.Graph.Edges {
+		if edge.Kind == "EXPOSES" {
+			t.Fatalf("collector emitted deprecated Open WebUI backend edge: %+v", edge)
+		}
+		if edge.Kind != "USES_BACKEND" || edge.TargetKind != "QdrantInstance" {
+			continue
+		}
+		backendEdges++
+		if edge.SourceKind != "OpenWebUIInstance" || edge.Target != qdrantID ||
+			edge.Properties["evidence_state"] != "configured" {
+			t.Errorf("Qdrant backend edge = %+v", edge)
+		}
+	}
+	if qdrantNodes != 1 || backendEdges != 1 {
+		t.Fatalf("Qdrant topology = nodes:%d edges:%d, want one converged path", qdrantNodes, backendEdges)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeComplete || res.Inventory.Items != 1 {
+		t.Fatalf("backend inventory = %+v, want complete one-backend surface", res.Inventory)
+	}
+	encoded, err := json.Marshal(res.IngestData.Graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "must-not-leak") || credCount(res) != 0 {
+		t.Fatalf("external backend credential leaked into graph: %s", encoded)
+	}
+}
+
+func TestCollect_OpenWebUI_IncompleteExternalConnectionsStayNonAuthoritative(t *testing.T) {
+	const key = "admin-jwt"
+	srv := openwebuiStub(t, openwebuiStubOptions{
+		apiKey:       key,
+		ollamaConfig: `{}`,
+		externalConnections: `{
+			"items":[{"id":"q-1","provider":"qdrant","endpoint":"http://qdrant:6333","enabled":true}],
+			"total":2
+		}`,
+	})
+	defer srv.Close()
+	res, err := (&Collector{}).Collect(context.Background(), action.Target{
+		Address: addrOf(srv),
+	}, action.CollectOptions{Extras: map[string]any{"api-key": key}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomePartial {
+		t.Fatalf("incomplete response inventory = %+v, want partial", res.Inventory)
+	}
+}
+
+func TestCollect_OpenWebUI_ConfigurationFailurePreventsAuthoritativeInventory(t *testing.T) {
+	const key = "admin-jwt"
+	srv := openwebuiStub(t, openwebuiStubOptions{
+		apiKey:       key,
+		ollamaConfig: `{"OLLAMA_BASE_URLS":["http://ollama:11434"]}`,
+		overrides: map[string]stubRoute{
+			"/api/v1/retrieval/config": {status: http.StatusInternalServerError},
+		},
+	})
+	defer srv.Close()
+	res, err := (&Collector{}).Collect(context.Background(), action.Target{
+		Address: addrOf(srv),
+	}, action.CollectOptions{Extras: map[string]any{"api-key": key}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomePartial {
+		t.Fatalf("failed configuration read inventory = %+v, want partial", res.Inventory)
+	}
+}
+
+func TestCollect_OpenWebUI_BackendLimitReportsTruncation(t *testing.T) {
+	const key = "admin-jwt"
+	srv := openwebuiStub(t, openwebuiStubOptions{
+		apiKey: key,
+		externalConnections: `{
+			"items":[
+				{"id":"q-1","provider":"qdrant","endpoint":"http://qdrant-a:6333","enabled":true},
+				{"id":"q-2","provider":"qdrant","endpoint":"http://qdrant-b:6333","enabled":true}
+			],
+			"total":2
+		}`,
+	})
+	defer srv.Close()
+	res, err := (&Collector{}).Collect(context.Background(), action.Target{
+		Address: addrOf(srv),
+	}, action.CollectOptions{MaxItems: 1, Extras: map[string]any{"api-key": key}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Inventory == nil || res.Inventory.State != ingest.OutcomeTruncated || res.Inventory.Items != 1 {
+		t.Fatalf("bounded configuration inventory = %+v, want one emitted item and truncated", res.Inventory)
+	}
+	var qdrantNodes int
+	for _, node := range res.IngestData.Graph.Nodes {
+		if node.Kinds[0] == "QdrantInstance" {
+			qdrantNodes++
+		}
+	}
+	if qdrantNodes != 1 {
+		t.Fatalf("Qdrant nodes = %d, want bounded emission of one", qdrantNodes)
 	}
 }
 
@@ -802,15 +958,14 @@ func TestCollect_OpenWebUI_RetrievalRerankingRouteAbsent(t *testing.T) {
 	}
 }
 
-// TestCanonicalizeBackendURL exercises the URL normalizer that used to
-// live in openwebuifp. Ported verbatim from the fingerprinter test.
+// TestCanonicalizeBackendURL locks in effective HTTP-port identity.
 func TestCanonicalizeBackendURL(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
 	}{
 		{"http://ollama:11434", "http://ollama:11434"},
-		{"https://ollama.example.com", "https://ollama.example.com:11434"},
+		{"https://ollama.example.com", "https://ollama.example.com"},
 		{"ollama-backend:11434", "http://ollama-backend:11434"},
 		{"ollama-backend", "http://ollama-backend:11434"},
 		{"", ""},
@@ -822,6 +977,30 @@ func TestCanonicalizeBackendURL(t *testing.T) {
 				t.Errorf("canonicalizeBackendURL(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCanonicalizeQdrantBackendURLUsesEffectivePorts(t *testing.T) {
+	tests := []struct {
+		left, right string
+		equal       bool
+	}{
+		{left: "qdrant", right: "qdrant:6333", equal: true},
+		{left: "http://qdrant", right: "http://qdrant:80", equal: true},
+		{left: "https://qdrant", right: "https://qdrant:443", equal: true},
+		{left: "http://qdrant", right: "http://qdrant:6333", equal: false},
+	}
+	for _, tc := range tests {
+		left := canonicalizeQdrantBackendURL(tc.left)
+		right := canonicalizeQdrantBackendURL(tc.right)
+		if (left == right) != tc.equal {
+			t.Errorf("canonical endpoints %q and %q equality = %t, want %t", left, right, left == right, tc.equal)
+		}
+		leftID := ingest.ComputeNodeID("QdrantInstance", left)
+		rightID := ingest.ComputeNodeID("QdrantInstance", right)
+		if (leftID == rightID) != tc.equal {
+			t.Errorf("Qdrant IDs for %q and %q equality = %t, want %t", tc.left, tc.right, leftID == rightID, tc.equal)
+		}
 	}
 }
 

--- a/modules/openwebuicollect/collector_test.go
+++ b/modules/openwebuicollect/collector_test.go
@@ -535,7 +535,7 @@ func TestCollect_OpenWebUI_EnabledQdrantBackendIsTypedAndRedacted(t *testing.T) 
 	const key = "admin-jwt"
 	srv := openwebuiStub(t, openwebuiStubOptions{
 		apiKey:       key,
-		ollamaConfig: `{}`,
+		ollamaConfig: `{"OLLAMA_BASE_URLS":[]}`,
 		externalConnections: `{
 			"items":[
 				{"id":"q-1","provider":"qdrant","endpoint":"qdrant","enabled":true,"auth_configured":true,"auth_config":{"api_key":"must-not-leak"}},
@@ -642,7 +642,8 @@ func TestCollect_OpenWebUI_ConfigurationFailurePreventsAuthoritativeInventory(t 
 func TestCollect_OpenWebUI_BackendLimitReportsTruncation(t *testing.T) {
 	const key = "admin-jwt"
 	srv := openwebuiStub(t, openwebuiStubOptions{
-		apiKey: key,
+		apiKey:       key,
+		ollamaConfig: `{"OLLAMA_BASE_URLS":[]}`,
 		externalConnections: `{
 			"items":[
 				{"id":"q-1","provider":"qdrant","endpoint":"http://qdrant-a:6333","enabled":true},
@@ -966,6 +967,7 @@ func TestCanonicalizeBackendURL(t *testing.T) {
 	}{
 		{"http://ollama:11434", "http://ollama:11434"},
 		{"https://ollama.example.com", "https://ollama.example.com"},
+		{"https://ollama.example.com:443", "https://ollama.example.com:443"},
 		{"ollama-backend:11434", "http://ollama-backend:11434"},
 		{"ollama-backend", "http://ollama-backend:11434"},
 		{"", ""},
@@ -975,6 +977,66 @@ func TestCanonicalizeBackendURL(t *testing.T) {
 			got := canonicalizeBackendURL(tt.input)
 			if got != tt.want {
 				t.Errorf("canonicalizeBackendURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalizeBackendURLMatchesDirectOllamaIdentity(t *testing.T) {
+	raw := "https://ollama.example.com:443"
+	direct := action.EndpointBaseURL(
+		action.Target{Kind: "url", Address: raw}, 11434, "http",
+	)
+	if configured := canonicalizeBackendURL(raw); configured != direct {
+		t.Fatalf("configured identity %q differs from direct identity %q", configured, direct)
+	}
+}
+
+func TestBackendInventoryRequiresResponseFields(t *testing.T) {
+	freshResult := func() *action.CollectResult {
+		return &action.CollectResult{IngestData: &ingest.IngestData{
+			Graph: ingest.GraphData{Nodes: []ingest.Node{{
+				ID: "openwebui", Properties: map[string]any{},
+			}}},
+		}}
+	}
+	tests := []struct {
+		name                string
+		ollamaConfig        string
+		externalConnections string
+	}{
+		{name: "missing", ollamaConfig: `{}`, externalConnections: `{}`},
+		{
+			name:                "null",
+			ollamaConfig:        `{"OLLAMA_BASE_URLS":null}`,
+			externalConnections: `{"items":null,"total":0}`,
+		},
+		{
+			name:                "wrong shape",
+			ollamaConfig:        `{"OLLAMA_BASE_URLS":{}}`,
+			externalConnections: `{"items":{},"total":0}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := openwebuiStub(t, openwebuiStubOptions{
+				ollamaConfig:        test.ollamaConfig,
+				externalConnections: test.externalConnections,
+			})
+			defer srv.Close()
+
+			_, ollama := runOllamaConfig(
+				context.Background(), srv.Client(), freshResult(), action.CollectOptions{},
+				"openwebui", srv.URL, "", 10, 10,
+			)
+			if ollama.State == ingest.OutcomeComplete {
+				t.Fatal("invalid OLLAMA_BASE_URLS was accepted as complete inventory")
+			}
+			qdrant := runExternalKnowledgeConnections(
+				context.Background(), srv.Client(), freshResult(), "openwebui", srv.URL, "", 10,
+			)
+			if qdrant.State == ingest.OutcomeComplete {
+				t.Fatal("invalid items or total was accepted as complete inventory")
 			}
 		})
 	}

--- a/modules/openwebuicollect/register.go
+++ b/modules/openwebuicollect/register.go
@@ -13,7 +13,7 @@ func (*Collector) ID() string            { return "openwebui.collect" }
 func (*Collector) Action() action.Action { return action.Collect }
 func (*Collector) Target() string        { return "openwebui" }
 func (*Collector) Description() string {
-	return "Collect Open WebUI posture and authenticated upstream provider keys"
+	return "Collect Open WebUI posture, configured backends, and authenticated upstream keys"
 }
 func (*Collector) Version() string     { return "0.4.0-dev" }
 func (*Collector) IsDestructive() bool { return false }

--- a/modules/openwebuifp/fingerprinter.go
+++ b/modules/openwebuifp/fingerprinter.go
@@ -10,9 +10,9 @@
 // OllamaInstance. The old edge was fenced on capturing $.ollama.base_url
 // from /api/config, but that field is verified absent from Open WebUI's
 // get_app_config response on every tag from v0.1.111 through v0.9.6 (and
-// main), so the edge never fired in practice. The authenticated
-// The Open WebUI service collector emits the EXPOSES edge from the admin-gated
-// /ollama/config endpoint (which does return OLLAMA_BASE_URLS).
+// main), so the edge never fired in practice. The authenticated Open WebUI
+// service collector now emits USES_BACKEND from the admin-gated configuration
+// endpoints. EXPOSES remains ingest-compatible only for historical artifacts.
 package openwebuifp
 
 import (

--- a/server/internal/ingest/publication_integration_test.go
+++ b/server/internal/ingest/publication_integration_test.go
@@ -1031,6 +1031,112 @@ func TestIntegrationTypedResourceMigrationKeepsHistoricalScan(t *testing.T) {
 	}
 }
 
+func TestIntegrationOpenWebUIBackendReplacementWaitsForCompleteInventory(t *testing.T) {
+	ctx, pipeline, db, _, _ := publicationIntegrationHarness(t, false)
+	root := sdkingest.CollectorRootCoverageKey("scan")
+	openwebuiEndpoint := "http://openwebui:3000"
+	ollamaEndpoint := "http://ollama:11434"
+	openwebuiID := sdkingest.ComputeNodeID("OpenWebUIInstance", openwebuiEndpoint)
+	ollamaID := sdkingest.ComputeNodeID("OllamaInstance", ollamaEndpoint)
+	inventory := sdkingest.CanonicalCoverageKey(
+		"scan", "service_inventory", "openwebui.collect\x00"+openwebuiID+"\x00configuration",
+	)
+
+	report := func(rootState, inventoryState sdkingest.OutcomeState) *sdkingest.CollectionReport {
+		outcomes := []sdkingest.CollectionOutcome{{
+			Collector: "scan", CoverageKey: root, Target: "scan", Method: "collect",
+			State: rootState,
+		}}
+		keys := []string{root}
+		if inventoryState != sdkingest.OutcomeUnknown {
+			keys = append(keys, inventory)
+			outcomes = append(outcomes, sdkingest.CollectionOutcome{
+				Collector: "scan", CoverageKey: inventory, ParentCoverageKey: root,
+				Target: openwebuiID, Method: "service_inventory:configuration", State: inventoryState,
+			})
+		}
+		return &sdkingest.CollectionReport{
+			State: sdkingest.AggregateOutcomeState(outcomes), CoverageKeys: keys, Outcomes: outcomes,
+		}
+	}
+	serviceNodes := func(scope string) []sdkingest.Node {
+		return []sdkingest.Node{
+			{
+				ID: openwebuiID, Kinds: []string{"OpenWebUIInstance", "AIService"},
+				Properties: map[string]any{
+					"objectid": openwebuiID, "name": "openwebui", "endpoint": openwebuiEndpoint,
+				},
+				ObservationDomains: []string{scope},
+			},
+			{
+				ID: ollamaID, Kinds: []string{"OllamaInstance", "AIService"},
+				Properties: map[string]any{
+					"objectid": ollamaID, "name": "ollama", "endpoint": ollamaEndpoint,
+				},
+				ObservationDomains: []string{scope},
+			},
+		}
+	}
+	legacyGraph := sdkingest.GraphData{
+		Nodes: serviceNodes(root),
+		Edges: []sdkingest.Edge{{
+			Source: openwebuiID, Target: ollamaID, Kind: "EXPOSES",
+			SourceKind: "OpenWebUIInstance", TargetKind: "OllamaInstance",
+			Properties: map[string]any{"risk_weight": 0.3}, ObservationDomains: []string{root},
+		}},
+	}
+	typedGraph := func() sdkingest.GraphData {
+		return sdkingest.GraphData{
+			Nodes: serviceNodes(inventory),
+			Edges: []sdkingest.Edge{{
+				Source: openwebuiID, Target: ollamaID, Kind: "USES_BACKEND",
+				SourceKind: "OpenWebUIInstance", TargetKind: "OllamaInstance",
+				Properties: map[string]any{
+					"risk_weight": 0.3, "confidence": 1.0,
+					"evidence_state": "configured", "last_seen": "2026-08-27T12:00:00Z",
+					"evidence": map[string]any{"source": "ollama_config"},
+				},
+				ObservationDomains: []string{inventory},
+			}},
+		}
+	}
+	ingestArtifact := func(scanID string, collection *sdkingest.CollectionReport, graphData sdkingest.GraphData) {
+		t.Helper()
+		data := newPublicationIntegrationData("scan", scanID)
+		data.Meta.Collection = collection
+		data.Graph = graphData
+		if _, err := pipeline.Ingest(ctx, data); err != nil {
+			t.Fatalf("ingest %s: %v", scanID, err)
+		}
+	}
+	edgeCount := func(kind string) int64 {
+		t.Helper()
+		rows, err := db.Query(ctx, `MATCH ()-[r]->() WHERE type(r) = $kind RETURN count(r) AS count`, map[string]any{
+			"kind": kind,
+		})
+		if err != nil {
+			t.Fatalf("query %s edges: %v", kind, err)
+		}
+		count, _ := int64Property(rows[0], "count")
+		return count
+	}
+
+	ingestArtifact("openwebui-backend-legacy", report(sdkingest.OutcomeComplete, sdkingest.OutcomeUnknown), legacyGraph)
+	if edgeCount("EXPOSES") != 1 {
+		t.Fatal("legacy EXPOSES edge was not written")
+	}
+
+	ingestArtifact("openwebui-backend-partial", report(sdkingest.OutcomePartial, sdkingest.OutcomePartial), typedGraph())
+	if edgeCount("EXPOSES") != 1 || edgeCount("USES_BACKEND") != 1 {
+		t.Fatal("partial replacement did not preserve legacy edge and write typed edge")
+	}
+
+	ingestArtifact("openwebui-backend-complete", report(sdkingest.OutcomeComplete, sdkingest.OutcomeComplete), typedGraph())
+	if edgeCount("EXPOSES") != 0 || edgeCount("USES_BACKEND") != 1 {
+		t.Fatal("complete replacement did not retire legacy edge after writing typed edge")
+	}
+}
+
 func TestIntegrationExhaustiveRootRemovesMissingChildAcrossGraphAndPublication(t *testing.T) {
 	ctx, pipeline, db, _, pool := freshPublicationIntegrationHarness(t)
 	root := sdkingest.CanonicalCoverageKey("mcp", "root", "collect")

--- a/server/internal/ingest/validator_test.go
+++ b/server/internal/ingest/validator_test.go
@@ -249,6 +249,53 @@ func TestValidatorAcceptsJupyterAndMLflowTypedResources(t *testing.T) {
 	})
 }
 
+func TestValidatorAcceptsConfiguredOpenWebUIBackends(t *testing.T) {
+	for _, target := range []struct {
+		name     string
+		kind     string
+		endpoint string
+	}{
+		{name: "Ollama", kind: "OllamaInstance", endpoint: "http://ollama:11434"},
+		{name: "Qdrant", kind: "QdrantInstance", endpoint: "http://qdrant:6333"},
+	} {
+		t.Run(target.name, func(t *testing.T) {
+			data := validIngestData()
+			scope := data.Meta.Collection.CoverageKeys[0]
+			openwebuiID := ingest.ComputeNodeID("OpenWebUIInstance", "http://openwebui:3000")
+			backendID := ingest.ComputeNodeID(target.kind, target.endpoint)
+			data.Graph.Nodes = []ingest.Node{
+				{
+					ID: openwebuiID, Kinds: []string{"OpenWebUIInstance", "AIService"},
+					Properties: map[string]any{
+						"objectid": openwebuiID, "endpoint": "http://openwebui:3000",
+					},
+					ObservationDomains: []string{scope},
+				},
+				{
+					ID: backendID, Kinds: []string{target.kind, "AIService"},
+					Properties: map[string]any{
+						"objectid": backendID, "endpoint": target.endpoint,
+					},
+					ObservationDomains: []string{scope},
+				},
+			}
+			data.Graph.Edges = []ingest.Edge{{
+				Source: openwebuiID, Target: backendID, Kind: "USES_BACKEND",
+				SourceKind: "OpenWebUIInstance", TargetKind: target.kind,
+				Properties: map[string]any{
+					"risk_weight": 0.3, "confidence": 1.0,
+					"evidence_state": "configured", "last_seen": "2026-08-27T12:00:00Z",
+					"evidence": map[string]any{"source": "openwebui_config"},
+				},
+				ObservationDomains: []string{scope},
+			}}
+			if err := NewValidator().Validate(data); err != nil {
+				t.Fatalf("valid configured backend rejected: %v", err)
+			}
+		})
+	}
+}
+
 func validInstructionEvidenceData(t *testing.T) *ingest.IngestData {
 	t.Helper()
 	data := validIngestData()

--- a/server/ui/src/features/explorer/ui/EdgeDetailDrawer.test.tsx
+++ b/server/ui/src/features/explorer/ui/EdgeDetailDrawer.test.tsx
@@ -78,4 +78,47 @@ describe("EdgeDetailDrawer relationship semantics", () => {
     expect(screen.getByText("Agent can reach credential")).toBeInTheDocument();
     expect(screen.queryByText("Agent can reach resource")).not.toBeInTheDocument();
   });
+
+  it("shows configured backend evidence and observation time", () => {
+    const properties = {
+      evidence_state: "configured",
+      last_seen: "2026-08-27T12:00:00Z",
+      evidence: {
+        source: "knowledge_external_connections",
+        connection_ids: ["fixture-link"],
+      },
+    };
+    useExplorerStore.setState({
+      selectedEdge: {
+        id: "agent|credential|USES_BACKEND",
+        source: "agent",
+        target: "credential",
+        data: {
+          ...credentialReach,
+          kind: "USES_BACKEND",
+          bundledKinds: ["USES_BACKEND"],
+          bundledEdges: [
+            {
+              kind: "USES_BACKEND",
+              confidence: 1,
+              severity: null,
+              properties,
+            },
+          ],
+          properties,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <EdgeDetailDrawer />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/knowledge_external_connections/)).toBeInTheDocument();
+    expect(screen.getByText("observed at")).toBeInTheDocument();
+    expect(screen.getByText("2026-08-27T12:00:00Z")).toBeInTheDocument();
+    expect(screen.getByText(/not directly verified/)).toBeInTheDocument();
+  });
 });

--- a/server/ui/src/features/explorer/ui/EdgeDetailDrawer.tsx
+++ b/server/ui/src/features/explorer/ui/EdgeDetailDrawer.tsx
@@ -16,7 +16,17 @@ import { EDGE_COLORS, SEVERITY, SEVERITY_BY_KEY } from "@shared/theme/tokens";
 import { cn } from "@shared/lib/utils";
 import { useEscapeKey } from "@shared/lib/useEscapeKey";
 
-const HIDDEN_PROPS = new Set(["scan_id", "last_seen", "is_composite"]);
+const HIDDEN_PROPS = new Set(["scan_id", "is_composite"]);
+
+function displayProperty(value: unknown): string {
+  if (typeof value === "boolean") return value ? "yes" : "no";
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
 
 function Endpoint({ id, name, kind }: { id: string; name: string; kind: string }) {
   const config = getHexConfig(kind);
@@ -62,6 +72,9 @@ function RelationshipCard({
   const entries = Object.entries(props).filter(
     ([k, v]) => !HIDDEN_PROPS.has(k) && v != null && v !== "",
   );
+  const configuredReference =
+    props["evidence_state"] === "configured" ||
+    props["assertion_type"] === "configured_reference";
 
   return (
     <div
@@ -82,7 +95,7 @@ function RelationshipCard({
           })}
         </span>
       </div>
-      {props["assertion_type"] === "configured_reference" && (
+      {configuredReference && (
         <div className="mt-2 rounded-[3px] border border-amber-400/30 bg-amber-400/10 px-2.5 py-2 text-[11px] leading-relaxed text-amber-100">
           Configuration reference only. The target service and its
           authentication were not directly verified.
@@ -110,10 +123,13 @@ function RelationshipCard({
           {entries.map(([key, val]) => (
             <div key={key} className="flex items-baseline gap-1.5">
               <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground">
-                {key.replace(/_/g, " ")}
+                {key === "last_seen" ? "observed at" : key.replace(/_/g, " ")}
               </span>
-              <span className="truncate font-mono text-[10px] text-foreground" title={String(val)}>
-                {typeof val === "boolean" ? (val ? "yes" : "no") : String(val)}
+              <span
+                className="truncate font-mono text-[10px] text-foreground"
+                title={displayProperty(val)}
+              >
+                {displayProperty(val)}
               </span>
             </div>
           ))}


### PR DESCRIPTION
## Problem and result

Open WebUI's explicit Ollama and Qdrant backend configuration was either absent from the graph or expressed with legacy relationship semantics. This change records those references as configured topology with inspectable provenance, while refusing to treat configuration as reachability, authentication, or direct verification.

- emit configured `USES_BACKEND` relationships from Open WebUI to Ollama and enabled Qdrant backends
- converge configured backend identities with the corresponding direct collectors
- require authoritative response fields before accepting a complete-empty backend inventory
- keep incomplete or malformed configuration responses non-authoritative
- attach bounded evidence with source and observation time, and render it in the existing edge detail UI
- explain configured-only relationships consistently in tooltip and detail views
- exclude backend credential material from relationship evidence
- retire historical Open WebUI `EXPOSES` edges only after a complete authoritative replacement

## Acceptance checks against #83

- [x] Explicit Open WebUI Ollama and Qdrant relationships are inspectable through existing graph surfaces.
- [x] Evidence identifies its configuration source and observation time.
- [x] Configured relationships remain configured-only and do not imply service availability, access, credential validity, or path verification.
- [x] Missing, null, malformed, partial, and truncated inventory cannot establish absence.
- [x] Complete authoritative empty inventory can reconcile the owned backend domain.
- [x] Direct and configured observations of the same backend converge on one deterministic identity.
- [x] Historical artifacts remain supported and historical scan evidence remains available.
- [x] Existing scan modes, operator controls, ingestion handoff, and investigation workflow remain unchanged.

## Validation

- `go test ./...`
- `golangci-lint run ./modules/openwebuicollect/...`: 0 issues
- UI: 274 tests passed; production build passed
- Neo4j 4 + PostgreSQL 16 integration: Open WebUI backend replacement waits for complete inventory
- stacked Jupyter/MLflow migration and Qdrant retained-detail integration tests passed

The repository-wide `make check` currently stops on six pre-existing `SA5011` findings in unchanged `modules/litellmcollect/collector_test.go`; the changed packages pass lint.

Part 3 of 3 for #83. Stacked on #157.
