### PR TITLE
fix(ui): preserve snapshot context in findings exports

### DIFF
--- a/server/ui/src/features/findings/lib/copy-report.test.ts
+++ b/server/ui/src/features/findings/lib/copy-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Finding } from "@entities/finding/model";
+import type { Finding, PublishedFindingScope } from "@entities/finding/model";
 import { buildFindingsTableMarkdown, buildMarkdownReport } from "./copy-report";
 import { formatFindingEvidenceState } from "./evidence-label";
 
@@ -41,7 +41,14 @@ describe("buildMarkdownReport proof", () => {
       owasp_map: [],
       atlas_map: [],
     };
-    const report = buildMarkdownReport(finding, null, []);
+    const report = buildMarkdownReport(finding, null, [], {
+      scope: "published", scan_id: "scan-1", revision: 7,
+      published_at: "2026-09-10T12:00:00Z", projection_status: "complete",
+      snapshot_status: "complete", available: true, stale: false,
+      evidence_state: "persisted_exact_evidence",
+    });
+    expect(report).toContain("Revision: 7 | Published: 2026-09-10T12:00:00Z");
+    expect(report).toContain("Observed: 2026-07-13T12:00:00Z");
     expect(formatFindingEvidenceState(finding.evidence.state)).toBe("Verified During Scan");
     expect(report).toContain("Evidence: Verified During Scan");
     expect(buildFindingsTableMarkdown([finding])).toContain("| Verified During Scan |");
@@ -51,5 +58,35 @@ describe("buildMarkdownReport proof", () => {
     expect(report).toContain("Credential: resource_read / allowed / resource_addressed=true");
     expect(report).toContain("Cleanup: not_applicable");
     expect(report).toContain("not observed agent invocation or downstream impact");
+  });
+});
+
+const snapshot: PublishedFindingScope = {
+  mode: "published", scanId: "scan-1", revision: 7,
+  publishedAt: "2026-09-10T12:00:00Z", projectionStatus: "complete",
+  snapshotStatus: "complete", available: true, stale: false,
+};
+
+describe("table export snapshot context", () => {
+  it("retains identity and qualifies stale, limited evidence", () => {
+    const report = buildFindingsTableMarkdown([], {
+      snapshot: { ...snapshot, stale: true, coverageLimited: true },
+    });
+    expect(report).toContain("scan-1 | Revision: 7 | Published: 2026-09-10T12:00:00Z");
+    expect(report).toContain("Stale snapshot");
+    expect(report).toContain("missing evidence is not proof of absence");
+  });
+
+  it("does not call a failed refresh current or mistake missing scope for an all-clear", () => {
+    expect(buildFindingsTableMarkdown([], { snapshot, refreshFailed: true }))
+      .toContain("current status is unknown");
+    expect(buildFindingsTableMarkdown([])).toContain("Snapshot:** Unavailable");
+  });
+
+  it("includes coverage limitations supplied by the matching posture without inventing warnings", () => {
+    expect(buildFindingsTableMarkdown([], { snapshot, coverageLimited: true })).toContain("**Coverage:** Limited");
+    const report = buildFindingsTableMarkdown([], { snapshot });
+    expect(report).not.toContain("**Freshness:**");
+    expect(report).not.toContain("**Coverage:**");
   });
 });

--- a/server/ui/src/features/findings/lib/copy-report.ts
+++ b/server/ui/src/features/findings/lib/copy-report.ts
@@ -3,7 +3,9 @@ import type {
   AttackPath,
   FindingDetail,
   RemediationStep,
+  PublishedFindingScope,
 } from "@entities/finding/model";
+import { isCurrentPublishedFindingScope } from "@entities/finding/model";
 import { formatFindingEvidenceState } from "./evidence-label";
 
 /**
@@ -11,9 +13,30 @@ import { formatFindingEvidenceState } from "./evidence-label";
  * selection). Path-level detail requires per-finding fetches, so this stays a
  * summary — id, severity, relationship, endpoints, OWASP, ATLAS, confidence.
  */
-export function buildFindingsTableMarkdown(findings: Finding[]): string {
+export function buildFindingsTableMarkdown(
+  findings: Finding[],
+  context: {
+    snapshot?: PublishedFindingScope;
+    refreshFailed?: boolean;
+    coverageLimited?: boolean;
+  } = {},
+): string {
   const lines: string[] = [];
   lines.push(`## AgentHound Findings (${findings.length})`);
+  const { snapshot, refreshFailed } = context;
+  if (snapshot?.available) {
+    lines.push(`**Snapshot:** ${markdownText(snapshot.scanId)} | Revision: ${snapshot.revision ?? "unknown"} | Published: ${markdownText(snapshot.publishedAt ?? "unknown")}`);
+    if (refreshFailed) {
+      lines.push("**Freshness:** Refresh failed; current status is unknown. These are cached findings.");
+    } else if (!isCurrentPublishedFindingScope(snapshot)) {
+      lines.push("**Freshness:** Stale snapshot; these findings are not a current-state verdict.");
+    }
+  } else {
+    lines.push("**Snapshot:** Unavailable; snapshot identity and current status cannot be established.");
+  }
+  if (context.coverageLimited || snapshot?.coverageLimited || (snapshot?.activeCoverageLimitations?.length ?? 0) > 0) {
+    lines.push("**Coverage:** Limited in the recorded snapshot; missing evidence is not proof of absence.");
+  }
   lines.push("");
   lines.push(
     "| Severity | Finding | Variant | Evidence | Relationship | Source → Target | OWASP | MITRE ATLAS | Conf |",
@@ -66,7 +89,7 @@ export function buildMarkdownReport(
   }
   if (snapshot) {
     lines.push(
-      `**Snapshot:** ${snapshot.scan_id} | Projection: ${snapshot.projection_status} | Evidence: ${snapshot.evidence_state}${snapshot.stale ? " | stale" : ""}`,
+      `**Snapshot:** ${snapshot.scan_id} | Revision: ${snapshot.revision ?? "unknown"} | Published: ${snapshot.published_at ?? "unknown"} | Projection: ${snapshot.projection_status} | Evidence: ${snapshot.evidence_state}${snapshot.stale ? " | stale" : ""}`,
     );
   }
   lines.push("");

--- a/server/ui/src/features/findings/ui/FindingsListPage.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.tsx
@@ -389,7 +389,11 @@ export function FindingsListPage() {
   function exportSelected() {
     const chosen = ordered.filter((f) => selected.has(f.id));
     if (chosen.length === 0) return;
-    void navigator.clipboard.writeText(buildFindingsTableMarkdown(chosen));
+    void navigator.clipboard.writeText(buildFindingsTableMarkdown(chosen, {
+      snapshot,
+      refreshFailed: cachedRefreshError,
+      coverageLimited: limitedCoverage,
+    }));
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   }


### PR DESCRIPTION
The findings list can display stale-snapshot or coverage warnings that disappear when its table is copied. Individual reports also omit the supplied publication revision and time, making shared findings harder to attribute and interpret.

Pass the already-loaded snapshot and display qualifications into the table exporter. Add a compact header with scan ID, revision, publication time, and known freshness/coverage limitations. Include revision and publication time in individual reports while keeping proof observation time separate. This requires no additional fetches or per-finding detail expansion.

Validation: four focused export tests pass, covering stale/limited snapshots, failed refreshes, unavailable scope, matching-posture coverage, and publication versus proof timestamps. TypeScript build and ESLint pass for the changed files.
