### PR TITLE
fix(ui): retain collection coverage in query results

### DIFF
--- a/server/ui/src/__tests__/QueryLibrary.test.tsx
+++ b/server/ui/src/__tests__/QueryLibrary.test.tsx
@@ -125,5 +125,24 @@ describe("QueryLibrary", () => {
     });
 
     expect(screen.getByText("85")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
+  it.each([{ rows: [] }, { rows: [{ name: "retained evidence" }] }])("preserves collection limitations alongside results: %j", async ({ rows }) => {
+    mockedFetchQueries.mockResolvedValue(mockQueries);
+    mockedRunQuery.mockResolvedValue({
+      query: mockQueries[0]!, rows,
+      projection: { scanId: "limited-scan", revision: 7, coverageLimited: true, coverageLimitationCount: 3 },
+    });
+    render(<QueryLibrary />, { wrapper: createWrapper() });
+    fireEvent.click((await screen.findByText("Agents with Shell Access")).closest("button")!);
+    expect(await screen.findByRole("alert")).toHaveTextContent("3 limited scopes");
+    expect(screen.getByText(/Snapshot: limited-scan/)).toHaveTextContent("Revision: 7");
+    if (rows.length) {
+      expect(screen.getByText("retained evidence")).toBeInTheDocument();
+    } else {
+      expect(screen.getByText(/No matches in available evidence/)).toBeInTheDocument();
+      expect(screen.queryByText(/No results for/)).not.toBeInTheDocument();
+    }
+  });
+
 });

--- a/server/ui/src/features/queries/ui/QueryLibrary.tsx
+++ b/server/ui/src/features/queries/ui/QueryLibrary.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { BookOpen, Play, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
 import { usePreBuiltQueries, useRunPreBuiltQuery } from "@entities/prebuilt";
-import type { PreBuiltQuery, TraversalMetadata } from "@entities/prebuilt";
+import type { PreBuiltQuery, PreBuiltResult } from "@entities/prebuilt";
 import { Skeleton } from "@shared/ui/primitives/skeleton";
 import { DataStateNotice } from "@shared/ui/feedback";
 import { severityColor } from "@shared/theme/tokens";
@@ -38,10 +38,7 @@ export function QueryLibrary() {
   } = usePreBuiltQueries();
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [resultRows, setResultRows] = useState<Record<string, unknown>[]>([]);
-  const [activeQuery, setActiveQuery] = useState<PreBuiltQuery | null>(null);
-  const [resultMetadata, setResultMetadata] =
-    useState<TraversalMetadata | null>(null);
+  const [result, setResult] = useState<PreBuiltResult | null>(null);
 
   const runQuery = useRunPreBuiltQuery();
 
@@ -51,16 +48,8 @@ export function QueryLibrary() {
       return;
     }
     setExpandedId(query.id);
-    setResultRows([]);
-    setActiveQuery(null);
-    setResultMetadata(null);
-    runQuery.mutate(query.id, {
-      onSuccess: (data) => {
-        setResultRows(data.rows);
-        setActiveQuery(data.query);
-        setResultMetadata(data.metadata ?? null);
-      },
-    });
+    setResult(null);
+    runQuery.mutate(query.id, { onSuccess: setResult });
   }
 
   const grouped = new Map<string, PreBuiltQuery[]>();
@@ -217,11 +206,12 @@ export function QueryLibrary() {
                                     ? runQuery.error.message
                                     : "Query failed"}
                                 </div>
-                              ) : activeQuery ? (
+                              ) : result ? (
                                 <QueryResult
-                                  rows={resultRows}
-                                  query={activeQuery}
-                                  metadata={resultMetadata ?? undefined}
+                                  rows={result.rows}
+                                  query={result.query}
+                                  metadata={result.metadata}
+                                  projection={result.projection}
                                 />
                               ) : null}
                             </div>

--- a/server/ui/src/features/queries/ui/QueryResult.tsx
+++ b/server/ui/src/features/queries/ui/QueryResult.tsx
@@ -1,5 +1,6 @@
 import type {
   PreBuiltQuery,
+  ProjectionIdentity,
   TraversalMetadata,
 } from "@entities/prebuilt/api";
 
@@ -7,6 +8,7 @@ interface QueryResultProps {
   rows: Record<string, unknown>[];
   query: PreBuiltQuery;
   metadata?: TraversalMetadata;
+  projection?: ProjectionIdentity;
 }
 
 function isStructuredValue(value: unknown): value is object {
@@ -23,7 +25,20 @@ function formatStructured(value: object): string {
   return JSON.stringify(value, null, 2) ?? "\u2014";
 }
 
-export function QueryResult({ rows, query, metadata }: QueryResultProps) {
+export function QueryResult({ rows, query, metadata, projection }: QueryResultProps) {
+  const limitedCoverage = projection?.coverageLimited === true;
+  const publication = projection ? (
+    <div className="mb-2 break-all font-mono text-[10px] text-muted-foreground">
+      Snapshot: {projection.scanId} · Revision: {projection.revision}
+    </div>
+  ) : null;
+  const coverageWarning = limitedCoverage ? (
+    <div role="alert" className="mb-2 rounded-[3px] border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-200">
+      Collection coverage is limited in this snapshot ({projection.coverageLimitationCount} limited scopes).
+      Missing evidence is not proof of absence. This is a snapshot-wide limitation,
+      not a count of scopes affected by this query.
+    </div>
+  ) : null;
   const incomplete =
     metadata !== undefined && (!metadata.complete || metadata.truncated);
   const warning = incomplete ? (
@@ -41,11 +56,15 @@ export function QueryResult({ rows, query, metadata }: QueryResultProps) {
   if (rows.length === 0) {
     return (
       <>
+        {publication}
+        {coverageWarning}
         {warning}
         <div className="py-4 text-center font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
           {incomplete
             ? `Result unavailable for "${query.name}" because traversal did not complete`
-            : `No results for "${query.name}"`}
+            : limitedCoverage
+              ? `No matches in available evidence for "${query.name}"; collection coverage is limited`
+              : `No results for "${query.name}"`}
         </div>
       </>
     );
@@ -55,6 +74,8 @@ export function QueryResult({ rows, query, metadata }: QueryResultProps) {
 
   return (
     <div>
+      {publication}
+      {coverageWarning}
       {warning}
       <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
         {rows.length} row{rows.length !== 1 ? "s" : ""}


### PR DESCRIPTION
Query Library discards the publication and collection-coverage metadata returned by the API. A query over incompletely collected evidence can therefore display an unqualified “No results,” even though its traversal completed successfully.

Keep the response together in one result state and display its scan/revision and snapshot-wide coverage warning in the existing result panel. Qualify empty results while retaining populated results and the separate traversal-truncation warning. The limitation count is explicitly snapshot-wide; it does not claim that those scopes affected this particular query.

Validation: 11 Query Library/result tests pass, including actual query-card interactions with empty and populated limited-coverage responses and existing structured-value/traversal cases. TypeScript build and ESLint pass for the changed files.
