### PR TITLE
fix(ui): report triage save failures and bulk outcomes

### DIFF
--- a/server/ui/src/features/findings/ui/FindingsListPage.test.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Finding } from "@entities/finding/model";
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   useFindings: vi.fn(),
   useProjectionState: vi.fn(),
   mutate: vi.fn(),
+  mutateAsync: vi.fn(),
 }));
 
 vi.mock("@entities/finding", async (importOriginal) => {
@@ -14,7 +15,7 @@ vi.mock("@entities/finding", async (importOriginal) => {
   return {
     ...actual,
     useFindings: mocks.useFindings,
-    useSetTriage: () => ({ mutate: mocks.mutate }),
+    useSetTriage: () => ({ mutate: mocks.mutate, mutateAsync: mocks.mutateAsync }),
   };
 });
 
@@ -325,4 +326,29 @@ describe("FindingsListPage request and snapshot states", () => {
     expect(screen.getByText("high finding")).toBeInTheDocument();
     expect(screen.queryByText("medium finding")).not.toBeInTheDocument();
   });
+});
+
+
+it("summarizes partial bulk saves and retries only failed findings", async () => {
+  Element.prototype.scrollIntoView = vi.fn();
+  mocks.useProjectionState.mockReturnValue(completePosture);
+  mocks.useFindings.mockReturnValue({
+    data: [finding("one", "high"), finding("two", "medium")],
+    snapshot: currentScope, isLoading: false, isError: false,
+  });
+  mocks.mutateAsync.mockImplementation(({ fingerprint }: { fingerprint: string }) =>
+    fingerprint === "two" ? Promise.reject(new Error("rejected")) : Promise.resolve(),
+  );
+  renderPage();
+  for (const checkbox of screen.getAllByRole("checkbox").slice(1)) fireEvent.click(checkbox);
+  fireEvent.keyDown(screen.getByRole("button", { name: "Set status" }), { key: "ArrowDown" });
+  fireEvent.click(await screen.findByRole("menuitem", { name: "Triaging" }));
+  expect(await screen.findByRole("alert")).toHaveTextContent("1 saved · 1 failed");
+  expect(screen.getAllByRole("checkbox").filter((el) => (el as HTMLInputElement).checked)).toHaveLength(1);
+  mocks.mutateAsync.mockClear();
+  mocks.mutateAsync.mockResolvedValue(undefined);
+  fireEvent.click(screen.getByRole("button", { name: "Retry failed items" }));
+  await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("1 saved · 0 failed"));
+  expect(mocks.mutateAsync).toHaveBeenCalledExactlyOnceWith({ fingerprint: "two", status: "triaging" });
+  expect(screen.queryByRole("button", { name: "Retry failed items" })).not.toBeInTheDocument();
 });

--- a/server/ui/src/features/findings/ui/FindingsListPage.tsx
+++ b/server/ui/src/features/findings/ui/FindingsListPage.tsx
@@ -144,6 +144,10 @@ export function FindingsListPage() {
     dir: "asc",
   });
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkPending, setBulkPending] = useState(false);
+  const [bulkResult, setBulkResult] = useState<{
+    saved: number; failed: string[]; status: TriageStatus;
+  } | null>(null);
   const [cursor, setCursor] = useState(0);
   const [copied, setCopied] = useState(false);
   const [railOpen, setRailOpen] = useState(true);
@@ -394,8 +398,20 @@ export function FindingsListPage() {
     setTimeout(() => setCopied(false), 1500);
   }
 
-  function bulkSetStatus(status: TriageStatus) {
-    for (const id of selected) setTriage.mutate({ fingerprint: id, status });
+  async function bulkSetStatus(status: TriageStatus, ids = [...selected]) {
+    if (bulkPending || ids.length === 0) return;
+    setBulkPending(true);
+    setBulkResult(null);
+    const results = await Promise.allSettled(
+      ids.map((fingerprint) => setTriage.mutateAsync({ fingerprint, status })),
+    );
+    const failed = ids.filter((_, index) => results[index]!.status === "rejected");
+    const saved = new Set(ids.filter((_, index) => results[index]!.status === "fulfilled"));
+    setSelected((previous) => new Set([
+      ...[...previous].filter((id) => !saved.has(id)), ...failed,
+    ]));
+    setBulkResult({ saved: saved.size, failed, status });
+    setBulkPending(false);
   }
 
   function setSortKey(key: SortKey) {
@@ -561,6 +577,17 @@ export function FindingsListPage() {
           as clean.
         </DataStateNotice>
       )}
+      {bulkPending && <p role="status" className="text-sm text-muted-foreground">Saving triage changes…</p>}
+      {bulkResult && (
+        <div role={bulkResult.failed.length ? "alert" : "status"} className="text-sm">
+          {bulkResult.saved} saved · {bulkResult.failed.length} failed.
+          {bulkResult.failed.length > 0 && (
+            <button className="ml-2 text-primary underline" onClick={() => void bulkSetStatus(bulkResult.status, bulkResult.failed)}>
+              Retry failed items
+            </button>
+          )}
+        </div>
+      )}
       {registerContent}
     </div>
   );
