### PR TITLE
fix(scans): expose execution details and bound history responses

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -57,7 +57,7 @@ The ingest body is a complete V1 envelope:
 
 The full schema requires collection identity, timestamps, coverage semantics, valid node and edge kinds, and consistent property types. Use the collector artifact directly rather than constructing envelopes by hand.
 
-Scan execution data remains under `meta.extra.scan_execution`. The server stores the complete record in `metadata.artifact_extra.scan_execution` and promotes its mode, deep flag, status, timestamps, and summary for scan-history views.
+Scan execution data remains under `meta.extra.scan_execution`. The server stores the complete record in `metadata.artifact_extra.scan_execution` and promotes its mode, deep flag, status, timestamps, and summary for scan-history views. `GET /api/v1/scans` returns only submitted counts, this promoted execution summary, and an empty `metadata.ruleset` object when ruleset provenance is available. The empty object is an availability marker, not a complete manifest. `GET /api/v1/scans/{id}` retains full metadata, including the execution journal, collection details, and ruleset entries; the UI loads these when inspecting a scan or its provenance.
 
 ## Findings
 

--- a/server/internal/appdb/integration_test.go
+++ b/server/internal/appdb/integration_test.go
@@ -2,9 +2,11 @@ package appdb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -361,6 +363,11 @@ func TestIntegrationScansCRUD(t *testing.T) {
 
 	scanID := "test-scan-" + time.Now().Format("20060102150405")
 
+	// A large retained journal must not grow the history response.
+	actions := make([]any, 1000)
+	for i := range actions {
+		actions[i] = map[string]any{"id": fmt.Sprintf("action-%d", i), "error": strings.Repeat("x", 240)}
+	}
 	// Create
 	scan := &model.Scan{
 		ID:        scanID,
@@ -368,6 +375,11 @@ func TestIntegrationScansCRUD(t *testing.T) {
 		Status:    model.ScanStatusRunning,
 		StartedAt: time.Now().UTC(),
 		Metadata: map[string]any{
+			"submitted":      map[string]any{"nodes": 12, "edges": 34},
+			"artifact_extra": map[string]any{"scan_execution": map[string]any{"actions": actions}},
+			"scan_execution": map[string]any{"version": 1, "mode": "active", "deep": false,
+				"status": "completed", "started_at": "2026-09-10T00:00:00Z", "updated_at": "2026-09-10T00:00:01Z",
+				"summary": map[string]any{"actions_attempted": 1000, "actions_succeeded": 0, "actions_failed": 1000, "actions_skipped": 0, "cleanup_failures": 0}},
 			"ruleset": map[string]any{
 				"authenticity": "unverified",
 				"entries": []any{map[string]any{
@@ -412,6 +424,13 @@ func TestIntegrationScansCRUD(t *testing.T) {
 		t.Fatalf("persisted canonical matcher = %#v", entry["effective_matcher"])
 	}
 
+	detailJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detailJSON) < 240000 {
+		t.Fatalf("detail lost journal: %d bytes", len(detailJSON))
+	}
 	// List
 	scans, err := store.ListScans(ctx, 10, 0)
 	if err != nil {
@@ -421,6 +440,40 @@ func TestIntegrationScansCRUD(t *testing.T) {
 		t.Error("expected at least 1 scan in list")
 	}
 
+	found := false
+	for _, listed := range scans {
+		if listed.ID != scanID {
+			continue
+		}
+		found = true
+		if _, exists := listed.Metadata["artifact_extra"]; exists {
+			t.Fatal("list retained full artifact")
+		}
+		if listed.Metadata["scan_execution"] == nil {
+			t.Fatal("list lost execution summary")
+		}
+		rules, ok := listed.Metadata["ruleset"].(map[string]any)
+		if !ok || len(rules) != 0 {
+			t.Fatalf("ruleset marker = %#v", listed.Metadata["ruleset"])
+		}
+		payload, err := json.Marshal(listed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(payload) > 2000 {
+			t.Fatalf("list row grew with journal: %d bytes", len(payload))
+		}
+		var wire struct{ Submitted model.ScanCounts }
+		if err := json.Unmarshal(payload, &wire); err != nil {
+			t.Fatal(err)
+		}
+		if wire.Submitted.Nodes != 12 || wire.Submitted.Edges != 34 {
+			t.Fatalf("lost submitted counts: %+v", wire.Submitted)
+		}
+	}
+	if !found {
+		t.Fatal("scan missing from history page")
+	}
 	// Cleanup
 	_, _ = pool.Exec(ctx, "DELETE FROM scans WHERE id = $1", scanID)
 }

--- a/server/internal/appdb/scans.go
+++ b/server/internal/appdb/scans.go
@@ -25,7 +25,18 @@ const scanSelectColumns = `id, collector, status, started_at, completed_at,
 	graph_total_nodes_before, graph_total_edges_before,
 	graph_total_nodes_after, graph_total_edges_after,
 	coalesce(comparable_to_scan_id, ''), published_revision, published_at,
-	lifecycle_updated_at, coalesce(metadata, '{}'::jsonb)`
+	lifecycle_updated_at, `
+
+const scanDetailColumns = scanSelectColumns + `coalesce(metadata, '{}'::jsonb)`
+
+// List rows carry the promoted execution summary and a ruleset-availability
+// marker. Journals, collection outcomes and rule entries belong to detail reads.
+const scanListColumns = scanSelectColumns + `jsonb_strip_nulls(jsonb_build_object(
+    'submitted', metadata->'submitted',
+    'scan_execution', metadata->'scan_execution',
+    'ruleset', CASE WHEN metadata->'ruleset' IS NOT NULL
+        AND metadata->'ruleset' <> 'null'::jsonb THEN '{}'::jsonb END
+))`
 
 type ScanFailure struct {
 	ID               string
@@ -539,7 +550,7 @@ func (s *ScanStore) RecoverInterruptedIngests(ctx context.Context) ([]string, er
 
 func (s *ScanStore) GetScan(ctx context.Context, id string) (*model.Scan, error) {
 	scan, err := scanScan(s.pool.QueryRow(ctx,
-		`SELECT `+scanSelectColumns+` FROM scans WHERE id = $1`, id))
+		`SELECT `+scanDetailColumns+` FROM scans WHERE id = $1`, id))
 	if err != nil {
 		return nil, fmt.Errorf("get scan: %w", err)
 	}
@@ -599,7 +610,7 @@ func (s *ScanStore) ListScansPage(
 	}
 
 	rows, err := tx.Query(ctx,
-		`SELECT `+scanSelectColumns+`
+		`SELECT `+scanListColumns+`
 		 FROM scans ORDER BY `+scanListOrderClause(order)+` LIMIT $1 OFFSET $2`, limit+1, offset)
 	if err != nil {
 		return nil, ScanPageInfo{}, fmt.Errorf("list scans: %w", err)

--- a/server/ui/src/features/rules/ui/RulesLibrary.test.tsx
+++ b/server/ui/src/features/rules/ui/RulesLibrary.test.tsx
@@ -13,7 +13,40 @@ vi.mock("@entities/rule", () => ({
   }),
 }));
 
-vi.mock("@entities/scan", () => ({
+vi.mock("@entities/scan", () => {
+  const currentScan = {
+        id: "scan-with-rules",
+        collector: "mcp",
+        status: "completed",
+        started_at: "2026-07-11T00:00:00Z",
+        completed_at: "2026-07-11T00:01:00Z",
+        submitted: { nodes: 1, edges: 1 },
+        write_rows: { nodes: 1, edges: 1 },
+        graph_totals: { before: null, after: null },
+        publication_status: "published",
+        metadata: {
+          ruleset: {
+            digest: "sha256:effective-rules",
+            load_state: "complete",
+            authenticity: "unverified",
+            entries: [
+              {
+                type: "text",
+                id: "custom-rule",
+                version: 2,
+                semantic_sha256: "sha256:custom-rule",
+                source: "custom",
+                effective_matcher: {
+                  type: "regex",
+                  pattern: "effective",
+                },
+              },
+            ],
+            errors: [],
+          },
+        },
+      };
+  return ({
   useScan: (id: string | null) => ({
     data:
       id === "older-scan"
@@ -49,51 +82,21 @@ vi.mock("@entities/scan", () => ({
               },
             },
           }
-        : undefined,
+        : id === currentScan.id ? currentScan : undefined,
     isLoading: false,
     isError: false,
     error: null,
   }),
   useScans: () => ({
     data: [
-      {
-        id: "scan-with-rules",
-        collector: "mcp",
-        status: "completed",
-        started_at: "2026-07-11T00:00:00Z",
-        completed_at: "2026-07-11T00:01:00Z",
-        submitted: { nodes: 1, edges: 1 },
-        write_rows: { nodes: 1, edges: 1 },
-        graph_totals: { before: null, after: null },
-        publication_status: "published",
-        metadata: {
-          ruleset: {
-            digest: "sha256:effective-rules",
-            load_state: "complete",
-            authenticity: "unverified",
-            entries: [
-              {
-                type: "text",
-                id: "custom-rule",
-                version: 2,
-                semantic_sha256: "sha256:custom-rule",
-                source: "custom",
-                effective_matcher: {
-                  type: "regex",
-                  pattern: "effective",
-                },
-              },
-            ],
-            errors: [],
-          },
-        },
-      },
+      { ...currentScan, metadata: { ruleset: {} } },
     ],
     isLoading: false,
     isError: false,
     error: null,
   }),
-}));
+});
+});
 
 describe("RulesLibrary", () => {
   it("shows scan-specific provenance separately from current server rules", () => {

--- a/server/ui/src/features/rules/ui/RulesLibrary.tsx
+++ b/server/ui/src/features/rules/ui/RulesLibrary.tsx
@@ -74,16 +74,18 @@ export function RulesLibrary() {
     scansWithProvenance.find(
       (scan) => scan.publication_status === "published",
     ) ?? scansWithProvenance[0];
+  const defaultScanQuery = useScan(requestedScanId ? null : defaultScan?.id ?? null);
+  const selectedScanQuery = requestedScanId ? requestedScanQuery : defaultScanQuery;
   const selectedScan =
     (requestedScanId
       ? requestedScanQuery.data?.metadata?.ruleset != null
         ? requestedScanQuery.data
         : null
-      : defaultScan) ?? null;
+      : defaultScanQuery.data) ?? null;
   const invalidRequestedScan =
     requestedScanId != null &&
-    !requestedScanQuery.isLoading &&
-    !requestedScanQuery.isError &&
+    !selectedScanQuery.isLoading &&
+    !selectedScanQuery.isError &&
     selectedScan == null;
   const provenance = selectedScan
     ? scanRulesetProvenance(selectedScan)
@@ -179,12 +181,12 @@ export function RulesLibrary() {
                 onChange={(event) => selectScan(event.target.value)}
                 disabled={
                   scansQuery.isLoading ||
-                  requestedScanQuery.isLoading ||
+                  selectedScanQuery.isLoading ||
                   scansWithProvenance.length === 0
                 }
                 className="h-8 w-full rounded-[3px] border border-border bg-black/40 px-2 font-mono text-[11px] text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50"
               >
-                {(invalidRequestedScan || requestedScanQuery.isError) && (
+                {(invalidRequestedScan || selectedScanQuery.isError) && (
                   <option value="">Requested scan unavailable</option>
                 )}
                 {scansWithProvenance.length === 0 && (
@@ -217,15 +219,15 @@ export function RulesLibrary() {
                 : "The scan-history request failed."}
             </DataStateNotice>
           )}
-          {requestedScanId && requestedScanQuery.isError && (
+          {selectedScanQuery.isError && (
             <DataStateNotice
               tone="error"
-              title="Requested scan provenance unavailable"
+              title="Scan provenance unavailable"
               className="mt-3"
             >
-              {requestedScanQuery.error instanceof Error
-                ? requestedScanQuery.error.message
-                : `Scan ${requestedScanId} could not be loaded.`}
+              {selectedScanQuery.error instanceof Error
+                ? selectedScanQuery.error.message
+                : `Scan ${requestedScanId ?? defaultScan?.id} could not be loaded.`}
             </DataStateNotice>
           )}
           {invalidRequestedScan && (
@@ -239,7 +241,7 @@ export function RulesLibrary() {
           )}
           {!scansQuery.isLoading &&
             !scansQuery.isError &&
-            !requestedScanQuery.isLoading &&
+            !selectedScanQuery.isLoading &&
             scansWithProvenance.length === 0 && (
               <DataStateNotice
                 tone="warning"

--- a/server/ui/src/features/scans/ui/ScanExecutionDetail.test.tsx
+++ b/server/ui/src/features/scans/ui/ScanExecutionDetail.test.tsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, it, vi } from "vitest";
+import { fetchScan } from "@entities/scan/api";
+import type { Scan } from "@entities/scan";
+import { ScanHistory } from "./ScanHistory";
+
+vi.mock("@entities/scan/api", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@entities/scan/api")>(),
+  fetchScan: vi.fn(),
+}));
+
+const scan: Scan = {
+  id: "scan-detail", collector: "scan", status: "completed", started_at: "2026-09-10T00:00:00Z",
+  submitted: { nodes: 0, edges: 0 }, write_rows: { nodes: 0, edges: 0 },
+  graph_totals: { before: null, after: null },
+};
+const detail: Scan = {
+  ...scan,
+  metadata: {
+    collection_identity: { collection_point_id: "point-1", network_context_id: "network-1" },
+    artifact_extra: { scan_execution: {
+      version: 1, status: "completed", updated_at: "2026-09-10T00:01:00Z",
+      actions: [{ id: "action-1", action: "test-action", status: "failed", target_id: "target-1", outcome: "failed", error: "recorded action error", recovery_id: "recovery-1" }],
+      recovery: [{ id: "recovery-1", action_id: "action-1", action: "test-action", status: "conflict", error: "recorded recovery error", data: { secret: "private recovery payload" } }],
+    } },
+  },
+};
+
+function renderHistory() {
+  return render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter><ScanHistory scans={[scan]} /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => vi.mocked(fetchScan).mockReset());
+
+it("loads diagnosis only when opened and keeps recovery payloads out of the view", async () => {
+  let resolve!: (value: Scan) => void;
+  vi.mocked(fetchScan).mockReturnValue(new Promise((done) => { resolve = done; }));
+  renderHistory();
+  expect(fetchScan).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole("button", { name: "View execution details for scan scan-detail" }));
+  expect(screen.getByRole("status")).toHaveTextContent("Loading execution details");
+  await act(async () => resolve(detail));
+  const dialog = screen.getByRole("dialog");
+  expect(await within(dialog).findByText(/Collection point: point-1/)).toHaveTextContent("Network context: network-1");
+  expect(within(dialog).getByText(/Target: target-1/)).toHaveTextContent("Action ID: action-1");
+  expect(within(dialog).getByRole("alert")).toHaveTextContent("1 unresolved cleanup records");
+  expect(within(dialog).getByText("recorded action error")).not.toBeVisible();
+  fireEvent.click(within(dialog).getAllByText("Reveal recorded error")[0]!);
+  expect(within(dialog).getByText("recorded action error")).toBeVisible();
+  expect(within(dialog).queryByText(/private recovery payload/)).not.toBeInTheDocument();
+  expect(fetchScan).toHaveBeenCalledExactlyOnceWith("scan-detail");
+});
+
+it("offers retry after a detail read fails, then shows missing journal honestly", async () => {
+  vi.mocked(fetchScan).mockRejectedValueOnce(new Error("network failure"));
+  renderHistory();
+  fireEvent.click(screen.getByRole("button", { name: "View execution details for scan scan-detail" }));
+  expect(await screen.findByRole("alert")).toHaveTextContent("could not be refreshed");
+  vi.mocked(fetchScan).mockResolvedValueOnce(scan);
+  fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+  await waitFor(() => expect(screen.getByText("Full execution journal unavailable for this scan.")).toBeInTheDocument());
+  expect(screen.queryByText(/unresolved cleanup records/)).not.toBeInTheDocument();
+});
+
+it("does not recommend recovery for restored records", async () => {
+  vi.mocked(fetchScan).mockResolvedValue({
+    ...scan,
+    metadata: { artifact_extra: { scan_execution: {
+      version: 1, status: "completed", actions: [],
+      recovery: [{ id: "restored-1", action_id: "action-1", action: "test-action", status: "restored" }],
+    } } },
+  });
+  renderHistory();
+  fireEvent.click(screen.getByRole("button", { name: "View execution details for scan scan-detail" }));
+  expect(await screen.findByText("test-action · restored")).toBeInTheDocument();
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});

--- a/server/ui/src/features/scans/ui/ScanExecutionDetail.tsx
+++ b/server/ui/src/features/scans/ui/ScanExecutionDetail.tsx
@@ -1,0 +1,91 @@
+import { useScan } from "@entities/scan";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+}
+
+function records(value: unknown): Record<string, unknown>[] | null {
+  if (!Array.isArray(value) || !value.every((item) => record(item) !== null)) return null;
+  return value as Record<string, unknown>[];
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" && value !== "" ? value : "Not recorded";
+}
+
+// Error text can contain endpoint or credential material. Reveal it deliberately;
+// recovery payloads remain in the detail API and are never rendered here.
+function RecordedError({ value }: { value: unknown }) {
+  return typeof value === "string" && value !== "" ? (
+    <details>
+      <summary className="cursor-pointer text-primary">Reveal recorded error</summary>
+      <pre className="mt-1 whitespace-pre-wrap break-all text-xs">{value}</pre>
+    </details>
+  ) : null;
+}
+
+export function ScanExecutionDetail({ scanId }: { scanId: string }) {
+  const query = useScan(scanId);
+  if (query.isLoading) return <p role="status">Loading execution details…</p>;
+  if (query.isError) return (
+    <p role="alert">
+      Execution details could not be refreshed.{' '}
+      <button className="text-primary underline" onClick={() => void query.refetch()}>Retry</button>
+    </p>
+  );
+  const scan = query.data;
+  const identity = record(scan?.metadata?.collection_identity);
+  const extra = record(scan?.metadata?.artifact_extra);
+  const execution = record(extra?.scan_execution);
+  const actions = records(execution?.actions);
+  const recovery = records(execution?.recovery);
+  const available = execution?.version === 1 && actions !== null && recovery !== null;
+  const unresolved = recovery?.filter((item) => item.status !== "restored") ?? [];
+
+  return (
+    <div className="space-y-3 break-words text-sm">
+      <p className="break-all font-mono text-xs">Scan: {scanId}</p>
+      <p>Collection point: {text(identity?.collection_point_id)}<br />
+        Network context: {text(identity?.network_context_id)}</p>
+      <RecordedError value={scan?.error} />
+      {!available ? <p>Full execution journal unavailable for this scan.</p> : (
+        <>
+          <p>{text(execution.status)} · Recorded update: {text(execution.updated_at)}</p>
+          {unresolved.length > 0 && (
+            <p role="alert" className="text-amber-200">
+              {unresolved.length} unresolved cleanup records. Use the original scan artifact
+              with collector recovery in its original collection environment. These are
+              recorded outcomes; this view does not perform recovery.
+            </p>
+          )}
+          <h3 className="font-semibold">Actions ({actions.length})</h3>
+          {actions.length === 0 && <p>No actions recorded.</p>}
+          {actions.map((item, index) => (
+            <div key={index} className="space-y-1 rounded border border-border p-2">
+              <p>{text(item.action)} · {text(item.status)}</p>
+              <p className="break-all font-mono text-xs">Action ID: {text(item.id)}<br />
+                Target: {text(item.target_id)}
+                {item.resource_id ? <><br />Resource: {text(item.resource_id)}</> : null}
+                {item.credential_id ? <><br />Credential ID: {text(item.credential_id)}</> : null}
+                {item.recovery_id ? <><br />Recovery ID: {text(item.recovery_id)}</> : null}
+              </p>
+              <p>Outcome: {text(item.outcome)}</p>
+              <RecordedError value={item.error} />
+            </div>
+          ))}
+          <h3 className="font-semibold">Recovery ({recovery.length})</h3>
+          {recovery.length === 0 && <p>No recovery records.</p>}
+          {recovery.map((item, index) => (
+            <div key={index} className="space-y-1 rounded border border-border p-2">
+              <p>{text(item.action)} · {text(item.status)}</p>
+              <p className="break-all font-mono text-xs">Recovery ID: {text(item.id)}<br />
+                Action ID: {text(item.action_id)}</p>
+              <RecordedError value={item.error} />
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/server/ui/src/features/scans/ui/ScanHistory.tsx
+++ b/server/ui/src/features/scans/ui/ScanHistory.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { ShieldCheck, Trash2 } from "lucide-react";
+import { FileText, ShieldCheck, Trash2 } from "lucide-react";
 import type { Scan } from "@entities/scan";
 import { useDeleteScan } from "@entities/scan";
 import {
@@ -20,6 +20,8 @@ import {
   FEEDBACK,
   NODE_KIND_COLORS,
 } from "@shared/theme/tokens";
+
+import { ScanExecutionDetail } from "./ScanExecutionDetail";
 
 interface ScanHistoryProps {
   scans: Scan[];
@@ -60,6 +62,7 @@ function Th({ children, className }: { children?: ReactNode; className?: string 
 }
 
 export function ScanHistory({ scans, onDeleted }: ScanHistoryProps) {
+  const [detailScanId, setDetailScanId] = useState<string | null>(null);
   const [confirmScan, setConfirmScan] = useState<Scan | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -277,6 +280,12 @@ export function ScanHistory({ scans, onDeleted }: ScanHistoryProps) {
                   </td>
                   <td className="px-3 py-2.5 align-middle">
                     <div className="flex justify-end gap-1">
+                      <button
+                        onClick={() => setDetailScanId(scan.id)}
+                        aria-label={`View execution details for scan ${scan.id}`}
+                        title="View execution details"
+                        className="inline-flex h-7 w-7 items-center justify-center rounded-[3px] text-muted-foreground hover:text-primary"
+                      ><FileText className="h-3.5 w-3.5" /></button>
                       {scan.metadata?.ruleset != null && (
                         <Link
                           to={`/rules?scan=${encodeURIComponent(scan.id)}`}
@@ -307,6 +316,16 @@ export function ScanHistory({ scans, onDeleted }: ScanHistoryProps) {
           </tbody>
         </table>
       </div>
+
+      <Dialog open={detailScanId !== null} onOpenChange={(open) => !open && setDetailScanId(null)}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Scan execution details</DialogTitle>
+            <DialogDescription>Recorded actions, affected scope, and cleanup outcomes.</DialogDescription>
+          </DialogHeader>
+          {detailScanId && <ScanExecutionDetail key={detailScanId} scanId={detailScanId} />}
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={!!confirmScan}


### PR DESCRIPTION
Scan history shows failed-action and unresolved-cleanup counts without a way to inspect their recorded diagnosis. At the same time, every list row loads the full execution journal, although the row only uses its promoted summary.

Add an on-demand execution detail dialog to history. It uses the existing scan detail endpoint to show action IDs, target/resource references, recorded outcomes, collection identity, and recovery records. Error text requires deliberate reveal; recovery payloads are not rendered. Unresolved records point users back to collector recovery with the original artifact. Recovery execution remains in the collector.

Project list metadata in SQL to submitted counts, the promoted execution summary, and a ruleset-availability marker. Full metadata remains available through the unchanged detail endpoint. Rules Library now reads the selected scan detail for provenance, including its default selection, so trimming list responses does not remove rule entries from that view. The API documentation describes the list/detail distinction.

Validation:
- PostgreSQL integration regression retains a journal over 240 KB in detail reads while keeping its list row below 2 KB; submitted counts, execution summary, and provenance availability survive.
- Affected appdb and API-handler suites pass against a disposable local PostgreSQL database.
- All 284 UI tests pass, including on-demand loading, failure/retry, absent journals, action diagnosis, error reveal, restored/unresolved recovery, and provenance with summary-only list responses.
- Production build, TypeScript, changed-file ESLint, and diff checks pass.

Compatibility: list consumers needing collection outcomes, rule entries, or artifact metadata must use GET /api/v1/scans/{id}. No persistence migration or new endpoint is required. The payload regression establishes bounded history data for the tested journal, not a measured production speedup.