@@ -687,7 +714,7 @@ export function FindingsListPage() {
               {pad2(selected.size)} selected
             </span>
             <span className="mx-1 h-4 w-px bg-border/70" />
-            <BulkStatusMenu onPick={bulkSetStatus} />
+            <BulkStatusMenu disabled={bulkPending} onPick={(status) => void bulkSetStatus(status)} />
             <button
               onClick={exportSelected}
               className="inline-flex items-center gap-1.5 rounded-[3px] border border-border bg-black/30 px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.06em] text-foreground/80 transition-colors hover:border-primary/50 hover:text-primary"
@@ -1162,11 +1189,11 @@ function GroupSection({
   );
 }
 
-function BulkStatusMenu({ onPick }: { onPick: (s: TriageStatus) => void }) {
+function BulkStatusMenu({ onPick, disabled }: { onPick: (s: TriageStatus) => void; disabled: boolean }) {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
-        <button className="inline-flex items-center gap-1.5 rounded-[3px] border border-border bg-black/30 px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.06em] text-foreground/80 transition-colors hover:border-primary/50 hover:text-primary">
+        <button disabled={disabled} className="inline-flex items-center gap-1.5 rounded-[3px] border border-border bg-black/30 px-2.5 py-1 font-mono text-[11px] uppercase tracking-[0.06em] text-foreground/80 transition-colors hover:border-primary/50 hover:text-primary">
           Set status
         </button>
       </DropdownMenu.Trigger>

--- a/server/ui/src/features/findings/ui/TriageControl.test.tsx
+++ b/server/ui/src/features/findings/ui/TriageControl.test.tsx
@@ -1,0 +1,33 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { expect, it, vi } from "vitest";
+import { TriageControl } from "./TriageControl";
+import { setTriage } from "@entities/finding/api";
+
+vi.mock("@entities/finding/api", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@entities/finding/api")>(),
+  setTriage: vi.fn(),
+}));
+
+it("shows pending and rejected saves and retries the same decision without navigating the row", async () => {
+  let reject!: (error: Error) => void;
+  const write = vi.mocked(setTriage);
+  write.mockReturnValueOnce(new Promise((_, fail) => { reject = fail; }));
+  const navigate = vi.fn();
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { mutations: { retry: false } } })}>
+      <div onClick={navigate}><TriageControl findingId="finding-1" status="new" /></div>
+    </QueryClientProvider>,
+  );
+  fireEvent.keyDown(screen.getByRole("button", { name: "Set triage status" }), { key: "ArrowDown" });
+  fireEvent.click(await screen.findByRole("menuitem", { name: "Triaging" }));
+  await waitFor(() => expect(screen.getByRole("button", { name: "Set triage status" })).toBeDisabled());
+  await act(async () => reject(new Error("write rejected")));
+  expect(await screen.findByRole("alert")).toHaveTextContent("Status save failed");
+  write.mockResolvedValueOnce({ status: "triaging", note: "", updated_at: "2026-09-10T00:00:00Z" });
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  expect(write).toHaveBeenLastCalledWith("finding-1", "triaging", undefined);
+  expect(write).toHaveBeenCalledTimes(2);
+  expect(navigate).not.toHaveBeenCalled();
+});

--- a/server/ui/src/features/findings/ui/TriageControl.tsx
+++ b/server/ui/src/features/findings/ui/TriageControl.tsx
@@ -29,6 +29,7 @@ export function TriageControl({ findingId, status, compact = false }: TriageCont
   const meta = TRIAGE_META[status] ?? TRIAGE_META.new;
 
   return (
+    <span className="inline-flex flex-wrap items-center gap-1" onClick={(e) => e.stopPropagation()}>
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
@@ -38,6 +39,8 @@ export function TriageControl({ findingId, status, compact = false }: TriageCont
             "border-border bg-black/30 text-foreground/80 hover:border-mauve-7 hover:text-foreground",
             compact ? "px-1.5 py-0.5 text-[9px]" : "px-2.5 py-1 text-[11px]",
           )}
+          disabled={setTriage.isPending}
+          aria-busy={setTriage.isPending}
           aria-label="Set triage status"
         >
           <span
@@ -45,6 +48,7 @@ export function TriageControl({ findingId, status, compact = false }: TriageCont
             style={{ backgroundColor: meta.color, boxShadow: `0 0 6px -1px ${meta.color}` }}
           />
           <span style={{ color: meta.color }}>{compact ? meta.short : meta.label}</span>
+          {setTriage.isPending && <span className="text-muted-foreground">Saving…</span>}
           <ChevronDown className="h-3 w-3 opacity-60" strokeWidth={2.5} />
         </button>
       </DropdownMenu.Trigger>
@@ -86,5 +90,14 @@ export function TriageControl({ findingId, status, compact = false }: TriageCont
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
+    {setTriage.isError && (
+      <span role="alert" className="text-xs text-destructive">
+        Status save failed.{' '}
+        <button className="underline" onClick={() => {
+          if (setTriage.variables) setTriage.mutate(setTriage.variables);
+        }}>Retry</button>
+      </span>
+    )}
+    </span>
   );
 }


### PR DESCRIPTION
A rejected triage write closes the status menu without explaining why the old status remains. Bulk changes also provide no completion summary, leaving users to work out which saves succeeded.

Show pending state and local failure/retry feedback for individual edits. For bulk edits, await each existing mutation, report saved/failed counts, remove successful items from the selection, and retain failed items for targeted retry. Successful writes continue using the existing cache invalidation. No endpoint or triage identity changes are needed.

Validation: all 283 UI tests pass, including actual dropdown interactions with a rejected write, retry of the same decision, and partial bulk completion followed by retry of only the failed item. Production build and changed-file ESLint pass.
